### PR TITLE
Design: split phase 2-5 into build pipeline and package store

### DIFF
--- a/docs/design/roadmap.md
+++ b/docs/design/roadmap.md
@@ -32,8 +32,9 @@ plane. v1 is the MVP: the minimum needed to host a real blockr app for real
 users. v1 adds user auth (OIDC), identity injection, per-user credential
 management (the integration system), and load balancing. Nothing beyond v1 is
 required to call the product useful. v2 adds single-node production
-completeness (CLI, scale-to-zero, pre-warming, runtime package install,
-board storage via PostgreSQL + PostgREST + vault Identity OIDC, cold-start
+completeness (CLI, scale-to-zero, pre-warming, build pipeline
+modernization with pak, a content-addressable package store, board
+storage via PostgreSQL + PostgREST + vault Identity OIDC, cold-start
 loading page). v3 adds
 the lightweight process backend plus deferred single-node features (data
 mounts, Docker daemon hardening, multiple execution environment images, UI
@@ -77,7 +78,7 @@ log_level        = "info"  # trace, debug, info, warn, error
 socket     = "/var/run/docker.sock"  # or Podman socket path
 image      = "ghcr.io/rocker-org/r-ver:4.4.3"
 shiny_port = 3838                    # internal port Shiny listens on
-rv_version = "latest"                # rv release tag, e.g. "v0.18.0"
+pak_version = "stable"               # pak release channel: "stable", "devel"
 
 [storage]
 bundle_server_path = "/data/bundles"   # where the server reads/writes bundles
@@ -250,8 +251,10 @@ plane protected by a single static bearer token in config.
   REST endpoint, unpack it to a content directory, trigger dependency
   restoration, and register it in the content database. App name and all
   configuration are supplied via the API — there is no in-bundle manifest file.
-  The conventional entrypoint is `app.R`; an `rv.lock` at the bundle root is
-  required for dependency restoration. Each upload creates a new versioned
+  The conventional entrypoint is `app.R`. Dependency restoration is
+  flexible: a `pkg.lock` (pak lockfile) provides exact reproducibility,
+  a `DESCRIPTION` file declares standard R package dependencies, or
+  bare scripts are scanned automatically for `library()`/`::` calls. Each upload creates a new versioned
   bundle; previous bundles are retained up to a configurable limit, enabling
   rollback. Typical deploy flow:
 
@@ -283,9 +286,9 @@ plane protected by a single static bearer token in config.
       {bundle-id}.tar.gz    # uploaded archive
       {bundle-id}/          # unpacked app code
         app.R
-        rv.lock
+        DESCRIPTION   # or pkg.lock, or neither
         ...
-      {bundle-id}_lib/      # R package library restored by rv
+      {bundle-id}_lib/      # R package library restored by pak
   ```
 
   Archives are written to a temp path first and moved atomically into place on
@@ -306,23 +309,29 @@ plane protected by a single static bearer token in config.
   packages at runtime.
 
 - **Dependency restoration.** After uploading a bundle, restore R package
-  dependencies from `rv.lock` using [`rv`](https://github.com/A2-ai/rv).
-  `rv` is a hard runtime requirement. Restore runs via the backend's build
-  method — how the build step executes is backend-specific: a run-to-completion
-  container on Docker/Podman, an init container or Job on Kubernetes. The `rv`
-  binary is downloaded from GitHub releases and cached locally in
-  `{bundle_server_path}/.rv-cache/` (`internal/rvcache`). Pinned versions are
-  cached indefinitely; `latest` is re-fetched when the cache is older than one
-  hour. Downloads are serialized via a global mutex and written atomically to
-  prevent partial-file corruption.
-  A shared cache avoids re-downloading packages on every deploy.
+  dependencies using [`pak`](https://pak.r-lib.org/). Restore runs via the
+  backend's build method — how the build step executes is backend-specific:
+  a run-to-completion container on Docker/Podman, an init container or Job
+  on Kubernetes. pak's pre-built bundle (which vendors all dependencies into
+  a single R package) is downloaded once and cached on the server in
+  `{bundle_server_path}/.pak-cache/` (`internal/pakcache`). It is mounted
+  read-only into build containers.
+
+  Three build modes are supported, selected by bundle contents:
+  - **Lockfile** (`pkg.lock`): `pak::lockfile_install()` — exact versions.
+  - **DESCRIPTION**: `pak::local_install_deps()` — standard R package deps
+    with optional `Remotes` field for GitHub/git sources.
+  - **Script scan** (fallback): `pak::scan_deps()` discovers `library()`,
+    `require()`, `::` calls in R scripts, then `pak::pkg_install()` resolves
+    and installs them. Zero-config deploys.
+
   The restored library is written to `{bundle-id}_lib/` alongside the unpacked
   bundle and mounted read-only into app workers at `/blockyard-lib`.
   The R version is configured server-wide — no per-deployment version selection
   or version matching logic.
 
-  Restore output (stdout/stderr from `rv`) is streamed to the caller via the
-  task log endpoint. The task lifecycle is managed by an in-memory task store.
+  Restore output is streamed to the caller via the task log endpoint. The task
+  lifecycle is managed by an in-memory task store.
 
 - **Content registry.** A SQLite database. Core v0 tables:
 

--- a/docs/design/v2/phase-2-5.md
+++ b/docs/design/v2/phase-2-5.md
@@ -1,0 +1,544 @@
+# Phase 2-5: Build Pipeline — rv → pak
+
+Replace rv with pak as the build-time dependency manager. Make lockfiles
+optional. Support three build modes depending on what the bundle ships:
+lockfile (exact reproducibility), DESCRIPTION (standard R package deps),
+or bare scripts (zero-config deploy via script scanning). This simplifies
+the deployment workflow — users no longer need rv or any special tooling
+to prepare bundles — and aligns blockyard with the standard R ecosystem.
+
+## Deliverables
+
+1. **pak cache** — download and cache pak's pre-built bundle on the
+   server, replacing the rv binary cache.
+2. **Build mode detection** — determine how to resolve dependencies
+   based on bundle contents (lockfile → DESCRIPTION → script scan).
+3. **Build container command** — R script that loads pak and runs the
+   appropriate resolution + install strategy.
+4. **BuildSpec extension** — add `Cmd` and `Mounts` fields so the
+   `Build` method supports flexible build commands beyond the current
+   hardcoded `rv sync`.
+5. **Config changes** — replace `rv_version` with `pak_version`.
+6. **Bundle validation** — relax the lockfile requirement; accept
+   bundles with only `app.R`.
+7. **Migration** — update examples, documentation, tests.
+
+---
+
+## Step 1: pak cache
+
+Replace `internal/rvcache/` with `internal/pakcache/`. Same pattern:
+download once, cache on the server, mount read-only into build
+containers.
+
+pak ships pre-built binaries that bundle all dependencies (pkgdepends,
+curl, cli, lpSolve, etc.) into a single R package — no dependency
+resolution needed to install pak itself.
+
+```go
+// internal/pakcache/pakcache.go
+
+const (
+    // Pre-built binary repo. Platform-specific URL is constructed at runtime.
+    pakRepoBase = "https://r-lib.github.io/p/pak"
+)
+
+// EnsureInstalled downloads the pak R package to the cache directory
+// if not already present. Returns the path to the cached pak package
+// directory (suitable for mounting into build containers).
+//
+// The cached pak is a fully installed R package tree — the build
+// container adds it to .libPaths() and calls pak functions directly.
+func EnsureInstalled(ctx context.Context, be backend.Backend,
+    image, version, cachePath string) (string, error) {
+
+    pakDir := filepath.Join(cachePath, "pak-"+version)
+    if dirExists(pakDir) {
+        return pakDir, nil
+    }
+
+    // Install pak into the cache directory using a short-lived container.
+    // The container runs R, installs pak from the pre-built binary repo,
+    // and writes the installed package tree to the mounted output dir.
+    installCmd := fmt.Sprintf(
+        `install.packages("pak", lib="/pak-output", repos=sprintf(`+
+            `"https://r-lib.github.io/p/pak/%s/%%s/%%s/%%s", `+
+            `.Platform$pkgType, R.Version()$os, R.Version()$arch))`,
+        version)
+
+    tmpDir, err := os.MkdirTemp(cachePath, ".pak-install-")
+    if err != nil {
+        return "", fmt.Errorf("create pak temp dir: %w", err)
+    }
+    defer os.RemoveAll(tmpDir)
+
+    spec := backend.BuildSpec{
+        AppID:    "_system",
+        BundleID: "pak-install-" + uuid.New().String()[:8],
+        Image:    image,
+        Cmd:      []string{"R", "--vanilla", "-e", installCmd},
+        Mounts: []backend.MountEntry{
+            {Source: tmpDir, Target: "/pak-output", ReadOnly: false},
+        },
+        Labels: map[string]string{
+            "dev.blockyard/managed": "true",
+            "dev.blockyard/role":    "build",
+        },
+    }
+
+    result, err := be.Build(ctx, spec)
+    if err != nil {
+        return "", fmt.Errorf("install pak: %w", err)
+    }
+    if !result.Success {
+        return "", fmt.Errorf("install pak failed (exit %d): %s",
+            result.ExitCode, lastLines(result.Logs, 10))
+    }
+
+    // Atomically move to final location.
+    if err := os.Rename(tmpDir, pakDir); err != nil {
+        return "", fmt.Errorf("move pak cache: %w", err)
+    }
+    return pakDir, nil
+}
+```
+
+**Cache path:** `{bundle_server_path}/.pak-cache/pak-{version}/`
+
+**Lifecycle:** cached indefinitely per version. Operators can clear the
+cache by deleting the directory and restarting the server.
+
+### Config changes
+
+In `internal/config/config.go`, replace `RvVersion` and `RvBinaryPath`:
+
+```go
+type DockerConfig struct {
+    // ... existing fields ...
+    // RvVersion  string — REMOVED
+    // RvBinaryPath string — REMOVED
+    PakVersion string `toml:"pak_version"` // "stable" (default), "devel", or pinned
+}
+```
+
+Default in `applyDefaults()`:
+
+```go
+if cfg.Docker.PakVersion == "" {
+    cfg.Docker.PakVersion = "stable"
+}
+```
+
+Config file change:
+
+```toml
+[docker]
+# rv_version = "v0.19.0"  — removed
+pak_version = "stable"     # "stable", "devel", or specific version
+```
+
+Env var: `BLOCKYARD_DOCKER_PAK_VERSION`.
+
+---
+
+## Step 2: Build mode detection
+
+When a bundle is uploaded, the server inspects its contents to determine
+the dependency resolution strategy. Checked in priority order:
+
+| Priority | File present | Strategy | pak function |
+|----------|-------------|----------|-------------|
+| 1 | `pkg.lock` | Lockfile restore | `pak::lockfile_install()` |
+| 2 | `DESCRIPTION` | Package deps | `pak::local_install_deps()` |
+| 3 | `app.R` only | Script scanning | `pak::pkg_install(pak::scan_deps()$package)` |
+
+```go
+// internal/bundle/buildmode.go
+
+type BuildMode int
+
+const (
+    BuildModeLockfile    BuildMode = iota // pkg.lock present
+    BuildModeDescription                  // DESCRIPTION present
+    BuildModeScan                         // bare scripts only
+)
+
+func DetectBuildMode(unpackedPath string) BuildMode {
+    if fileExists(filepath.Join(unpackedPath, "pkg.lock")) {
+        return BuildModeLockfile
+    }
+    if fileExists(filepath.Join(unpackedPath, "DESCRIPTION")) {
+        return BuildModeDescription
+    }
+    return BuildModeScan
+}
+```
+
+**Lockfile format:** pak's native `pkg.lock`, created by
+`pak::lockfile_create()`. Users run this locally for reproducible
+deploys. renv.lock is not supported — pak lockfiles are the single
+format.
+
+**DESCRIPTION mode:** standard R package DESCRIPTION file with
+`Imports`, `Depends`, and optionally `Remotes` for GitHub/git deps.
+This is how most R packages declare dependencies and is familiar to
+all R developers.
+
+**Scan mode:** pak scans all `.R` files for `library()`, `require()`,
+`::` calls and resolves + installs the discovered packages. Zero
+config — just upload app.R and deploy.
+
+### Bundle validation changes
+
+In `bundle.ValidateEntrypoint()`, remove the rv.lock requirement.
+Only `app.R` is mandatory:
+
+```go
+func ValidateEntrypoint(paths Paths) error {
+    entrypoint := filepath.Join(paths.Unpacked, "app.R")
+    if _, err := os.Stat(entrypoint); err != nil {
+        return fmt.Errorf("missing entrypoint: app.R")
+    }
+    return nil
+}
+```
+
+### SetLibraryPath removal
+
+Remove `bundle.SetLibraryPath()` which modifies `rproject.toml` to
+set the library path for rv. pak uses the `lib` parameter directly —
+no config file modification needed.
+
+---
+
+## Step 3: BuildSpec extension
+
+Add `Cmd` and `Mounts` fields to `BuildSpec` so the `Build` method
+supports different build commands. This is needed now (rv → pak) and
+will be reused by the package store (phase 2-6).
+
+```go
+// internal/backend/backend.go
+
+type BuildSpec struct {
+    AppID        string
+    BundleID     string
+    Image        string
+    RvBinaryPath string            // DEPRECATED: used only for rv compat
+    BundlePath   string            // used when Mounts is empty (legacy)
+    LibraryPath  string            // used when Mounts is empty (legacy)
+    Labels       map[string]string
+    LogWriter    func(string)
+    Cmd          []string          // overrides default command when set
+    Mounts       []MountEntry      // overrides default mounts when set
+}
+
+type MountEntry struct {
+    Source   string
+    Target   string
+    ReadOnly bool
+}
+```
+
+### Docker backend changes
+
+In `Build()`, use `Cmd` and `Mounts` when set:
+
+```go
+cmd := []string{"/usr/local/bin/rv", "sync"} // legacy default
+if spec.Cmd != nil {
+    cmd = spec.Cmd
+}
+
+var binds []string
+var dockerMounts []mount.Mount
+if len(spec.Mounts) > 0 {
+    for _, m := range spec.Mounts {
+        b, dm := d.mountCfg.TranslateMount(m)
+        binds = append(binds, b...)
+        dockerMounts = append(dockerMounts, dm...)
+    }
+} else {
+    binds, dockerMounts = d.mountCfg.BuildMounts(
+        spec.BundlePath, spec.LibraryPath, spec.RvBinaryPath)
+}
+```
+
+### MountConfig.TranslateMount
+
+```go
+// internal/backend/docker/mounts.go
+
+func (mc MountConfig) TranslateMount(m backend.MountEntry) (
+    binds []string, mounts []mount.Mount,
+) {
+    switch mc.Mode {
+    case MountModeVolume:
+        mounts = append(mounts,
+            mc.volumeMount(m.Target, m.ReadOnly, m.Source))
+    case MountModeBind:
+        flag := ":ro"
+        if !m.ReadOnly {
+            flag = ""
+        }
+        binds = append(binds, mc.toHostPath(m.Source)+":"+m.Target+flag)
+    default: // Native
+        flag := ":ro"
+        if !m.ReadOnly {
+            flag = ""
+        }
+        binds = append(binds, m.Source+":"+m.Target+flag)
+    }
+    return binds, mounts
+}
+```
+
+---
+
+## Step 4: Build container command
+
+The restore flow in `internal/bundle/restore.go` changes from running
+`rv sync` to running an R script that uses pak.
+
+### Build command per mode
+
+```go
+// internal/bundle/restore.go
+
+func buildCommand(mode BuildMode) []string {
+    var rScript string
+    switch mode {
+    case BuildModeLockfile:
+        rScript = `
+            library(pak, lib.loc = "/pak")
+            lockfile_install(
+                lockfile = "/app/pkg.lock",
+                lib = "/build-lib",
+                update = TRUE
+            )`
+    case BuildModeDescription:
+        rScript = `
+            library(pak, lib.loc = "/pak")
+            local_install_deps(
+                root = "/app",
+                lib = "/build-lib",
+                upgrade = FALSE,
+                ask = FALSE
+            )`
+    case BuildModeScan:
+        rScript = `
+            library(pak, lib.loc = "/pak")
+            deps <- scan_deps("/app")
+            pkgs <- unique(deps$package)
+            pkgs <- setdiff(pkgs, rownames(installed.packages(
+                lib.loc = .Library)))
+            if (length(pkgs) > 0) {
+                pkg_install(pkgs, lib = "/build-lib", ask = FALSE)
+            }`
+    }
+    return []string{"R", "--vanilla", "-e", rScript}
+}
+```
+
+### Mount setup
+
+```go
+func buildMounts(pakCachePath, bundlePath, libraryPath string) []backend.MountEntry {
+    return []backend.MountEntry{
+        {Source: bundlePath, Target: "/app", ReadOnly: true},
+        {Source: libraryPath, Target: "/build-lib", ReadOnly: false},
+        {Source: pakCachePath, Target: "/pak", ReadOnly: true},
+    }
+}
+```
+
+pak is mounted read-only at `/pak` and loaded via
+`library(pak, lib.loc = "/pak")`. The app bundle is read-only at
+`/app`. The output library is writable at `/build-lib`.
+
+### Restore flow changes
+
+In `runRestore()`:
+
+```go
+func runRestore(p RestoreParams) error {
+    // 1. Update bundle status to "building".
+    p.DB.UpdateBundleStatus(p.BundleID, "building")
+    p.Sender.Write("restoring dependencies...")
+
+    // 2. Ensure pak is cached.
+    pakPath, err := pakcache.EnsureInstalled(
+        context.Background(), p.Backend,
+        p.Image, p.PakVersion, p.PakCachePath)
+    if err != nil {
+        return fmt.Errorf("ensure pak: %w", err)
+    }
+
+    // 3. Detect build mode.
+    mode := DetectBuildMode(p.Paths.Unpacked)
+    p.Sender.Write(fmt.Sprintf("build mode: %s", mode))
+
+    // 4. Build.
+    spec := backend.BuildSpec{
+        AppID:    p.AppID,
+        BundleID: p.BundleID,
+        Image:    p.Image,
+        Cmd:      buildCommand(mode),
+        Mounts:   buildMounts(pakPath, p.Paths.Unpacked, p.Paths.Library),
+        Labels: map[string]string{
+            "dev.blockyard/managed":   "true",
+            "dev.blockyard/role":      "build",
+            "dev.blockyard/app-id":    p.AppID,
+            "dev.blockyard/bundle-id": p.BundleID,
+        },
+        LogWriter: func(line string) { p.Sender.Write(line) },
+    }
+
+    result, err := p.Backend.Build(context.Background(), spec)
+    if err != nil {
+        return fmt.Errorf("build: %w", err)
+    }
+    if !result.Success {
+        return fmt.Errorf("dependency restore failed (exit %d)", result.ExitCode)
+    }
+
+    // 5. Activate bundle.
+    if err := p.DB.ActivateBundle(p.AppID, p.BundleID); err != nil {
+        return fmt.Errorf("activate bundle: %w", err)
+    }
+
+    // 6. Enforce retention.
+    bundle.EnforceRetention(p.DB, p.BasePath, p.AppID, p.BundleID, p.Retention)
+
+    return nil
+}
+```
+
+### RestoreParams changes
+
+```go
+type RestoreParams struct {
+    Backend      backend.Backend
+    DB           *db.DB
+    Tasks        *task.Store
+    Sender       task.Sender
+    AppID        string
+    BundleID     string
+    Paths        Paths
+    Image        string
+    PakVersion   string  // replaces RvVersion
+    PakCachePath string  // replaces RvBinaryPath
+    Retention    int
+    BasePath     string
+    AuditLog     *audit.Log
+    AuditActor   string
+}
+```
+
+---
+
+## Step 5: Remove rv
+
+Delete or deprecate:
+
+- `internal/rvcache/` — remove entirely (replaced by `pakcache`)
+- `bundle.SetLibraryPath()` — remove (pak uses `lib` parameter)
+- `BuildSpec.RvBinaryPath` — remove after migration
+- `DockerConfig.RvVersion` / `DockerConfig.RvBinaryPath` — remove
+- `MountConfig.BuildMounts()` — keep for now but the new
+  `TranslateMount` path handles pak builds. Remove once all callers
+  use `BuildSpec.Mounts`.
+
+### Example updates
+
+Update `examples/hello-shiny/app/`:
+
+- Remove `rv.lock` and `rproject.toml`
+- Add `DESCRIPTION`:
+
+```
+Package: hello-shiny
+Title: Hello Shiny Example
+Version: 0.1.0
+Imports:
+    shiny
+```
+
+Or for the zero-config experience, leave just `app.R` — pak will
+scan it and discover `library(shiny)`.
+
+---
+
+## Step 6: Tests
+
+### Unit tests
+
+**pakcache:**
+- `TestEnsureInstalled` — first call downloads, second is cache hit.
+- Cache path format verification.
+
+**Build mode detection:**
+- `TestDetectBuildMode_Lockfile` — pkg.lock present → lockfile mode.
+- `TestDetectBuildMode_Description` — DESCRIPTION present → description mode.
+- `TestDetectBuildMode_Scan` — only app.R → scan mode.
+- Priority: pkg.lock wins over DESCRIPTION.
+
+**Build command:**
+- `TestBuildCommand_Lockfile` — verify R script uses `lockfile_install`.
+- `TestBuildCommand_Description` — verify R script uses `local_install_deps`.
+- `TestBuildCommand_Scan` — verify R script uses `scan_deps` + `pkg_install`.
+
+**BuildSpec extension:**
+- Existing Build tests pass unchanged (Cmd is nil, legacy path).
+- `TestBuildWithCmd` — verify Cmd overrides default.
+- `TestBuildWithMounts` — verify explicit Mounts used.
+- `TestTranslateMount` — all three mount modes.
+
+### Integration tests
+
+- Deploy bundle with pkg.lock → restore succeeds, packages installed.
+- Deploy bundle with DESCRIPTION → restore succeeds, packages installed.
+- Deploy bundle with just app.R (library(shiny)) → restore succeeds,
+  shiny installed.
+- Deploy bundle with DESCRIPTION + Remotes field → GitHub package
+  installed.
+- Deploy bundle with invalid DESCRIPTION → meaningful error.
+
+### E2E tests
+
+- Update existing e2e tests to use DESCRIPTION instead of rv.lock.
+- Verify the full deploy → run → access cycle works with pak.
+
+---
+
+## Design Decisions
+
+1. **pak over renv.** pak has a proper constraint solver (via
+   pkgdepends/lpSolve), broader script scanning, lockfile support,
+   and bundles all its dependencies into a single self-contained
+   package. renv lacks a solver and is primarily a project isolation
+   tool, not a dependency resolver.
+
+2. **pak's pre-built bundle, not CRAN pak.** The pre-built binary from
+   `r-lib.github.io/p/pak/` vendors all 16 dependencies (pkgdepends,
+   curl, cli, etc.) into one package. Install is a single download +
+   unpack — same pattern as rv binary caching. The CRAN version of pak
+   (installed by users into their apps) is a separate concern.
+
+3. **Three build modes with clear priority.** Lockfile wins (exact
+   repro), then DESCRIPTION (standard R), then scan (zero config).
+   This covers the spectrum from CI/CD reproducibility to quick
+   prototyping. Users opt into reproducibility by adding a lockfile;
+   they don't need to opt out of it.
+
+4. **No rproject.toml.** This was rv-specific. pak reads standard R
+   files (DESCRIPTION, pkg.lock). No proprietary config format.
+
+5. **pak lockfile format (pkg.lock).** pak's native format, not
+   renv.lock. One tool, one lockfile format. Users generate it with
+   `pak::lockfile_create()`.
+
+6. **Server-side pak cache, not in the pkg-store.** pak-the-build-tool
+   is internal infrastructure, cached alongside server binaries. If a
+   user's app depends on pak as an R package, that's a separate CRAN
+   install that goes through the normal dependency path.

--- a/docs/design/v2/phase-2-6.md
+++ b/docs/design/v2/phase-2-6.md
@@ -1,0 +1,622 @@
+# Phase 2-6: Package Store and Runtime Assembly
+
+A server-level content-addressable package store that is populated
+during builds and consumed at runtime. Every dependency restore adds
+packages to the store. Workers assemble their libraries from store
+entries via hard links — near-instant, zero additional disk usage.
+An API endpoint allows requesting packages from the store for running
+workers (e.g., during blockr board restore).
+
+Depends on phase 2-5 (pak-based build pipeline).
+
+## Deliverables
+
+1. **Package store** (`internal/pkgstore/store.go`) — content-
+   addressable directory keyed by `{package}/{version}-{source}`.
+   Populated during builds. Append-only.
+2. **Build integration** — after a successful dependency restore,
+   catalog all installed packages into the store.
+3. **Per-worker library views** (`internal/pkgstore/view.go`) — flat
+   directories populated with hard links from the store. Mounted
+   read-only at `/extra-lib/` in worker containers.
+4. **Worker lifecycle integration** — create view directories on spawn,
+   mount them, clean up on eviction.
+5. **Runtime assembly API** — `POST /api/v1/packages` endpoint that
+   hard-links packages from the store into a running worker's view.
+6. **Worker authentication** — HMAC-based worker tokens for
+   in-container API access.
+
+---
+
+## Step 1: Package store
+
+New package: `internal/pkgstore/`.
+
+### Directory layout
+
+```
+{bundle_server_path}/.pkg-store/
+├── ggplot2/
+│   └── 3.5.0-cran/           ← installed R package tree
+├── shiny/
+│   └── 1.13.0-cran/
+├── blockr.ggplot/
+│   ├── 0.2.0-cran/
+│   └── 0.2.1-github/
+└── ...
+```
+
+Keyed by `{package}/{version}-{source}`. Multiple versions and sources
+coexist. Append-only — packages are never modified after installation.
+
+The R major.minor version is NOT part of the key. The store lives under
+a server that runs a single R version (configured via `[docker] image`).
+When the image changes, the operator clears the store
+(`rm -rf .pkg-store/`) — same as clearing any package cache after an
+R upgrade. This keeps store keys simple and avoids a startup-time R
+version detection container.
+
+### Store struct
+
+```go
+// internal/pkgstore/store.go
+
+type Store struct {
+    basePath string // {bundle_server_path}/.pkg-store
+}
+
+func NewStore(basePath string) *Store {
+    return &Store{basePath: basePath}
+}
+
+func storeKey(pkg, version, source string) string {
+    return filepath.Join(pkg, version+"-"+source)
+}
+
+func (s *Store) Path(pkg, version, source string) string {
+    return filepath.Join(s.basePath, storeKey(pkg, version, source))
+}
+
+func (s *Store) Has(pkg, version, source string) bool {
+    _, err := os.Stat(s.Path(pkg, version, source))
+    return err == nil
+}
+```
+
+### DESCRIPTION parser
+
+```go
+// internal/pkgstore/description.go
+
+type PkgInfo struct {
+    Name       string
+    Version    string
+    Source     string // "cran", "github", etc.; derived from RemoteType or defaulted
+}
+
+func ReadPkgInfo(pkgDir string) (PkgInfo, error) {
+    data, err := os.ReadFile(filepath.Join(pkgDir, "DESCRIPTION"))
+    if err != nil {
+        return PkgInfo{}, err
+    }
+    var info PkgInfo
+    for _, line := range strings.Split(string(data), "\n") {
+        switch {
+        case strings.HasPrefix(line, "Package:"):
+            info.Name = strings.TrimSpace(line[len("Package:"):])
+        case strings.HasPrefix(line, "Version:"):
+            info.Version = strings.TrimSpace(line[len("Version:"):])
+        case strings.HasPrefix(line, "RemoteType:"):
+            info.Source = strings.TrimSpace(line[len("RemoteType:"):])
+        }
+    }
+    if info.Name == "" || info.Version == "" {
+        return PkgInfo{}, fmt.Errorf("invalid DESCRIPTION in %s", pkgDir)
+    }
+    if info.Source == "" {
+        info.Source = "cran"
+    }
+    return info, nil
+}
+```
+
+### Ingest — add packages to the store
+
+```go
+// Ingest catalogs all R packages in a library directory and moves
+// new ones into the store. Returns the list of all packages found.
+// Existing store entries are skipped (not overwritten).
+func (s *Store) Ingest(libraryPath string) ([]PkgInfo, error) {
+    entries, err := os.ReadDir(libraryPath)
+    if err != nil {
+        return nil, fmt.Errorf("read library: %w", err)
+    }
+
+    var pkgs []PkgInfo
+    for _, entry := range entries {
+        if !entry.IsDir() {
+            continue
+        }
+        info, err := ReadPkgInfo(filepath.Join(libraryPath, entry.Name()))
+        if err != nil {
+            slog.Debug("pkgstore: skipping non-package dir",
+                "name", entry.Name(), "error", err)
+            continue
+        }
+
+        storePath := s.Path(info.Name, info.Version, info.Source)
+        if !dirExists(storePath) {
+            if err := os.MkdirAll(filepath.Dir(storePath), 0o755); err != nil {
+                return nil, fmt.Errorf("create store dir: %w", err)
+            }
+            // cp -al: hard-link the package tree into the store.
+            // The source (library) is kept intact for the current bundle.
+            out, cpErr := exec.Command(
+                "cp", "-al",
+                filepath.Join(libraryPath, entry.Name()),
+                storePath,
+            ).CombinedOutput()
+            if cpErr != nil {
+                slog.Warn("pkgstore: ingest failed",
+                    "package", info.Name, "error", string(out))
+                continue
+            }
+        }
+
+        pkgs = append(pkgs, info)
+    }
+    return pkgs, nil
+}
+```
+
+`cp -al` hard-links the package directory tree into the store. Both
+the original library (used by the current bundle) and the store entry
+point to the same inodes. Zero additional disk usage.
+
+---
+
+## Step 2: Build integration
+
+After a successful dependency restore, ingest the restored library
+into the store.
+
+In `internal/bundle/restore.go`, after `ActivateBundle`:
+
+```go
+// Populate package store.
+if p.PkgStore != nil {
+    pkgs, err := p.PkgStore.Ingest(p.Paths.Library)
+    if err != nil {
+        slog.Warn("pkgstore: ingest failed", "error", err)
+        // Non-fatal — the bundle is still usable.
+    } else {
+        slog.Info("pkgstore: ingested packages",
+            "count", len(pkgs), "bundle_id", p.BundleID)
+    }
+}
+```
+
+**RestoreParams** gains a `PkgStore *pkgstore.Store` field.
+
+Every deploy populates the store. Over time, the store accumulates
+packages from all apps. When a worker needs a package that any prior
+build installed, it's a store hit — hard-link, instant.
+
+---
+
+## Step 3: Per-worker library views
+
+```go
+// internal/pkgstore/view.go
+
+type View struct {
+    basePath string // {bundle_server_path}/.worker-libs
+}
+
+func NewView(basePath string) *View {
+    return &View{basePath: basePath}
+}
+
+func (v *View) BasePath() string { return v.basePath }
+
+func (v *View) Dir(workerID string) string {
+    return filepath.Join(v.basePath, workerID)
+}
+
+func (v *View) Create(workerID string) error {
+    return os.MkdirAll(v.Dir(workerID), 0o755)
+}
+
+// Link hard-links a package from the store into a worker's view.
+func (v *View) Link(workerID, pkgName, storePath string) error {
+    viewPkgPath := filepath.Join(v.Dir(workerID), pkgName)
+    if dirExists(viewPkgPath) {
+        return nil // already linked
+    }
+    out, err := exec.Command("cp", "-al", storePath, viewPkgPath).
+        CombinedOutput()
+    if err != nil {
+        return fmt.Errorf("hard-link %s: %s: %w", pkgName, out, err)
+    }
+    return nil
+}
+
+func (v *View) Cleanup(workerID string) error {
+    dir := v.Dir(workerID)
+    if _, err := os.Stat(dir); os.IsNotExist(err) {
+        return nil
+    }
+    return os.RemoveAll(dir)
+}
+```
+
+**Same-filesystem constraint:** hard links require source and target
+on the same filesystem. Both store and views live under
+`bundle_server_path`, naturally satisfied in all mount modes.
+
+**Mount propagation:** when packages are linked into a running
+worker's view on the host side, they appear inside the container
+immediately — bind mounts share the underlying filesystem. The `ro`
+flag only prevents writes from inside the container.
+
+---
+
+## Step 4: Worker lifecycle integration
+
+### WorkerSpec changes
+
+```go
+// internal/backend/backend.go
+
+type WorkerSpec struct {
+    // ... existing fields ...
+    ExtraLibPath string // server-side path to extra-lib view dir; empty if unused
+}
+```
+
+### WorkerMounts
+
+Extend `WorkerMounts` to include the extra-lib mount when set:
+
+```go
+func (mc MountConfig) WorkerMounts(
+    bundlePath, libraryPath, workerMount, extraLibPath string,
+) (binds []string, mounts []mount.Mount) {
+    // ... existing bundle + library mount logic ...
+
+    if extraLibPath != "" {
+        // same translation logic as other mounts (Volume/Bind/Native)
+    }
+    return binds, mounts
+}
+```
+
+### R_LIBS
+
+Update `R_LIBS` in `createWorkerContainer` to search `/extra-lib`
+first:
+
+```go
+"R_LIBS=/extra-lib:/blockyard-lib"
+```
+
+When `/extra-lib` is empty, R silently ignores it. Live-installed
+packages shadow the base library because `/extra-lib` comes first.
+
+### Spawn integration
+
+In `spawnWorker()`, create the view directory and pass the path:
+
+```go
+var extraLibPath string
+if srv.PkgView != nil {
+    if err := srv.PkgView.Create(wid); err != nil {
+        return "", "", fmt.Errorf("create pkg view: %w", err)
+    }
+    extraLibPath = srv.PkgView.Dir(wid)
+}
+
+spec := backend.WorkerSpec{
+    // ... existing fields ...
+    ExtraLibPath: extraLibPath,
+}
+```
+
+### Eviction cleanup
+
+In `EvictWorker()`, clean up the view after the container stops:
+
+```go
+if srv.PkgView != nil {
+    if err := srv.PkgView.Cleanup(workerID); err != nil {
+        slog.Warn("evict: failed to clean pkg view",
+            "worker_id", workerID, "error", err)
+    }
+}
+```
+
+### Server struct
+
+```go
+type Server struct {
+    // ... existing fields ...
+    PkgStore *pkgstore.Store // nil when not available
+    PkgView  *pkgstore.View // nil when not available
+}
+```
+
+### Startup cleanup
+
+Remove orphaned view directories from previous runs:
+
+```go
+if srv.PkgView != nil {
+    entries, _ := os.ReadDir(srv.PkgView.BasePath())
+    for _, e := range entries {
+        if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+            continue
+        }
+        if _, found := srv.Workers.Get(e.Name()); !found {
+            os.RemoveAll(filepath.Join(srv.PkgView.BasePath(), e.Name()))
+        }
+    }
+}
+```
+
+---
+
+## Step 5: Runtime assembly API
+
+### Endpoint
+
+```
+POST /api/v1/packages
+{
+    "worker_id": "...",
+    "packages": [
+        { "name": "ggplot2", "version": "3.5.0", "source": "cran" },
+        { "name": "blockr.ggplot" }
+    ]
+}
+→ 200 { "installed": [...], "missing": [...] }
+→ 400 invalid request
+→ 404 worker not found
+→ 501 package store not enabled
+```
+
+The endpoint looks up each requested package in the store. Packages
+found in the store are hard-linked into the worker's view (instant).
+Packages not found are returned in a `missing` list — the caller
+decides what to do (deploy an app that includes them, or accept the
+gap).
+
+```go
+// internal/api/packages.go
+
+func InstallPackages(srv *server.Server) http.HandlerFunc {
+    return func(w http.ResponseWriter, r *http.Request) {
+        if srv.PkgStore == nil {
+            http.Error(w, "package store not enabled",
+                http.StatusNotImplemented)
+            return
+        }
+
+        var body installPackagesRequest
+        if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+            badRequest(w, "invalid JSON body")
+            return
+        }
+        // ... validate worker_id, packages, auth ...
+
+        worker, found := srv.Workers.Get(body.WorkerID)
+        if !found {
+            notFound(w, "worker not found")
+            return
+        }
+
+        var installed, missing []pkgResult
+        for _, pkg := range body.Packages {
+            source := pkg.Source
+            if source == "" {
+                source = "cran"
+            }
+
+            if pkg.Version != "" && srv.PkgStore.Has(pkg.Name, pkg.Version, source) {
+                storePath := srv.PkgStore.Path(pkg.Name, pkg.Version, source)
+                if err := srv.PkgView.Link(
+                    body.WorkerID, pkg.Name, storePath,
+                ); err != nil {
+                    serverError(w, fmt.Sprintf("link %s: %s", pkg.Name, err))
+                    return
+                }
+                installed = append(installed, pkgResult{
+                    Name: pkg.Name, Version: pkg.Version, Source: source,
+                })
+            } else {
+                // Version not specified or not in store — try to find
+                // any version of this package.
+                if found := srv.PkgStore.FindLatest(pkg.Name, source); found != nil {
+                    if err := srv.PkgView.Link(
+                        body.WorkerID, pkg.Name, found.Path,
+                    ); err != nil {
+                        serverError(w, fmt.Sprintf("link %s: %s", pkg.Name, err))
+                        return
+                    }
+                    installed = append(installed, pkgResult{
+                        Name: found.Name, Version: found.Version, Source: found.Source,
+                    })
+                } else {
+                    missing = append(missing, pkgResult{
+                        Name: pkg.Name, Version: pkg.Version, Source: source,
+                    })
+                }
+            }
+        }
+
+        w.Header().Set("Content-Type", "application/json")
+        json.NewEncoder(w).Encode(installPackagesResponse{
+            Installed: installed,
+            Missing:   missing,
+        })
+    }
+}
+```
+
+### FindLatest
+
+```go
+// FindLatest returns the newest version of a package in the store,
+// or nil if not found. Uses directory modification time as a proxy
+// for recency.
+func (s *Store) FindLatest(pkg, source string) *PkgInfo {
+    pkgDir := filepath.Join(s.basePath, pkg)
+    entries, err := os.ReadDir(pkgDir)
+    if err != nil {
+        return nil
+    }
+    suffix := "-" + source
+    var best *PkgInfo
+    var bestTime time.Time
+    for _, e := range entries {
+        if !e.IsDir() || !strings.HasSuffix(e.Name(), suffix) {
+            continue
+        }
+        info, err := e.Info()
+        if err != nil {
+            continue
+        }
+        if best == nil || info.ModTime().After(bestTime) {
+            version := strings.TrimSuffix(e.Name(), suffix)
+            best = &PkgInfo{Name: pkg, Version: version, Source: source}
+            best.Path = filepath.Join(pkgDir, e.Name())
+            bestTime = info.ModTime()
+        }
+    }
+    return best
+}
+```
+
+### Route registration
+
+```go
+r.Post("/packages", InstallPackages(srv))
+```
+
+---
+
+## Step 6: Worker authentication
+
+The R app inside a worker needs to call the package assembly API.
+HMAC-based worker tokens provide lightweight, stateless auth for
+in-container callers.
+
+```go
+// internal/auth/workertoken.go
+
+func WorkerToken(sessionSecret []byte, workerID string) string {
+    mac := hmac.New(sha256.New, sessionSecret)
+    mac.Write([]byte("blockyard-worker:" + workerID))
+    return hex.EncodeToString(mac.Sum(nil))
+}
+
+func ValidateWorkerToken(sessionSecret []byte, workerID, token string) bool {
+    expected := WorkerToken(sessionSecret, workerID)
+    return hmac.Equal([]byte(expected), []byte(token))
+}
+```
+
+Injected at spawn time as `BLOCKYARD_WORKER_TOKEN` and
+`BLOCKYARD_WORKER_ID` environment variables. The API accepts either
+standard auth (session cookie / PAT) or
+`Authorization: Worker <id>:<token>`.
+
+R side:
+
+```r
+worker_id <- Sys.getenv("BLOCKYARD_WORKER_ID")
+token     <- Sys.getenv("BLOCKYARD_WORKER_TOKEN")
+api_url   <- Sys.getenv("BLOCKYARD_API_URL")
+
+resp <- httr::POST(
+    paste0(api_url, "/api/v1/packages"),
+    body = list(worker_id = worker_id,
+                packages = list(list(name = "ggplot2"))),
+    encode = "json",
+    httr::add_headers(
+        Authorization = paste0("Worker ", worker_id, ":", token)))
+
+# resp$missing tells the app which packages aren't available.
+```
+
+---
+
+## Step 7: Tests
+
+### Unit tests
+
+**Package store:**
+- `TestStoreKey` — format: `{name}/{version}-{source}`.
+- `TestStoreHas` — empty store → false; create entry → true.
+- `TestIngest` — create temp library with mock packages, ingest,
+  verify store entries created with correct hard links.
+- `TestIngestIdempotent` — ingest same library twice, second is no-op.
+- `TestFindLatest` — multiple versions, returns most recent.
+- `TestReadPkgInfo` — valid and invalid DESCRIPTION files.
+
+**Views:**
+- `TestViewCreate`, `TestViewLink`, `TestViewCleanup`,
+  `TestViewLinkIdempotent` — same as before.
+
+**Worker token:**
+- `TestWorkerToken`, `TestWorkerTokenWrongSecret`,
+  `TestWorkerTokenWrongWorkerID`.
+
+### Integration tests
+
+- Deploy app → verify packages ingested into store.
+- Deploy second app with overlapping deps → verify no duplicate store
+  entries (hard links to same inodes).
+- POST /api/v1/packages for a package in the store → 200, installed.
+- POST for a package not in the store → 200, missing list populated.
+- POST for non-existent worker → 404.
+- Worker token auth works; wrong token → rejected.
+
+---
+
+## Design Decisions
+
+1. **Builds populate the store; runtime consumes it.** The store is
+   filled during dependency restore — a process that already takes
+   seconds to minutes. Adding store ingestion is near-free (hard links
+   take milliseconds). Runtime assembly is always instant (hard-link
+   from store to view). No build containers at runtime.
+
+2. **Store misses return `missing`, not errors.** The API reports which
+   packages weren't found rather than failing. The caller (R app)
+   decides how to handle gaps — degrade gracefully, show a message, or
+   request a redeploy. This keeps the runtime path non-blocking.
+
+3. **No R version in store key.** The server runs a single R version.
+   On R upgrades, clear the store. This avoids startup-time R version
+   detection and keeps keys simple.
+
+4. **`cp -al` for both ingest and view linking.** Hard links give zero
+   disk overhead and instant creation. The same-filesystem constraint
+   is naturally satisfied (everything under `bundle_server_path`).
+
+5. **No package cleanup/GC in v2.** Append-only. At ~10–50 MB per
+   package, hundreds of packages use only a few GB. Store cleanup
+   (LRU eviction, size limits) is a v3 concern.
+
+6. **`R_LIBS` always includes `/extra-lib`.** Even without the package
+   store enabled, R silently ignores non-existent paths. No
+   conditional logic needed.
+
+## Open Questions
+
+1. **Store miss at runtime — future options.** v2 returns missing
+   packages to the caller. Future phases could add: (a) worker-side
+   `install.packages()` into a rw extra-lib mount for immediate
+   fallback, (b) async background build that populates the store, or
+   (c) a "pre-populate store" admin API. The right answer depends on
+   real-world usage patterns.

--- a/docs/design/v2/plan.md
+++ b/docs/design/v2/plan.md
@@ -11,7 +11,8 @@ and adds usability improvements, safety nets, and blockr-specific features:
 dual-database support (SQLite + PostgreSQL), bundle rollback, soft-delete,
 resource limit enforcement, scale-to-zero with pre-warming, a cold-start
 loading page, board storage (PostgreSQL + PostgREST + vault Identity OIDC),
-runtime package installation, web UI expansion, and a CLI tool.
+build pipeline modernization (rv → pak), a content-addressable package
+store, web UI expansion, and a CLI tool.
 
 ## New Packages
 
@@ -525,155 +526,60 @@ Tags:    PATCH  /boards?owner_sub=eq.{sub}&board_id=eq.{id}
                                  { tags: ["analysis", "demo"] }
 ```
 
