### PR TITLE
Harden proxy middleware against spoofing, CSRF, and resource exhaustion

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -106,10 +106,12 @@ func securityHeaders(externalURL string) func(http.Handler) http.Handler {
 }
 
 // apiCSP sets a strict Content-Security-Policy for JSON API endpoints
-// where no HTML rendering occurs.
+// where no HTML rendering occurs, and prevents caching of sensitive
+// API responses by intermediate proxies and browsers.
 func apiCSP(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'")
+		w.Header().Set("Cache-Control", "no-store")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,7 @@ type ProxyConfig struct {
 	LogRetention       Duration `toml:"log_retention"`
 	SessionIdleTTL     Duration `toml:"session_idle_ttl"`
 	IdleWorkerTimeout  Duration `toml:"idle_worker_timeout"`
+	HTTPForwardTimeout Duration `toml:"http_forward_timeout"`
 }
 
 type OidcConfig struct {
@@ -187,6 +188,9 @@ func applyDefaults(cfg *Config) {
 	}
 	if cfg.Proxy.IdleWorkerTimeout.Duration == 0 {
 		cfg.Proxy.IdleWorkerTimeout.Duration = 5 * time.Minute
+	}
+	if cfg.Proxy.HTTPForwardTimeout.Duration == 0 {
+		cfg.Proxy.HTTPForwardTimeout.Duration = 5 * time.Minute
 	}
 	if cfg.OIDC != nil {
 		oidcDefaults(cfg.OIDC)

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1,17 +1,31 @@
 package proxy
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"path"
 	"strings"
+	"time"
 )
 
 // forwardHTTP proxies an HTTP request to the worker at addr. The
 // /app/{name} prefix is stripped from the path before forwarding.
-func forwardHTTP(w http.ResponseWriter, r *http.Request, addr, appName, externalURL string, transport http.RoundTripper) {
+// httpTimeout caps the total request lifetime (dial + headers + body)
+// to prevent a worker from holding connections indefinitely.
+func forwardHTTP(w http.ResponseWriter, r *http.Request, addr, appName, externalURL string, transport http.RoundTripper, httpTimeout time.Duration) {
+	// Apply a deadline so the entire round-trip is bounded. This
+	// prevents a worker from holding resources by trickling response
+	// bytes indefinitely.
+	ctx, cancel := r.Context(), func() {}
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		ctx, cancel = context.WithTimeout(ctx, httpTimeout)
+	}
+	defer cancel()
+	r = r.WithContext(ctx)
+
 	slog.Debug("proxy: forwarding HTTP",
 		"app", appName, "backend", addr,
 		"path", stripAppPrefix(r.URL.Path, appName))

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -61,6 +61,7 @@ func testProxyServer(t *testing.T) (*server.Server, *httptest.Server) {
 			WsCacheTTL:         config.Duration{Duration: 5 * time.Second},
 			WorkerStartTimeout: config.Duration{Duration: 5 * time.Second},
 			MaxWorkers:         10,
+			HTTPForwardTimeout: config.Duration{Duration: 5 * time.Minute},
 		},
 	}
 
@@ -538,11 +539,10 @@ func TestProxyWebSocketCacheReconnect(t *testing.T) {
 	}
 }
 
-// TestProxyWebSocketCrossOrigin verifies that cross-origin WebSocket
-// upgrades are accepted (Bug 2 fix — origin checking). Browsers always
-// send an Origin header on WebSocket upgrades; the proxy must not
-// reject requests where Origin differs from Host.
-func TestProxyWebSocketCrossOrigin(t *testing.T) {
+// TestProxyWebSocketCrossOriginRejected verifies that cross-origin
+// WebSocket upgrades are rejected when external_url is not configured.
+// This prevents cross-site WebSocket hijacking in misconfigured deployments.
+func TestProxyWebSocketCrossOriginRejected(t *testing.T) {
 	srv, ts := testProxyServer(t)
 	srv.Backend.(*mock.MockBackend).SetWSHandler(wsEchoHandler())
 	createAndStartApp(t, ts, "origin-app")
@@ -551,18 +551,46 @@ func TestProxyWebSocketCrossOrigin(t *testing.T) {
 	wsURL := strings.Replace(ts.URL, "http://", "ws://", 1) +
 		"/app/origin-app/"
 
-	// Dial with an explicit cross-origin Origin header.
-	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+	// Dial with a cross-origin Origin header — should be rejected
+	// because external_url is not configured.
+	_, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
 		HTTPHeader: http.Header{
 			"Origin": []string{"http://different-host.example.com"},
 		},
 	})
+	if err == nil {
+		t.Fatal("expected cross-origin WebSocket to be rejected, but it succeeded")
+	}
+}
+
+// TestProxyWebSocketCrossOriginAllowedByExternalURL verifies that
+// cross-origin WebSocket upgrades are accepted when the Origin matches
+// the configured external_url host.
+func TestProxyWebSocketCrossOriginAllowedByExternalURL(t *testing.T) {
+	srv, ts := testProxyServer(t)
+	srv.Backend.(*mock.MockBackend).SetWSHandler(wsEchoHandler())
+
+	// Configure external_url to match the cross-origin header we'll send.
+	srv.Config.Server.ExternalURL = "http://my-app.example.com"
+
+	createAndStartApp(t, ts, "origin-app")
+
+	ctx := context.Background()
+	wsURL := strings.Replace(ts.URL, "http://", "ws://", 1) +
+		"/app/origin-app/"
+
+	// Dial with Origin matching the configured external_url host.
+	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		HTTPHeader: http.Header{
+			"Origin": []string{"http://my-app.example.com"},
+		},
+	})
 	if err != nil {
-		t.Fatalf("cross-origin WebSocket dial failed: %v", err)
+		t.Fatalf("same-origin WebSocket dial failed: %v", err)
 	}
 	defer conn.CloseNow()
 
