### PR TITLE
Phase 2-2: bundle rollback, soft-delete, resource limits

### DIFF
--- a/cmd/blockyard/main.go
+++ b/cmd/blockyard/main.go
@@ -243,6 +243,12 @@ func main() {
 		proxy.RunAutoscaler(bgCtx, srv)
 	}()
 
+	bgWg.Add(1)
+	go func() {
+		defer bgWg.Done()
+		ops.SpawnSoftDeleteSweeper(bgCtx, srv)
+	}()
+
 	// Start audit log background writer.
 	if srv.AuditLog != nil {
 		bgWg.Add(1)

--- a/docs/design/v2/phase-2-2.md
+++ b/docs/design/v2/phase-2-2.md
@@ -104,7 +104,7 @@ func RollbackApp(srv *server.Server) http.HandlerFunc {
         previousBundle := app.ActiveBundle
 
         // Drain and stop running workers.
-        // stopAppSync waits up to shutdown_timeout/2 for sessions to end,
+        // stopAppSync waits up to shutdown_timeout for sessions to end,
         // then force-evicts. If no workers are running, this is a no-op.
         stopAppSync(srv, app.ID)
 
@@ -143,7 +143,7 @@ func stringOrNil(s *string) any {
 ```
 
 **Rollback is synchronous.** The drain takes at most
-`shutdown_timeout / 2` (default 15s). This is acceptable for a
+`shutdown_timeout` (default 30s). This is acceptable for a
 deployment operation — the caller (CLI, CI/CD, admin) needs to know the
 rollback is complete before proceeding. If the app has no running
 workers, the drain is a no-op and the response is instant.
@@ -843,8 +843,8 @@ if body.CPULimit != nil {
         badRequest(w, "cpu_limit must be non-negative")
         return
     }
-    if srv.Config.Proxy.MaxCPULimit > 0 && *body.CPULimit > srv.Config.Proxy.MaxCPULimit {
-        badRequest(w, fmt.Sprintf("cpu_limit must not exceed %.1f", srv.Config.Proxy.MaxCPULimit))
+    if *srv.Config.Proxy.MaxCPULimit > 0 && *body.CPULimit > *srv.Config.Proxy.MaxCPULimit {
+        badRequest(w, fmt.Sprintf("cpu_limit must not exceed %.1f", *srv.Config.Proxy.MaxCPULimit))
         return
     }
 }
@@ -878,16 +878,21 @@ check applies).
 Add `MaxCPULimit` to `ProxyConfig` in `internal/config/config.go`:
 
 ```go
-MaxCPULimit float64 `toml:"max_cpu_limit"`
+MaxCPULimit *float64 `toml:"max_cpu_limit"`
 ```
 
 Default in `applyDefaults()`:
 
 ```go
-if cfg.Proxy.MaxCPULimit == 0 {
-    cfg.Proxy.MaxCPULimit = 16
+if cfg.Proxy.MaxCPULimit == nil {
+    v := 16.0
+    cfg.Proxy.MaxCPULimit = &v
 }
 ```
+
+A pointer distinguishes "absent" (`nil` → apply default 16) from
+"explicitly set to 0" (`*0.0` → no ceiling). Same pattern as
+`AppRow.MaxWorkersPerApp`.
 
 Env var: `BLOCKYARD_PROXY_MAX_CPU_LIMIT`.
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1843,3 +1843,481 @@ func TestTaskLogsNotFound2(t *testing.T) {
 		t.Errorf("expected 404, got %d", resp.StatusCode)
 	}
 }
+
+// --- Rollback tests ---
+
+func TestRollbackAppValidBundle(t *testing.T) {
+	srv, ts := testServer(t)
+	created := createApp(t, ts, "my-app")
+	id := created["id"].(string)
+
+	// Create two ready bundles.
+	srv.DB.CreateBundle("b-1", id)
+	srv.DB.UpdateBundleStatus("b-1", "ready")
+	srv.DB.SetActiveBundle(id, "b-1")
+
+	srv.DB.CreateBundle("b-2", id)
+	srv.DB.UpdateBundleStatus("b-2", "ready")
+
+	// Rollback to b-2.
+	body := `{"bundle_id":"b-2"}`
+	req := authReq("POST", ts.URL+"/api/v1/apps/"+id+"/rollback", strings.NewReader(body))
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, b)
+	}
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	if result["active_bundle"] != "b-2" {
+		t.Errorf("expected active_bundle=b-2, got %v", result["active_bundle"])
+	}
+}
+
+func TestRollbackToNonexistentBundle(t *testing.T) {
+	_, ts := testServer(t)
+	created := createApp(t, ts, "my-app")
+	id := created["id"].(string)
+
+	body := `{"bundle_id":"nonexistent"}`
+	req := authReq("POST", ts.URL+"/api/v1/apps/"+id+"/rollback", strings.NewReader(body))
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != 404 {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestRollbackToBundleOfDifferentApp(t *testing.T) {
+	srv, ts := testServer(t)
+	app1 := createApp(t, ts, "app-one")
+	id1 := app1["id"].(string)
+	app2 := createApp(t, ts, "app-two")
+	id2 := app2["id"].(string)
+
+	srv.DB.CreateBundle("b-other", id2)
+	srv.DB.UpdateBundleStatus("b-other", "ready")
+
+	body := `{"bundle_id":"b-other"}`
+	req := authReq("POST", ts.URL+"/api/v1/apps/"+id1+"/rollback", strings.NewReader(body))
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != 404 {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestRollbackToFailedBundle(t *testing.T) {
+	srv, ts := testServer(t)
+	created := createApp(t, ts, "my-app")
+	id := created["id"].(string)
+
+	srv.DB.CreateBundle("b-fail", id)
+	srv.DB.UpdateBundleStatus("b-fail", "failed")
+
+	body := `{"bundle_id":"b-fail"}`
+	req := authReq("POST", ts.URL+"/api/v1/apps/"+id+"/rollback", strings.NewReader(body))
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != 400 {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestRollbackToAlreadyActiveBundle(t *testing.T) {
+	srv, ts := testServer(t)
+	created := createApp(t, ts, "my-app")
+	id := created["id"].(string)
+
+	srv.DB.CreateBundle("b-1", id)
+	srv.DB.UpdateBundleStatus("b-1", "ready")
+	srv.DB.SetActiveBundle(id, "b-1")
+
+	body := `{"bundle_id":"b-1"}`
+	req := authReq("POST", ts.URL+"/api/v1/apps/"+id+"/rollback", strings.NewReader(body))
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != 400 {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestRollbackWithoutBundleID(t *testing.T) {
+	_, ts := testServer(t)
+	created := createApp(t, ts, "my-app")
+	id := created["id"].(string)
+
+	body := `{}`
+	req := authReq("POST", ts.URL+"/api/v1/apps/"+id+"/rollback", strings.NewReader(body))
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != 400 {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestRollbackStopsRunningWorkers(t *testing.T) {
+	srv, ts := testServer(t)
+	created := createApp(t, ts, "my-app")
+	id := created["id"].(string)
+
+	// Upload bundle and wait for restore.
+	req, _ := http.NewRequest("POST",
+		ts.URL+"/api/v1/apps/"+id+"/bundles",
+		bytes.NewReader(testutil.MakeBundle(t)))
+	req.Header.Set("Authorization", "Bearer "+testPAT)
+	http.DefaultClient.Do(req)
+	time.Sleep(200 * time.Millisecond)
+
+	// Start app.
+	req = authReq("POST", ts.URL+"/api/v1/apps/"+id+"/start", nil)
+	http.DefaultClient.Do(req)
+	if srv.Workers.Count() != 1 {
+		t.Fatalf("expected 1 worker, got %d", srv.Workers.Count())
+	}
+
+	// Create a second ready bundle.
+	srv.DB.CreateBundle("b-rollback", id)
+	srv.DB.UpdateBundleStatus("b-rollback", "ready")
+
+	// Rollback to the new bundle.
+	body := `{"bundle_id":"b-rollback"}`
+	req = authReq("POST", ts.URL+"/api/v1/apps/"+id+"/rollback", strings.NewReader(body))
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, b)
+	}
+
+	// Workers should be stopped.
+	if srv.Workers.Count() != 0 {
+		t.Errorf("expected 0 workers after rollback, got %d", srv.Workers.Count())
+	}
+
+	// Active bundle should be changed.
+	app, _ := srv.DB.GetApp(id)
+	if app.ActiveBundle == nil || *app.ActiveBundle != "b-rollback" {
+		t.Errorf("expected active bundle b-rollback, got %v", app.ActiveBundle)
+	}
+}
+
+// --- Soft-delete API tests ---
+
+func testServerWithSoftDelete(t *testing.T) (*server.Server, *httptest.Server) {
+	t.Helper()
+	tmp := t.TempDir()
+
+	cfg := &config.Config{
+		Docker: config.DockerConfig{Image: "test-image", ShinyPort: 3838, RvBinaryPath: testutil.FakeRvBinary(t)},
+		Storage: config.StorageConfig{
+			BundleServerPath:    tmp,
+			BundleWorkerPath:    "/app",
+			BundleRetention:     50,
+			MaxBundleSize:       10 * 1024 * 1024,
+			SoftDeleteRetention: config.Duration{Duration: 720 * time.Hour},
+		},
+		Proxy: config.ProxyConfig{MaxWorkers: 100},
+	}
+
+	database, err := db.Open(config.DatabaseConfig{Driver: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	seedTestAdmin(t, database)
+
+	be := mock.New()
+	srv := server.NewServer(cfg, be, database)
+	handler := NewRouter(srv)
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	return srv, ts
+}
+
+func TestSoftDeleteApp(t *testing.T) {
+	srv, ts := testServerWithSoftDelete(t)
+	created := createApp(t, ts, "my-app")
+	id := created["id"].(string)
+
+	// Delete (soft).
+	req := authReq("DELETE", ts.URL+"/api/v1/apps/"+id, nil)
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != 204 {
+		t.Errorf("expected 204, got %d", resp.StatusCode)
+	}
+
+	// App should be gone from listings.
+	req = authReq("GET", ts.URL+"/api/v1/apps/"+id, nil)
+	resp, _ = http.DefaultClient.Do(req)
+	if resp.StatusCode != 404 {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+
+	// But still in DB with deleted_at set.
+	app, _ := srv.DB.GetAppIncludeDeleted(id)
+	if app == nil {
+		t.Fatal("expected app to still be in DB")
+	}
+	if app.DeletedAt == nil {
+		t.Error("expected deleted_at to be set")
+	}
+}
+
+func TestHardDeleteAppWhenSoftDeleteDisabled(t *testing.T) {
+	srv, ts := testServer(t) // no soft_delete_retention
+	created := createApp(t, ts, "my-app")
+	id := created["id"].(string)
+
+	req := authReq("DELETE", ts.URL+"/api/v1/apps/"+id, nil)
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != 204 {
+		t.Errorf("expected 204, got %d", resp.StatusCode)
+	}
+
+	// Should be fully gone.
+	app, _ := srv.DB.GetAppIncludeDeleted(id)
+	if app != nil {
+		t.Error("expected app to be completely removed")
+	}
+}
+
+func TestRestoreAppAPI(t *testing.T) {
+	_, ts := testServerWithSoftDelete(t)
+	created := createApp(t, ts, "my-app")
+	id := created["id"].(string)
+
+	// Soft delete.
+	req := authReq("DELETE", ts.URL+"/api/v1/apps/"+id, nil)
+	http.DefaultClient.Do(req)
+
+	// Restore.
+	req = authReq("POST", ts.URL+"/api/v1/apps/"+id+"/restore", nil)
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, b)
+	}
+
+	// App should be back in listings.
+	req = authReq("GET", ts.URL+"/api/v1/apps/"+id, nil)
+	resp, _ = http.DefaultClient.Do(req)
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestRestoreWithNameCollisionAPI(t *testing.T) {
+	_, ts := testServerWithSoftDelete(t)
+	created := createApp(t, ts, "my-app")
+	id := created["id"].(string)
+
+	// Soft delete.
+	req := authReq("DELETE", ts.URL+"/api/v1/apps/"+id, nil)
+	http.DefaultClient.Do(req)
+
+	// Create another app with the same name.
+	createApp(t, ts, "my-app")
+
+	// Restore should fail with 409.
+	req = authReq("POST", ts.URL+"/api/v1/apps/"+id+"/restore", nil)
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != 409 {
+		t.Errorf("expected 409, got %d", resp.StatusCode)
+	}
+}
+
+func TestRestoreNonexistentApp(t *testing.T) {
+	_, ts := testServer(t)
+
+	req := authReq("POST", ts.URL+"/api/v1/apps/nonexistent/restore", nil)
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != 404 {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestRestoreNonDeletedApp(t *testing.T) {
+	_, ts := testServer(t)
+	created := createApp(t, ts, "my-app")
+	id := created["id"].(string)
+
+	req := authReq("POST", ts.URL+"/api/v1/apps/"+id+"/restore", nil)
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != 404 {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestListDeletedAppsAdmin(t *testing.T) {
+	_, ts := testServerWithSoftDelete(t)
+	created := createApp(t, ts, "my-app")
+	id := created["id"].(string)
+	createApp(t, ts, "live-app")
+
+	// Soft delete one app.
+	req := authReq("DELETE", ts.URL+"/api/v1/apps/"+id, nil)
+	http.DefaultClient.Do(req)
+
+	// List deleted apps.
+	req = authReq("GET", ts.URL+"/api/v1/apps?deleted=true", nil)
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var apps []map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&apps)
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 deleted app, got %d", len(apps))
+	}
+	if apps[0]["id"] != id {
+		t.Errorf("expected deleted app id=%s, got %v", id, apps[0]["id"])
+	}
+}
+
+// --- Resource limit validation tests ---
+
+func TestUpdateAppInvalidMemoryLimit(t *testing.T) {
+	_, ts := testServer(t)
+	created := createApp(t, ts, "my-app")
+	id := created["id"].(string)
+
+	body := `{"memory_limit":"banana"}`
+	req := authReq("PATCH", ts.URL+"/api/v1/apps/"+id, strings.NewReader(body))
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != 400 {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestUpdateAppNegativeCPULimit(t *testing.T) {
+	_, ts := testServer(t)
+	created := createApp(t, ts, "my-app")
+	id := created["id"].(string)
+
+	body := `{"cpu_limit":-1}`
+	req := authReq("PATCH", ts.URL+"/api/v1/apps/"+id, strings.NewReader(body))
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != 400 {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestUpdateAppCPULimitExceedsCeiling(t *testing.T) {
+	tmp := t.TempDir()
+	maxCPU := 4.0
+	cfg := &config.Config{
+		Docker: config.DockerConfig{Image: "test-image", ShinyPort: 3838, RvBinaryPath: testutil.FakeRvBinary(t)},
+		Storage: config.StorageConfig{
+			BundleServerPath: tmp,
+			BundleWorkerPath: "/app",
+			BundleRetention:  50,
+			MaxBundleSize:    10 * 1024 * 1024,
+		},
+		Proxy: config.ProxyConfig{
+			MaxWorkers:  100,
+			MaxCPULimit: &maxCPU,
+		},
+	}
+	database, _ := db.Open(config.DatabaseConfig{Driver: "sqlite", Path: ":memory:"})
+	t.Cleanup(func() { database.Close() })
+	seedTestAdmin(t, database)
+	be := mock.New()
+	srv := server.NewServer(cfg, be, database)
+	handler := NewRouter(srv)
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	created := createApp(t, ts, "my-app")
+	id := created["id"].(string)
+
+	body := `{"cpu_limit":5.0}`
+	req := authReq("PATCH", ts.URL+"/api/v1/apps/"+id, strings.NewReader(body))
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != 400 {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+
+	// Within ceiling should succeed.
+	body = `{"cpu_limit":2.0}`
+	req = authReq("PATCH", ts.URL+"/api/v1/apps/"+id, strings.NewReader(body))
+	resp, _ = http.DefaultClient.Do(req)
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Errorf("expected 200, got %d: %s", resp.StatusCode, b)
+	}
+}
+
+func TestUpdateAppCPULimitCeilingDisabled(t *testing.T) {
+	tmp := t.TempDir()
+	zeroCPU := 0.0
+	cfg := &config.Config{
+		Docker: config.DockerConfig{Image: "test-image", ShinyPort: 3838, RvBinaryPath: testutil.FakeRvBinary(t)},
+		Storage: config.StorageConfig{
+			BundleServerPath: tmp,
+			BundleWorkerPath: "/app",
+			BundleRetention:  50,
+			MaxBundleSize:    10 * 1024 * 1024,
+		},
+		Proxy: config.ProxyConfig{
+			MaxWorkers:  100,
+			MaxCPULimit: &zeroCPU,
+		},
+	}
+	database, _ := db.Open(config.DatabaseConfig{Driver: "sqlite", Path: ":memory:"})
+	t.Cleanup(func() { database.Close() })
+	seedTestAdmin(t, database)
+	be := mock.New()
+	srv := server.NewServer(cfg, be, database)
+	handler := NewRouter(srv)
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	created := createApp(t, ts, "my-app")
+	id := created["id"].(string)
+
+	// Any positive value should be accepted.
+	body := `{"cpu_limit":100.0}`
+	req := authReq("PATCH", ts.URL+"/api/v1/apps/"+id, strings.NewReader(body))
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Errorf("expected 200, got %d: %s", resp.StatusCode, b)
+	}
+}
+
+func TestUpdateAppValidResourceLimits(t *testing.T) {
+	_, ts := testServer(t)
+	created := createApp(t, ts, "my-app")
+	id := created["id"].(string)
+
+	body := `{"memory_limit":"512m","cpu_limit":2.0}`
+	req := authReq("PATCH", ts.URL+"/api/v1/apps/"+id, strings.NewReader(body))
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Errorf("expected 200, got %d: %s", resp.StatusCode, b)
+	}
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	if result["memory_limit"] != "512m" {
+		t.Errorf("expected memory_limit=512m, got %v", result["memory_limit"])
+	}
+	if result["cpu_limit"] != 2.0 {
+		t.Errorf("expected cpu_limit=2, got %v", result["cpu_limit"])
+	}
+}
+
+func TestUpdateAppEmptyMemoryLimitAccepted(t *testing.T) {
+	_, ts := testServer(t)
+	created := createApp(t, ts, "my-app")
+	id := created["id"].(string)
+
+	// Empty string clears the limit — should not be validated.
+	body := `{"memory_limit":""}`
+	req := authReq("PATCH", ts.URL+"/api/v1/apps/"+id, strings.NewReader(body))
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Errorf("expected 200, got %d: %s", resp.StatusCode, b)
+	}
+}

--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -17,6 +15,7 @@ import (
 	"github.com/cynkra/blockyard/internal/auth"
 	"github.com/cynkra/blockyard/internal/authz"
 	"github.com/cynkra/blockyard/internal/backend"
+	docker "github.com/cynkra/blockyard/internal/backend/docker"
 	"github.com/cynkra/blockyard/internal/bundle"
 	"github.com/cynkra/blockyard/internal/db"
 	"github.com/cynkra/blockyard/internal/ops"
@@ -41,6 +40,7 @@ type AppResponse struct {
 	Description          *string  `json:"description"`
 	CreatedAt            string   `json:"created_at"`
 	UpdatedAt            string   `json:"updated_at"`
+	DeletedAt            *string  `json:"deleted_at,omitempty"`
 	Status               string   `json:"status"`
 	Workers              []string `json:"workers"`
 }
@@ -68,6 +68,7 @@ func appResponse(app *db.AppRow, workers *server.WorkerMap) AppResponse {
 		Description:          app.Description,
 		CreatedAt:            app.CreatedAt,
 		UpdatedAt:            app.UpdatedAt,
+		DeletedAt:            app.DeletedAt,
 		Status:               status,
 		Workers:              workerIDs,
 	}
@@ -224,7 +225,15 @@ func ListApps(srv *server.Server) http.HandlerFunc {
 			forbidden(w, "insufficient permissions")
 			return
 		}
-		if caller.Role.CanViewAllApps() {
+
+		// ?deleted=true — admin-only, returns soft-deleted apps
+		if r.URL.Query().Get("deleted") == "true" {
+			if !caller.Role.CanViewAllApps() {
+				forbidden(w, "admin only")
+				return
+			}
+			apps, err = srv.DB.ListDeletedApps()
+		} else if caller.Role.CanViewAllApps() {
 			apps, err = srv.DB.ListApps()
 		} else {
 			apps, err = srv.DB.ListAccessibleApps(caller.Sub)
@@ -287,6 +296,22 @@ func UpdateApp(srv *server.Server) http.HandlerFunc {
 		if body.MaxWorkersPerApp != nil && *body.MaxWorkersPerApp < 1 {
 			badRequest(w, "max_workers_per_app must be >= 1")
 			return
+		}
+		if body.MemoryLimit != nil && *body.MemoryLimit != "" {
+			if _, ok := docker.ParseMemoryLimit(*body.MemoryLimit); !ok {
+				badRequest(w, `invalid memory_limit format: use e.g. "256m", "1g", "512mb"`)
+				return
+			}
+		}
+		if body.CPULimit != nil {
+			if *body.CPULimit < 0 {
+				badRequest(w, "cpu_limit must be non-negative")
+				return
+			}
+			if srv.Config.Proxy.MaxCPULimit != nil && *srv.Config.Proxy.MaxCPULimit > 0 && *body.CPULimit > *srv.Config.Proxy.MaxCPULimit {
+				badRequest(w, fmt.Sprintf("cpu_limit must not exceed %.1f", *srv.Config.Proxy.MaxCPULimit))
+				return
+			}
 		}
 
 		app, relation, ok := resolveAppRelation(srv, w, caller, id)
@@ -353,45 +378,18 @@ func DeleteApp(srv *server.Server) http.HandlerFunc {
 		slog.Info("deleting app",
 			"app_id", app.ID, "name", app.Name, "caller", caller.Sub)
 
-		// 1. Stop all workers for this app (synchronous for delete).
-		stopAppSync(srv, app.ID)
+		// Always stop running workers.
+		ops.StopAppSync(srv, app.ID)
 
-		// 2. Delete bundle files from disk
-		bundles, err := srv.DB.ListBundlesByApp(app.ID)
-		if err != nil {
-			serverError(w, "list bundles: "+err.Error())
-			return
-		}
-		for _, b := range bundles {
-			paths := bundle.NewBundlePaths(srv.Config.Storage.BundleServerPath, app.ID, b.ID)
-			bundle.DeleteFiles(paths)
-		}
-
-		// 3. Clear active_bundle FK before deleting bundles
-		if err := srv.DB.ClearActiveBundle(app.ID); err != nil {
-			serverError(w, "clear active bundle: "+err.Error())
-			return
-		}
-
-		// 4. Delete bundle rows
-		for _, b := range bundles {
-			if _, err := srv.DB.DeleteBundle(b.ID); err != nil {
-				slog.Warn("failed to delete bundle row",
-					"bundle_id", b.ID, "app_id", app.ID, "error", err)
+		if srv.Config.Storage.SoftDeleteRetention.Duration > 0 {
+			// Soft-delete: mark as deleted, retain files and rows.
+			if err := srv.DB.SoftDeleteApp(app.ID); err != nil {
+				serverError(w, "soft delete: "+err.Error())
+				return
 			}
-		}
-
-		// 5. Delete app row
-		if _, err := srv.DB.DeleteApp(app.ID); err != nil {
-			serverError(w, "delete app: "+err.Error())
-			return
-		}
-
-		// 6. Remove app directory from disk (best-effort)
-		appDir := filepath.Join(srv.Config.Storage.BundleServerPath, app.ID)
-		if err := os.RemoveAll(appDir); err != nil {
-			slog.Warn("failed to remove app directory",
-				"app_id", app.ID, "path", appDir, "error", err)
+		} else {
+			// Immediate hard delete (legacy behavior).
+			ops.PurgeApp(srv, app)
 		}
 
 		if srv.AuditLog != nil {
@@ -401,6 +399,152 @@ func DeleteApp(srv *server.Server) http.HandlerFunc {
 
 		w.WriteHeader(http.StatusNoContent)
 	}
+}
+
+type rollbackRequest struct {
+	BundleID string `json:"bundle_id"`
+}
+
+func RollbackApp(srv *server.Server) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller := auth.CallerFromContext(r.Context())
+		id := chi.URLParam(r, "id")
+
+		var body rollbackRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			badRequest(w, "invalid JSON body")
+			return
+		}
+
+		if body.BundleID == "" {
+			badRequest(w, "bundle_id is required")
+			return
+		}
+
+		app, relation, ok := resolveAppRelation(srv, w, caller, id)
+		if !ok {
+			return
+		}
+		if !relation.CanDeploy() {
+			notFound(w, "app not found")
+			return
+		}
+
+		// Validate target bundle.
+		b, err := srv.DB.GetBundle(body.BundleID)
+		if err != nil {
+			serverError(w, "db error: "+err.Error())
+			return
+		}
+		if b == nil || b.AppID != app.ID {
+			notFound(w, "bundle not found")
+			return
+		}
+		if b.Status != "ready" {
+			badRequest(w, "bundle is not ready (status: "+b.Status+")")
+			return
+		}
+		if app.ActiveBundle != nil && *app.ActiveBundle == body.BundleID {
+			badRequest(w, "bundle is already active")
+			return
+		}
+
+		slog.Info("rolling back app",
+			"app_id", app.ID, "name", app.Name,
+			"target_bundle", body.BundleID, "caller", caller.Sub)
+
+		// Capture previous bundle before switching.
+		previousBundle := app.ActiveBundle
+
+		// Drain and stop running workers.
+		ops.StopAppSync(srv, app.ID)
+
+		// Switch active bundle.
+		if err := srv.DB.SetActiveBundle(app.ID, body.BundleID); err != nil {
+			serverError(w, "set active bundle: "+err.Error())
+			return
+		}
+
+		// Re-read app to get updated state.
+		app, err = srv.DB.GetApp(app.ID)
+		if err != nil || app == nil {
+			serverError(w, "get app after rollback")
+			return
+		}
+
+		if srv.AuditLog != nil {
+			srv.AuditLog.Emit(auditEntry(r, audit.ActionAppRollback, app.ID,
+				map[string]any{
+					"bundle_id":          body.BundleID,
+					"previous_bundle_id": stringOrNil(previousBundle),
+				}))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(appResponse(app, srv.Workers))
+	}
+}
+
+func RestoreApp(srv *server.Server) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller := auth.CallerFromContext(r.Context())
+		id := chi.URLParam(r, "id")
+
+		if caller == nil {
+			forbidden(w, "insufficient permissions")
+			return
+		}
+
+		// Look up the app including deleted — GetApp filters them out.
+		app, err := srv.DB.GetAppIncludeDeleted(id)
+		if err != nil {
+			serverError(w, "db error: "+err.Error())
+			return
+		}
+		if app == nil || app.DeletedAt == nil {
+			notFound(w, "deleted app not found")
+			return
+		}
+
+		// Only admins and the original owner can restore.
+		if !caller.Role.CanViewAllApps() && app.Owner != caller.Sub {
+			notFound(w, "deleted app not found")
+			return
+		}
+
+		if err := srv.DB.RestoreApp(app.ID); err != nil {
+			if db.IsUniqueConstraintError(err) {
+				conflict(w, "another app already uses the name "+app.Name)
+				return
+			}
+			serverError(w, "restore app: "+err.Error())
+			return
+		}
+
+		app, err = srv.DB.GetApp(app.ID)
+		if err != nil || app == nil {
+			serverError(w, "get app after restore")
+			return
+		}
+
+		slog.Info("app restored",
+			"app_id", app.ID, "name", app.Name, "caller", caller.Sub)
+
+		if srv.AuditLog != nil {
+			srv.AuditLog.Emit(auditEntry(r, audit.ActionAppRestore, app.ID,
+				map[string]any{"name": app.Name}))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(appResponse(app, srv.Workers))
+	}
+}
+
+func stringOrNil(s *string) any {
+	if s == nil {
+		return nil
+	}
+	return *s
 }
 
 // --- App lifecycle ---
@@ -606,29 +750,6 @@ func drainWorkers(srv *server.Server, appID string, workerIDs []string, sender t
 	sender.Write(fmt.Sprintf("stopped %d workers", len(workerIDs)))
 }
 
-// stopAppSync stops all workers for an app synchronously.
-// Used by DeleteApp where we must wait for workers to stop before
-// deleting the app row. Not suitable for the stop endpoint (use
-// the async drainWorkers path instead).
-func stopAppSync(srv *server.Server, appID string) {
-	workerIDs := srv.Workers.MarkDraining(appID)
-	if len(workerIDs) == 0 {
-		return
-	}
-
-	deadline := time.Now().Add(srv.Config.Server.ShutdownTimeout.Duration)
-	for {
-		remaining := srv.Sessions.CountForWorkers(workerIDs)
-		if remaining == 0 || time.Now().After(deadline) {
-			break
-		}
-		time.Sleep(time.Second)
-	}
-
-	for _, wid := range workerIDs {
-		ops.EvictWorker(context.Background(), srv, wid)
-	}
-}
 
 // AppLogs streams logs from the LogStore for a specific worker.
 func AppLogs(srv *server.Server) http.HandlerFunc {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -219,6 +219,9 @@ func NewRouter(srv *server.Server) http.Handler {
 
 		r.Get("/apps/{id}/bundles", ListBundles(srv))
 
+		r.Post("/apps/{id}/rollback", RollbackApp(srv))
+		r.Post("/apps/{id}/restore", RestoreApp(srv))
+
 		r.Post("/apps/{id}/start", StartApp(srv))
 		r.Post("/apps/{id}/stop", StopApp(srv))
 		r.Get("/apps/{id}/logs", AppLogs(srv))

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -22,6 +22,8 @@ const (
 	ActionBundleUpload      Action = "bundle.upload"
 	ActionBundleRestoreOK   Action = "bundle.restore.success"
 	ActionBundleRestoreFail Action = "bundle.restore.fail"
+	ActionAppRollback       Action = "app.rollback"
+	ActionAppRestore        Action = "app.restore"
 	ActionAccessGrant       Action = "access.grant"
 	ActionAccessRevoke      Action = "access.revoke"
 	ActionCredentialEnroll  Action = "credential.enroll"

--- a/internal/backend/docker/docker.go
+++ b/internal/backend/docker/docker.go
@@ -220,9 +220,9 @@ func (d *DockerBackend) ensureImage(ctx context.Context, img string) error {
 
 // --- Memory limit parsing ---
 
-// parseMemoryLimit converts human-readable memory strings like "512m", "1g",
+// ParseMemoryLimit converts human-readable memory strings like "512m", "1g",
 // "256mb" to bytes. Returns (bytes, true) on success.
-func parseMemoryLimit(s string) (int64, bool) {
+func ParseMemoryLimit(s string) (int64, bool) {
 	s = strings.TrimSpace(strings.ToLower(s))
 	var numStr string
 	var multiplier int64
@@ -379,7 +379,7 @@ func (d *DockerBackend) createWorkerContainer(
 
 	var resources container.Resources
 	if spec.MemoryLimit != "" {
-		if mem, ok := parseMemoryLimit(spec.MemoryLimit); ok {
+		if mem, ok := ParseMemoryLimit(spec.MemoryLimit); ok {
 			resources.Memory = mem
 		}
 	}
@@ -501,6 +501,9 @@ func (d *DockerBackend) Spawn(ctx context.Context, spec backend.WorkerSpec) erro
 		return fmt.Errorf("spawn: start container: %w", err)
 	}
 
+	// Verify resource limits match what was requested.
+	d.verifyResourceLimits(ctx, containerID, spec)
+
 	// Record internal state
 	d.mu.Lock()
 	d.workers[spec.WorkerID] = &workerState{
@@ -515,6 +518,43 @@ func (d *DockerBackend) Spawn(ctx context.Context, spec backend.WorkerSpec) erro
 		"elapsed_ms", time.Since(spawnStart).Milliseconds())
 
 	return nil
+}
+
+// verifyResourceLimits inspects a running container and warns if
+// actual resource limits don't match what was requested.
+func (d *DockerBackend) verifyResourceLimits(
+	ctx context.Context,
+	containerID string,
+	spec backend.WorkerSpec,
+) {
+	info, err := d.client.ContainerInspect(ctx, containerID)
+	if err != nil {
+		slog.Warn("spawn: failed to verify resource limits",
+			"worker_id", spec.WorkerID, "error", err)
+		return
+	}
+
+	if spec.MemoryLimit != "" {
+		expected, ok := ParseMemoryLimit(spec.MemoryLimit)
+		if ok && info.HostConfig.Resources.Memory != expected {
+			slog.Warn("spawn: memory limit mismatch",
+				"worker_id", spec.WorkerID,
+				"requested", spec.MemoryLimit,
+				"expected_bytes", expected,
+				"actual_bytes", info.HostConfig.Resources.Memory)
+		}
+	}
+
+	if spec.CPULimit > 0 {
+		expected := int64(spec.CPULimit * 1e9)
+		if info.HostConfig.Resources.NanoCPUs != expected {
+			slog.Warn("spawn: CPU limit mismatch",
+				"worker_id", spec.WorkerID,
+				"requested_cpus", spec.CPULimit,
+				"expected_nanocpus", expected,
+				"actual_nanocpus", info.HostConfig.Resources.NanoCPUs)
+		}
+	}
 }
 
 func (d *DockerBackend) Stop(ctx context.Context, id string) error {

--- a/internal/backend/docker/docker_integration_test.go
+++ b/internal/backend/docker/docker_integration_test.go
@@ -1090,13 +1090,13 @@ func TestParseMemoryLimitEdgeCases(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got, ok := parseMemoryLimit(tt.input)
+		got, ok := ParseMemoryLimit(tt.input)
 		if ok != tt.wantOk {
-			t.Errorf("parseMemoryLimit(%q): ok=%v, want %v", tt.input, ok, tt.wantOk)
+			t.Errorf("ParseMemoryLimit(%q): ok=%v, want %v", tt.input, ok, tt.wantOk)
 			continue
 		}
 		if ok && got != tt.want {
-			t.Errorf("parseMemoryLimit(%q) = %d, want %d", tt.input, got, tt.want)
+			t.Errorf("ParseMemoryLimit(%q) = %d, want %d", tt.input, got, tt.want)
 		}
 	}
 }

--- a/internal/backend/docker/docker_unit_test.go
+++ b/internal/backend/docker/docker_unit_test.go
@@ -23,13 +23,13 @@ func TestParseMemoryLimit(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got, ok := parseMemoryLimit(tt.input)
+		got, ok := ParseMemoryLimit(tt.input)
 		if ok != tt.ok {
-			t.Errorf("parseMemoryLimit(%q) ok = %v, want %v", tt.input, ok, tt.ok)
+			t.Errorf("ParseMemoryLimit(%q) ok = %v, want %v", tt.input, ok, tt.ok)
 			continue
 		}
 		if ok && got != tt.want {
-			t.Errorf("parseMemoryLimit(%q) = %d, want %d", tt.input, got, tt.want)
+			t.Errorf("ParseMemoryLimit(%q) = %d, want %d", tt.input, got, tt.want)
 		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,10 +55,11 @@ type DockerConfig struct {
 }
 
 type StorageConfig struct {
-	BundleServerPath string `toml:"bundle_server_path"`
-	BundleWorkerPath string `toml:"bundle_worker_path"`
-	BundleRetention  int    `toml:"bundle_retention"`
-	MaxBundleSize    int64  `toml:"max_bundle_size"`
+	BundleServerPath    string   `toml:"bundle_server_path"`
+	BundleWorkerPath    string   `toml:"bundle_worker_path"`
+	BundleRetention     int      `toml:"bundle_retention"`
+	MaxBundleSize       int64    `toml:"max_bundle_size"`
+	SoftDeleteRetention Duration `toml:"soft_delete_retention"`
 }
 
 type DatabaseConfig struct {
@@ -76,6 +77,7 @@ type ProxyConfig struct {
 	SessionIdleTTL     Duration `toml:"session_idle_ttl"`
 	IdleWorkerTimeout  Duration `toml:"idle_worker_timeout"`
 	HTTPForwardTimeout Duration `toml:"http_forward_timeout"`
+	MaxCPULimit        *float64 `toml:"max_cpu_limit"`
 }
 
 type OidcConfig struct {
@@ -196,6 +198,10 @@ func applyDefaults(cfg *Config) {
 	}
 	if cfg.Proxy.HTTPForwardTimeout.Duration == 0 {
 		cfg.Proxy.HTTPForwardTimeout.Duration = 5 * time.Minute
+	}
+	if cfg.Proxy.MaxCPULimit == nil {
+		v := 16.0
+		cfg.Proxy.MaxCPULimit = &v
 	}
 	if cfg.OIDC != nil {
 		oidcDefaults(cfg.OIDC)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -166,7 +166,9 @@ func (db *DB) migrateDriver() (migratedb.Driver, error) {
 	case DialectPostgres:
 		return migratepostgres.WithInstance(db.DB.DB, &migratepostgres.Config{})
 	default:
-		return migratesqlite.WithInstance(db.DB.DB, &migratesqlite.Config{})
+		return migratesqlite.WithInstance(db.DB.DB, &migratesqlite.Config{
+			NoTxWrap: true,
+		})
 	}
 }
 
@@ -218,6 +220,7 @@ type AppRow struct {
 	Description          *string  `db:"description" json:"description"`
 	CreatedAt            string   `db:"created_at" json:"created_at"`
 	UpdatedAt            string   `db:"updated_at" json:"updated_at"`
+	DeletedAt            *string  `db:"deleted_at" json:"deleted_at,omitempty"`
 }
 
 type BundleRow struct {
@@ -253,7 +256,8 @@ func (db *DB) CreateApp(name, owner string) (*AppRow, error) {
 
 func (db *DB) GetApp(id string) (*AppRow, error) {
 	var app AppRow
-	err := db.DB.Get(&app, db.rebind(`SELECT * FROM apps WHERE id = ?`), id)
+	err := db.DB.Get(&app, db.rebind(
+		`SELECT * FROM apps WHERE id = ? AND deleted_at IS NULL`), id)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -265,7 +269,8 @@ func (db *DB) GetApp(id string) (*AppRow, error) {
 
 func (db *DB) GetAppByName(name string) (*AppRow, error) {
 	var app AppRow
-	err := db.DB.Get(&app, db.rebind(`SELECT * FROM apps WHERE name = ?`), name)
+	err := db.DB.Get(&app, db.rebind(
+		`SELECT * FROM apps WHERE name = ? AND deleted_at IS NULL`), name)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -277,7 +282,8 @@ func (db *DB) GetAppByName(name string) (*AppRow, error) {
 
 func (db *DB) ListApps() ([]AppRow, error) {
 	var apps []AppRow
-	err := db.DB.Select(&apps, `SELECT * FROM apps ORDER BY created_at DESC`)
+	err := db.DB.Select(&apps,
+		`SELECT * FROM apps WHERE deleted_at IS NULL ORDER BY created_at DESC`)
 	if err != nil {
 		return nil, err
 	}
@@ -291,9 +297,10 @@ func (db *DB) ListAccessibleApps(sub string) ([]AppRow, error) {
 		`SELECT DISTINCT a.*
 		 FROM apps a
 		 LEFT JOIN app_access aa ON a.id = aa.app_id
-		 WHERE a.access_type IN ('public', 'logged_in')
-		    OR a.owner = ?
-		    OR (aa.kind = 'user' AND aa.principal = ?)
+		 WHERE a.deleted_at IS NULL
+		   AND (a.access_type IN ('public', 'logged_in')
+		        OR a.owner = ?
+		        OR (aa.kind = 'user' AND aa.principal = ?))
 		 ORDER BY a.created_at DESC`)
 
 	var apps []AppRow
@@ -304,13 +311,71 @@ func (db *DB) ListAccessibleApps(sub string) ([]AppRow, error) {
 	return apps, nil
 }
 
-func (db *DB) DeleteApp(id string) (bool, error) {
-	result, err := db.Exec(db.rebind(`DELETE FROM apps WHERE id = ?`), id)
-	if err != nil {
-		return false, err
+// GetAppIncludeDeleted returns an app by ID regardless of soft-delete
+// status. Used by the restore endpoint and the sweeper.
+func (db *DB) GetAppIncludeDeleted(id string) (*AppRow, error) {
+	var app AppRow
+	err := db.DB.Get(&app, db.rebind(`SELECT * FROM apps WHERE id = ?`), id)
+	if err == sql.ErrNoRows {
+		return nil, nil
 	}
-	n, _ := result.RowsAffected()
-	return n > 0, nil
+	if err != nil {
+		return nil, err
+	}
+	return &app, nil
+}
+
+// SoftDeleteApp sets deleted_at on an app.
+func (db *DB) SoftDeleteApp(id string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := db.Exec(db.rebind(
+		`UPDATE apps SET deleted_at = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL`),
+		now, now, id,
+	)
+	return err
+}
+
+// RestoreApp clears deleted_at on a soft-deleted app.
+func (db *DB) RestoreApp(id string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := db.Exec(db.rebind(
+		`UPDATE apps SET deleted_at = NULL, updated_at = ? WHERE id = ? AND deleted_at IS NOT NULL`),
+		now, id,
+	)
+	return err
+}
+
+// HardDeleteApp permanently removes an app row. Used by the sweeper
+// after all associated resources (bundles, files) have been cleaned up.
+func (db *DB) HardDeleteApp(id string) error {
+	_, err := db.Exec(db.rebind(`DELETE FROM apps WHERE id = ?`), id)
+	return err
+}
+
+// ListDeletedApps returns all soft-deleted apps, newest deletion first.
+func (db *DB) ListDeletedApps() ([]AppRow, error) {
+	var apps []AppRow
+	err := db.DB.Select(&apps,
+		`SELECT * FROM apps WHERE deleted_at IS NOT NULL ORDER BY deleted_at DESC`)
+	if err != nil {
+		return nil, err
+	}
+	return apps, nil
+}
+
+// ListExpiredDeletedApps returns soft-deleted apps whose deleted_at is
+// older than the given cutoff time. Used by the sweeper.
+func (db *DB) ListExpiredDeletedApps(cutoff string) ([]AppRow, error) {
+	var apps []AppRow
+	err := db.DB.Select(&apps, db.rebind(
+		`SELECT * FROM apps WHERE deleted_at IS NOT NULL AND deleted_at < ?
+		 ORDER BY deleted_at ASC`),
+		cutoff,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return apps, nil
 }
 
 // --- Bundles ---
@@ -744,7 +809,7 @@ type CatalogParams struct {
 // ListCatalog returns apps visible to the caller with access control,
 // tag filtering, search, and pagination.
 func (db *DB) ListCatalog(params CatalogParams) ([]AppRow, int, error) {
-	var conditions []string
+	conditions := []string{"apps.deleted_at IS NULL"}
 	var args []any
 
 	// Access control filter

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -145,12 +145,9 @@ func TestDuplicateNameFails(t *testing.T) {
 func TestDeleteApp(t *testing.T) {
 	eachDB(t, func(t *testing.T, db *DB) {
 		app, _ := db.CreateApp("my-app", "admin")
-		deleted, err := db.DeleteApp(app.ID)
+		err := db.HardDeleteApp(app.ID)
 		if err != nil {
 			t.Fatal(err)
-		}
-		if !deleted {
-			t.Error("expected deletion")
 		}
 
 		fetched, _ := db.GetApp(app.ID)
@@ -675,12 +672,9 @@ func TestGetBundleNonexistent(t *testing.T) {
 
 func TestDeleteAppNonexistent(t *testing.T) {
 	eachDB(t, func(t *testing.T, db *DB) {
-		deleted, err := db.DeleteApp("00000000-0000-0000-0000-000000000000")
+		err := db.HardDeleteApp("00000000-0000-0000-0000-000000000000")
 		if err != nil {
 			t.Fatal(err)
-		}
-		if deleted {
-			t.Error("expected false for nonexistent app")
 		}
 	})
 }
@@ -1207,4 +1201,222 @@ func TestOpenUnsupportedDriver(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unsupported driver")
 	}
+}
+
+// --- Soft-delete tests ---
+
+func TestSoftDeleteApp(t *testing.T) {
+	eachDB(t, func(t *testing.T, db *DB) {
+		app, _ := db.CreateApp("my-app", "admin")
+
+		if err := db.SoftDeleteApp(app.ID); err != nil {
+			t.Fatal(err)
+		}
+
+		// App should not be visible via GetApp.
+		fetched, _ := db.GetApp(app.ID)
+		if fetched != nil {
+			t.Error("expected nil from GetApp after soft delete")
+		}
+
+		// App should be visible via GetAppIncludeDeleted.
+		fetched, _ = db.GetAppIncludeDeleted(app.ID)
+		if fetched == nil {
+			t.Fatal("expected non-nil from GetAppIncludeDeleted")
+		}
+		if fetched.DeletedAt == nil {
+			t.Error("expected deleted_at to be set")
+		}
+	})
+}
+
+func TestSoftDeleteAppIdempotent(t *testing.T) {
+	eachDB(t, func(t *testing.T, db *DB) {
+		app, _ := db.CreateApp("my-app", "admin")
+		db.SoftDeleteApp(app.ID)
+
+		// Second soft-delete should be a no-op (WHERE deleted_at IS NULL).
+		if err := db.SoftDeleteApp(app.ID); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestRestoreApp(t *testing.T) {
+	eachDB(t, func(t *testing.T, db *DB) {
+		app, _ := db.CreateApp("my-app", "admin")
+		db.SoftDeleteApp(app.ID)
+
+		if err := db.RestoreApp(app.ID); err != nil {
+			t.Fatal(err)
+		}
+
+		fetched, _ := db.GetApp(app.ID)
+		if fetched == nil {
+			t.Fatal("expected app to reappear after restore")
+		}
+		if fetched.DeletedAt != nil {
+			t.Error("expected deleted_at to be nil after restore")
+		}
+	})
+}
+
+func TestRestoreNonDeletedApp(t *testing.T) {
+	eachDB(t, func(t *testing.T, db *DB) {
+		app, _ := db.CreateApp("my-app", "admin")
+
+		// Restore on a non-deleted app is a no-op.
+		if err := db.RestoreApp(app.ID); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestListAppsExcludesDeleted(t *testing.T) {
+	eachDB(t, func(t *testing.T, db *DB) {
+		db.CreateApp("app-a", "admin")
+		app2, _ := db.CreateApp("app-b", "admin")
+		db.SoftDeleteApp(app2.ID)
+
+		apps, _ := db.ListApps()
+		if len(apps) != 1 {
+			t.Fatalf("expected 1 app, got %d", len(apps))
+		}
+		if apps[0].Name != "app-a" {
+			t.Errorf("expected app-a, got %s", apps[0].Name)
+		}
+	})
+}
+
+func TestListDeletedApps(t *testing.T) {
+	eachDB(t, func(t *testing.T, db *DB) {
+		app1, _ := db.CreateApp("app-a", "admin")
+		db.CreateApp("app-b", "admin")
+		db.SoftDeleteApp(app1.ID)
+
+		deleted, _ := db.ListDeletedApps()
+		if len(deleted) != 1 {
+			t.Fatalf("expected 1 deleted app, got %d", len(deleted))
+		}
+		if deleted[0].ID != app1.ID {
+			t.Error("expected deleted app to be app-a")
+		}
+	})
+}
+
+func TestListExpiredDeletedApps(t *testing.T) {
+	eachDB(t, func(t *testing.T, db *DB) {
+		app1, _ := db.CreateApp("app-a", "admin")
+		db.SoftDeleteApp(app1.ID)
+
+		// Use a cutoff in the future — all soft-deleted apps are expired.
+		future := "2099-01-01T00:00:00Z"
+		expired, _ := db.ListExpiredDeletedApps(future)
+		if len(expired) != 1 {
+			t.Fatalf("expected 1 expired app, got %d", len(expired))
+		}
+
+		// Use a cutoff in the past — no apps are expired.
+		past := "2000-01-01T00:00:00Z"
+		expired, _ = db.ListExpiredDeletedApps(past)
+		if len(expired) != 0 {
+			t.Fatalf("expected 0 expired apps, got %d", len(expired))
+		}
+	})
+}
+
+func TestListCatalogExcludesDeleted(t *testing.T) {
+	eachDB(t, func(t *testing.T, db *DB) {
+		app1, _ := db.CreateApp("app-a", "admin")
+		db.CreateApp("app-b", "admin")
+		db.SoftDeleteApp(app1.ID)
+
+		apps, total, err := db.ListCatalog(CatalogParams{
+			CallerRole: "admin",
+			Page:       1,
+			PerPage:    10,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != 1 {
+			t.Errorf("expected total 1, got %d", total)
+		}
+		if len(apps) != 1 || apps[0].Name != "app-b" {
+			t.Errorf("expected app-b, got %v", apps)
+		}
+	})
+}
+
+func TestListAccessibleAppsExcludesDeleted(t *testing.T) {
+	eachDB(t, func(t *testing.T, db *DB) {
+		app1, _ := db.CreateApp("app-a", "admin")
+		db.CreateApp("app-b", "admin")
+		db.SoftDeleteApp(app1.ID)
+
+		apps, _ := db.ListAccessibleApps("admin")
+		if len(apps) != 1 {
+			t.Fatalf("expected 1 accessible app, got %d", len(apps))
+		}
+	})
+}
+
+func TestHardDeleteApp(t *testing.T) {
+	eachDB(t, func(t *testing.T, db *DB) {
+		app, _ := db.CreateApp("my-app", "admin")
+		if err := db.HardDeleteApp(app.ID); err != nil {
+			t.Fatal(err)
+		}
+		fetched, _ := db.GetAppIncludeDeleted(app.ID)
+		if fetched != nil {
+			t.Error("expected nil after hard delete")
+		}
+	})
+}
+
+func TestSoftDeletedNameReusable(t *testing.T) {
+	eachDB(t, func(t *testing.T, db *DB) {
+		app, _ := db.CreateApp("my-app", "admin")
+		db.SoftDeleteApp(app.ID)
+
+		// Creating a new app with the same name should succeed.
+		app2, err := db.CreateApp("my-app", "admin")
+		if err != nil {
+			t.Fatalf("expected name reuse to succeed: %v", err)
+		}
+		if app2.Name != "my-app" {
+			t.Error("expected new app to have the same name")
+		}
+	})
+}
+
+func TestRestoreWithNameCollision(t *testing.T) {
+	eachDB(t, func(t *testing.T, db *DB) {
+		app1, _ := db.CreateApp("my-app", "admin")
+		db.SoftDeleteApp(app1.ID)
+
+		// Create a new app with the same name.
+		db.CreateApp("my-app", "admin")
+
+		// Restoring the original should fail with unique constraint error.
+		err := db.RestoreApp(app1.ID)
+		if err == nil {
+			t.Fatal("expected unique constraint error on restore")
+		}
+		if !IsUniqueConstraintError(err) {
+			t.Fatalf("expected unique constraint error, got: %v", err)
+		}
+	})
+}
+
+func TestGetAppByNameExcludesDeleted(t *testing.T) {
+	eachDB(t, func(t *testing.T, db *DB) {
+		app, _ := db.CreateApp("my-app", "admin")
+		db.SoftDeleteApp(app.ID)
+
+		fetched, _ := db.GetAppByName("my-app")
+		if fetched != nil {
+			t.Error("expected nil from GetAppByName for soft-deleted app")
+		}
+	})
 }

--- a/internal/db/migrations/postgres/002_v2_soft_delete.down.sql
+++ b/internal/db/migrations/postgres/002_v2_soft_delete.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_apps_name_live;
+ALTER TABLE apps ADD CONSTRAINT apps_name_key UNIQUE (name);
+ALTER TABLE apps DROP COLUMN deleted_at;

--- a/internal/db/migrations/postgres/002_v2_soft_delete.up.sql
+++ b/internal/db/migrations/postgres/002_v2_soft_delete.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE apps ADD COLUMN deleted_at TEXT;
+
+-- Replace the column-level UNIQUE on name with a partial unique index.
+ALTER TABLE apps DROP CONSTRAINT apps_name_key;
+CREATE UNIQUE INDEX idx_apps_name_live ON apps(name) WHERE deleted_at IS NULL;

--- a/internal/db/migrations/sqlite/002_v2_soft_delete.down.sql
+++ b/internal/db/migrations/sqlite/002_v2_soft_delete.down.sql
@@ -1,0 +1,33 @@
+-- Rebuild apps table: restore column-level UNIQUE on name, remove deleted_at.
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE apps_new (
+    id                      TEXT PRIMARY KEY,
+    name                    TEXT NOT NULL UNIQUE,
+    owner                   TEXT NOT NULL DEFAULT 'admin',
+    access_type             TEXT NOT NULL DEFAULT 'acl'
+                            CHECK (access_type IN ('acl', 'logged_in', 'public')),
+    active_bundle           TEXT REFERENCES bundles(id) ON DELETE SET NULL,
+    max_workers_per_app     INTEGER,
+    max_sessions_per_worker INTEGER DEFAULT 1,
+    memory_limit            TEXT,
+    cpu_limit               REAL,
+    title                   TEXT,
+    description             TEXT,
+    created_at              TEXT NOT NULL,
+    updated_at              TEXT NOT NULL
+);
+
+INSERT INTO apps_new
+    SELECT id, name, owner, access_type, active_bundle,
+           max_workers_per_app, max_sessions_per_worker,
+           memory_limit, cpu_limit, title, description,
+           created_at, updated_at
+    FROM apps
+    WHERE deleted_at IS NULL;
+
+DROP INDEX IF EXISTS idx_apps_name_live;
+DROP TABLE apps;
+ALTER TABLE apps_new RENAME TO apps;
+
+PRAGMA foreign_keys = ON;

--- a/internal/db/migrations/sqlite/002_v2_soft_delete.up.sql
+++ b/internal/db/migrations/sqlite/002_v2_soft_delete.up.sql
@@ -1,0 +1,36 @@
+-- Disable FK checks so we can rebuild the apps table.
+PRAGMA foreign_keys = OFF;
+
+-- Rebuild apps table: replace column-level UNIQUE on name with a
+-- partial unique index that only covers live (non-deleted) apps.
+CREATE TABLE apps_new (
+    id                      TEXT PRIMARY KEY,
+    name                    TEXT NOT NULL,
+    owner                   TEXT NOT NULL DEFAULT 'admin',
+    access_type             TEXT NOT NULL DEFAULT 'acl'
+                            CHECK (access_type IN ('acl', 'logged_in', 'public')),
+    active_bundle           TEXT REFERENCES bundles(id) ON DELETE SET NULL,
+    max_workers_per_app     INTEGER,
+    max_sessions_per_worker INTEGER DEFAULT 1,
+    memory_limit            TEXT,
+    cpu_limit               REAL,
+    title                   TEXT,
+    description             TEXT,
+    created_at              TEXT NOT NULL,
+    updated_at              TEXT NOT NULL,
+    deleted_at              TEXT
+);
+
+INSERT INTO apps_new
+    SELECT id, name, owner, access_type, active_bundle,
+           max_workers_per_app, max_sessions_per_worker,
+           memory_limit, cpu_limit, title, description,
+           created_at, updated_at, NULL
+    FROM apps;
+
+DROP TABLE apps;
+ALTER TABLE apps_new RENAME TO apps;
+
+CREATE UNIQUE INDEX idx_apps_name_live ON apps(name) WHERE deleted_at IS NULL;
+
+PRAGMA foreign_keys = ON;

--- a/internal/ops/ops.go
+++ b/internal/ops/ops.go
@@ -237,6 +237,81 @@ func GracefulShutdown(ctx context.Context, srv *server.Server) {
 	}
 }
 
+// StopAppSync stops all workers for an app synchronously.
+// Marks workers as draining, waits for sessions to end (up to
+// shutdown_timeout), then force-evicts. If no workers are running,
+// this is a no-op.
+func StopAppSync(srv *server.Server, appID string) {
+	workerIDs := srv.Workers.MarkDraining(appID)
+	if len(workerIDs) == 0 {
+		return
+	}
+
+	deadline := time.Now().Add(srv.Config.Server.ShutdownTimeout.Duration)
+	for {
+		remaining := srv.Sessions.CountForWorkers(workerIDs)
+		if remaining == 0 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+
+	for _, wid := range workerIDs {
+		EvictWorker(context.Background(), srv, wid)
+	}
+}
+
+// SpawnSoftDeleteSweeper periodically purges soft-deleted apps whose
+// retention period has expired. Blocks until ctx is cancelled.
+// Does not start if soft_delete_retention is zero (soft-delete
+// disabled — nothing to sweep).
+func SpawnSoftDeleteSweeper(ctx context.Context, srv *server.Server) {
+	retention := srv.Config.Storage.SoftDeleteRetention.Duration
+	if retention == 0 {
+		<-ctx.Done()
+		return
+	}
+
+	// Sweep every hour or every retention period, whichever is shorter.
+	interval := 1 * time.Hour
+	if retention < interval {
+		interval = retention
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			sweepDeletedApps(srv)
+		}
+	}
+}
+
+func sweepDeletedApps(srv *server.Server) {
+	retention := srv.Config.Storage.SoftDeleteRetention.Duration
+	cutoff := time.Now().Add(-retention).UTC().Format(time.RFC3339)
+
+	apps, err := srv.DB.ListExpiredDeletedApps(cutoff)
+	if err != nil {
+		slog.Warn("soft-delete sweeper: list failed", "error", err)
+		return
+	}
+
+	if len(apps) == 0 {
+		return
+	}
+
+	slog.Info("soft-delete sweeper: purging expired apps", "count", len(apps))
+	for _, app := range apps {
+		StopAppSync(srv, app.ID)
+		PurgeApp(srv, &app)
+	}
+}
+
 // SpawnLogRetentionCleaner periodically prunes expired log entries.
 // Blocks until ctx is cancelled.
 func SpawnLogRetentionCleaner(ctx context.Context, srv *server.Server) {

--- a/internal/ops/purge.go
+++ b/internal/ops/purge.go
@@ -1,0 +1,52 @@
+package ops
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/cynkra/blockyard/internal/bundle"
+	"github.com/cynkra/blockyard/internal/db"
+	"github.com/cynkra/blockyard/internal/server"
+)
+
+// PurgeApp permanently removes an app's bundles, files, and database
+// rows. The app must already have no running workers. Used by both
+// the DeleteApp handler (immediate delete) and the sweeper.
+func PurgeApp(srv *server.Server, app *db.AppRow) {
+	bundles, err := srv.DB.ListBundlesByApp(app.ID)
+	if err != nil {
+		slog.Warn("purge: list bundles failed",
+			"app_id", app.ID, "error", err)
+	}
+
+	for _, b := range bundles {
+		paths := bundle.NewBundlePaths(srv.Config.Storage.BundleServerPath, app.ID, b.ID)
+		bundle.DeleteFiles(paths)
+	}
+
+	if err := srv.DB.ClearActiveBundle(app.ID); err != nil {
+		slog.Warn("purge: clear active bundle failed",
+			"app_id", app.ID, "error", err)
+	}
+
+	for _, b := range bundles {
+		if _, err := srv.DB.DeleteBundle(b.ID); err != nil {
+			slog.Warn("purge: delete bundle row failed",
+				"bundle_id", b.ID, "app_id", app.ID, "error", err)
+		}
+	}
+
+	if err := srv.DB.HardDeleteApp(app.ID); err != nil {
+		slog.Warn("purge: delete app row failed",
+			"app_id", app.ID, "error", err)
+	}
+
+	appDir := filepath.Join(srv.Config.Storage.BundleServerPath, app.ID)
+	if err := os.RemoveAll(appDir); err != nil {
+		slog.Warn("purge: remove app directory failed",
+			"app_id", app.ID, "path", appDir, "error", err)
+	}
+
+	slog.Info("purged app", "app_id", app.ID, "name", app.Name)
+}


### PR DESCRIPTION
## Summary

- **Bundle rollback**: `POST /api/v1/apps/{id}/rollback` — validates target bundle, drains active workers, switches active bundle synchronously
- **Soft-delete for apps**: `DELETE` marks apps as deleted when `soft_delete_retention` is configured; `POST /restore` to undo; background sweeper purges expired; partial unique index allows name reuse
- **Resource limit validation**: `UpdateApp` rejects invalid `memory_limit` formats and `cpu_limit` values exceeding configurable ceiling; post-spawn container inspection warns on mismatches
- **Infrastructure**: extracted `ops.StopAppSync` and `ops.PurgeApp` for shared use across handlers and sweeper; migration 002 for both SQLite and PostgreSQL