-### Phase 2-5: Runtime Package Installation
+### Phase 2-5: Build Pipeline — rv → pak
 
-The most complex feature in v2. Allows users to install additional R
-packages during a live session. The design separates three concerns: a
-server-level package store, per-worker library views, and an API that
-blockr calls to request packages.
+Replace rv with pak as the build-time dependency manager. Make lockfiles
+optional. Support three build modes depending on what the bundle ships:
+lockfile (`pkg.lock` → `pak::lockfile_install()`), DESCRIPTION
+(`pak::local_install_deps()`), or bare scripts (`pak::scan_deps()` +
+`pak::pkg_install()`). This simplifies the deployment workflow and
+aligns blockyard with the standard R ecosystem.
 
 **Deliverables:**
 
-1. **Package store** (`internal/pkgstore/store.go`) — a
-   content-addressable directory on the host:
+1. **pak cache** — download and cache pak's pre-built bundle on the
+   server, replacing the rv binary cache (`internal/pakcache/`). pak
+   vendors all 16 of its dependencies into a single self-contained
+   package — one download, instant install.
+2. **Build mode detection** — inspect bundle contents to select the
+   resolution strategy: lockfile > DESCRIPTION > script scan.
+3. **Build container command** — R script that loads pak (mounted
+   read-only) and runs the appropriate strategy.
+4. **BuildSpec extension** — add `Cmd` and `Mounts` fields to
+   `BuildSpec` so the `Build` method supports flexible commands.
+5. **Config changes** — replace `rv_version` with `pak_version`.
+6. **Bundle validation** — relax lockfile requirement; only `app.R`
+   is mandatory.
+7. **Remove rv** — delete `internal/rvcache/`, `SetLibraryPath()`,
+   `RvBinaryPath`, update examples.
 