-	// Confirm the connection actually works end-to-end.
+	// Confirm the connection works end-to-end.
 	if err := conn.Write(ctx, websocket.MessageText, []byte("xorigin")); err != nil {
 		t.Fatal(err)
 	}
@@ -1006,6 +1034,7 @@ func testProxyServerWithOIDC(t *testing.T, idp *testutil.MockIdP) (*server.Serve
 			WsCacheTTL:         config.Duration{Duration: 5 * time.Second},
 			WorkerStartTimeout: config.Duration{Duration: 5 * time.Second},
 			MaxWorkers:         10,
+			HTTPForwardTimeout: config.Duration{Duration: 5 * time.Minute},
 		},
 		OIDC: &config.OidcConfig{
 			IssuerURL:    idp.IssuerURL(),

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -27,7 +27,9 @@ func Handler(srv *server.Server) http.Handler {
 	cache := NewWsCache()
 
 	// Limit concurrent WebSocket connections to prevent resource exhaustion.
-	const maxWSConns = 1000
+	// Aligned with max_workers (default 100): each session holds at most
+	// one WebSocket, so this bounds memory even if every session is active.
+	const maxWSConns = 100
 	wsSem := make(chan struct{}, maxWSConns)
 
 	transport := &http.Transport{
@@ -189,6 +191,7 @@ func Handler(srv *server.Server) http.Handler {
 		// then re-add from verified identity.
 		r.Header.Del("X-Shiny-User")
 		r.Header.Del("X-Shiny-Access")
+		r.Header.Del("X-Shiny-Groups")
 		// Strip client-supplied forwarding headers so httputil.ReverseProxy
 		// builds a fresh X-Forwarded-For from the resolved RemoteAddr.
 		r.Header.Del("X-Forwarded-For")
@@ -216,7 +219,7 @@ func Handler(srv *server.Server) http.Handler {
 			}
 			shuttleWS(w, r, addr, appName, sessionID, cache, srv)
 		} else {
-			forwardHTTP(w, r, addr, appName, srv.Config.Server.ExternalURL, transport)
+			forwardHTTP(w, r, addr, appName, srv.Config.Server.ExternalURL, transport, srv.Config.Proxy.HTTPForwardTimeout.Duration)
 		}
 		telemetry.ProxyRequestDuration.Observe(time.Since(forwardStart).Seconds())
 	})

--- a/internal/proxy/ws.go
+++ b/internal/proxy/ws.go
@@ -14,14 +14,18 @@ import (
 )
 
 // wsOriginPatterns derives WebSocket origin patterns from the external URL.
-// Falls back to allowing all origins if the URL is empty or unparseable.
+// Rejects all cross-origin requests when the URL is empty or unparseable
+// to prevent cross-site WebSocket hijacking in misconfigured deployments.
 func wsOriginPatterns(externalURL string) []string {
 	if externalURL == "" {
-		return []string{"*"}
+		slog.Warn("ws: external_url not configured, rejecting all cross-origin WebSocket requests")
+		return []string{}
 	}
 	u, err := url.Parse(externalURL)
 	if err != nil || u.Host == "" {
-		return []string{"*"}
+		slog.Warn("ws: external_url unparseable, rejecting all cross-origin WebSocket requests",
+			"external_url", externalURL)
+		return []string{}
 	}
 	// Allow both http and https variants of the configured host.
 	return []string{u.Host}


### PR DESCRIPTION
## Summary

- **Strip `X-Shiny-Groups` header** before forwarding to workers — was forwarded verbatim from clients unlike `X-Shiny-User` and `X-Shiny-Access`, allowing spoofing
- **Reject cross-origin WebSocket upgrades** when `external_url` is not configured, instead of falling back to wildcard `*` origin acceptance (prevents cross-site WebSocket hijacking)
- **Add `Cache-Control: no-store`** to all API responses to prevent intermediate proxies/browsers from caching sensitive data (vault tokens, PATs, user info)
- **Add configurable `http_forward_timeout`** (default 5m) to cap total HTTP request lifetime to workers, preventing slow-trickle resource holding by malicious/stuck workers
- **Reduce max concurrent WebSocket connections** from 1000 to 100, aligned with `max_workers` default

## Test plan

- [x] All proxy integration tests pass (including updated WebSocket origin tests)
- [x] All API tests pass
- [x] Config tests pass
- [x] CI green