### PR TITLE
Fix flaky TestMetricsBundleUploaded restore race

### DIFF
--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -73,9 +74,14 @@ func testProxyServer(t *testing.T) (*server.Server, *httptest.Server) {
 
 	be := mock.New()
 	srv := server.NewServer(cfg, be, database)
+	// Track background restore goroutines so cleanup waits for them.
+	var wg sync.WaitGroup
+	srv.RestoreWG = &wg
 	handler := api.NewRouter(srv)
 	ts := httptest.NewServer(handler)
 	t.Cleanup(ts.Close)
+	// Wait for restore goroutines before DB/TempDir cleanup (LIFO order).
+	t.Cleanup(wg.Wait)
 
 	return srv, ts
 }


### PR DESCRIPTION
## Summary
- Proxy integration tests did not wait for background bundle-restore goroutines before `t.TempDir()` cleanup, causing intermittent `directory not empty` failures
- Wire `srv.RestoreWG` + `t.Cleanup(wg.Wait)` in `testProxyServer`, mirroring the pattern already used in `api/api_test.go`

## Test plan
- [ ] `go test -tags docker_test -run TestMetricsBundleUploaded -count=5 ./internal/proxy/` passes consistently
- [ ] CI green