-   ```
-   {bundle_server_path}/.pkg-store/
-   ├── ggplot2/
-   │   ├── 3.4.0-cran/          ← installed R package tree
-   │   └── 3.5.0-cran/
-   ├── blockr.ggplot/
-   │   ├── 0.2.0-cran/
-   │   └── 0.2.1-gh-blockr/     ← same version, different source
-   └── ...
-   ```
+### Phase 2-6: Package Store and Runtime Assembly
 
-   Keyed by `{package}/{version}-{source}`. Multiple versions and
-   sources coexist. Append-only — packages are never modified after
-   installation. The store key includes the R major.minor version to
-   handle R upgrades (e.g., `ggplot2/3.5.0-cran-R4.4/`).
+A server-level content-addressable package store populated during
+builds and consumed at runtime. Every dependency restore catalogs its
+installed packages into the store. Workers assemble additional packages
+from store entries via hard links — near-instant, zero disk overhead.
 
-   ```go
-   type Store struct {
-       basePath   string    // {bundle_server_path}/.pkg-store
-       rVersion   string    // e.g. "4.4" — from the configured image
-       mu         sync.Mutex
-       installing map[string]chan struct{} // dedup concurrent installs
-   }
+**Deliverables:**
 
-   // Has checks if a package version exists in the store.
-   func (s *Store) Has(pkg, version, source string) bool
+1. **Package store** (`internal/pkgstore/store.go`) — content-
+   addressable directory keyed by `{package}/{version}-{source}`.
+   Populated during builds via `Store.Ingest()`. Append-only.
+2. **Build integration** — after a successful restore, hard-link all
+   installed packages into the store.
+3. **Per-worker library views** (`internal/pkgstore/view.go`) — flat
+   directories populated with hard links from the store. Mounted
+   read-only at `/extra-lib/` in worker containers.
+4. **Worker lifecycle integration** — create view directories on spawn,
+   mount them, clean up on eviction.
+5. **Runtime assembly API** — `POST /api/v1/packages` endpoint that
+   hard-links packages from the store into a running worker's view.
+   Store hits are instant. Store misses are reported to the caller
+   (no build containers at runtime).
+6. **Worker authentication** — HMAC-based worker tokens for
+   in-container API access.
 
-   // Install runs a build container to install a package into the store.
-   // Blocks until complete. Concurrent requests for the same package
-   // coalesce — only one build runs; others wait on the channel.
-   func (s *Store) Install(ctx context.Context, backend backend.Backend,
-       req InstallRequest) error
-
-   // Path returns the store path for a package entry.
-   func (s *Store) Path(pkg, version, source string) string
-   ```
-
-2. **Per-worker library views** (`internal/pkgstore/view.go`) — flat
-   directories populated with hard links into the store:
-
-   ```
-   {bundle_server_path}/.worker-libs/{worker-id}/
-   ├── ggplot2/     ← hard-linked from .pkg-store/ggplot2/3.5.0-cran-R4.4/
-   ├── blockr.ggplot/
-   └── ...
-   ```
-
-   Mounted read-only at `/extra-lib/` in the worker container.
-   R's `.libPaths()` is set to `c("/extra-lib/", "/blockyard-lib")` —
-   live-installed packages shadow the base library.
-
-   ```go
-   type View struct {
-       basePath string // {bundle_server_path}/.worker-libs
-   }
-
-   // Create creates a view directory for a worker.
-   func (v *View) Create(workerID string) error
-
-   // Link hard-links a package from the store into a worker's view.
-   func (v *View) Link(workerID string, storePath string) error
-
-   // Cleanup removes a worker's view directory.
-   func (v *View) Cleanup(workerID string) error
-   ```
-
-   Hard links (`cp -al`) give zero additional disk usage. Creating a
-   linked tree takes milliseconds. Cleanup is `rm -rf` on the view
-   directory — the store is unaffected.
-
-3. **Package install API** — new endpoint:
-
-   ```
-   POST /api/v1/packages
-   {
-       "worker_id": "...",
-       "packages": [
-           { "name": "blockr.ggplot" },
-           { "name": "ggplot2", "version": "3.5.0", "source": "cran" }
-       ]
-   }
-   ```
-
-   Flow:
-
-   ```
-   1. Validate worker exists and caller has access to the app
-   2. For each package:
-      a. Check store — if present, skip to step (d)
-      b. Spawn build container: same base image, mounts store rw,
-         runs pak::pkg_install() with the store as the library
-      c. Record installed package in store index
-      d. Hard-link from store into the worker's view
-   3. Return 200 with list of installed packages
-   ```
-
-   Build containers carry the same isolation as workers: cap-drop ALL,
-   no-new-privileges, isolated network. The store is mounted read-write
-   (the only writable mount). The existing base R library is mounted
-   read-only as an additional lib path so `pak` sees already-installed
-   dependencies and only installs the delta.
-
-   Open installs — no allowlist, no source restrictions. The threat
-   model is unchanged from the worker containers themselves.
-
-4. **Worker lifecycle integration** — on `Spawn`, create a view
-   directory and mount it. On `evictWorker`, clean up the view. The
-   view directory is created alongside the existing bundle and library
-   mounts.
-
-5. **Board restore integration** — when a board is loaded, blockr
-   records its dependency set (package names, versions, sources) in
-   the board metadata. On restore, blockr checks which packages are
-   available and requests missing ones via the API. Since packages
-   likely exist in the store from prior sessions, this is a
-   hard-link operation — near-instant.
-
-**Build container for package installation:**
-
-```go
-type PkgBuildSpec struct {
-    Image         string            // same base R image
-    StorePath     string            // host path to .pkg-store (rw mount)
-    BaseLibPath   string            // host path to bundle's rv library (ro mount)
-    Package       string            // e.g. "blockr.ggplot"
-    Version       string            // optional; empty = latest
-    Source        string            // "cran", "gh-blockr", etc.
-    Labels        map[string]string
-}
-```
-
-The build command runs `pak::pkg_install()` targeting a package-specific
-output directory within the store. Transitive dependencies that already
-exist in the store or base library are reused — `pak` sees them via the
-read-only library mount.
-
-### Phase 2-6: Web UI Expansion
+### Phase 2-7: Web UI Expansion
 
 Extends the v1 dashboard with per-app management and operational
 visibility. Server-rendered HTML, no JavaScript framework.
