### PR TITLE
Fix e2e createPAT to expect 201 Created

### DIFF
--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -165,7 +165,7 @@ func createPAT(t *testing.T, baseURL string, cookies []*http.Cookie) string {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusCreated {
 		b, _ := io.ReadAll(resp.Body)
 		t.Fatalf("create PAT: status %d, body: %s", resp.StatusCode, b)
 	}


### PR DESCRIPTION
## Summary
- `createPAT` in e2e helpers expected HTTP 200 but the `/api/v1/users/me/tokens` endpoint returns HTTP 201 (Created)
- This caused all e2e tests to fail: `TestHelloBlockr/user1_deploy`, `TestHelloShiny/auth_and_pat`, and cascading `enroll_credential_via_api` (empty token → 401)

## Test plan
- [ ] CI `check` job passes
- [ ] CI `e2e` job passes (via merge queue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)