@@ -707,7 +613,7 @@ visibility. Server-rendered HTML, no JavaScript framework.
 
 No new navigation chrome (navbar, app switcher) — deferred to v3.
 
-### Phase 2-7: CLI Tool
+### Phase 2-8: CLI Tool
 
 A dedicated Go binary (`cmd/by/`) for interacting with the server via
 the REST API. Built last to target the stable, final v2 API surface.
@@ -753,31 +659,35 @@ Phase 2-1: Database Dual-Backend Foundation
 
 Phase 2-2: Quick Wins (Rollback, Soft-Delete, Resource Limits)
   └── depends on: phase 2-1 (migrations)
-  └── independent of: phases 2-3 through 2-7
+  └── independent of: phases 2-3 through 2-6
 
 Phase 2-3: Worker Lifecycle (Scale-to-Zero, Pre-Warming, Loading Page)
   └── depends on: phase 2-1 (pre_warmed_seats column)
-  └── independent of: phases 2-4, 2-5
+  └── independent of: phases 2-4 through 2-6
 
 Phase 2-4: Board Storage
   └── depends on: phase 2-1 (PostgreSQL support)
-  └── independent of: phases 2-3, 2-5
+  └── independent of: phases 2-3, 2-5, 2-6
 
-Phase 2-5: Runtime Package Installation
-  └── depends on: phase 2-1 (migrations for any new tables)
+Phase 2-5: Build Pipeline (rv → pak)
+  └── independent of: phases 2-2 through 2-4
+  └── can be developed in parallel with everything after 2-1
+
+Phase 2-6: Package Store and Runtime Assembly
+  └── depends on: phase 2-5 (pak-based builds populate the store)
   └── independent of: phases 2-3, 2-4
 
-Phase 2-6: Web UI Expansion
+Phase 2-7: Web UI Expansion
   └── depends on: phases 2-2 (rollback, soft-delete UI),
       2-3 (pre-warming config), 2-4 (board storage optional)
 
-Phase 2-7: CLI Tool
-  └── depends on: all API-changing phases (2-2 through 2-5)
+Phase 2-8: CLI Tool
+  └── depends on: all API-changing phases (2-2 through 2-6)
   └── built last to target final API surface
 ```
 
 Phases 2-3, 2-4, and 2-5 are independent of each other and can be
-developed in parallel after the foundation.
+developed in parallel after the foundation. Phase 2-6 requires 2-5.
 
 ## Test Strategy
 


### PR DESCRIPTION
## Summary
- **Phase 2-5** rewritten: replace rv with pak as the build-time dependency manager. Three build modes (lockfile / DESCRIPTION / script scan) make lockfiles optional.
- **Phase 2-6** added: content-addressable package store populated during builds, consumed at runtime via hard-linked worker views. No build containers at runtime — store hits are instant.
- Old phases 2-6 (Web UI) and 2-7 (CLI) renumbered to 2-7 and 2-8. Roadmap and plan dependency graph updated.

## Test plan
- [ ] Design review
- [ ] No code changes — docs only