### PR TITLE
Build multi-arch :main image, switch examples from :latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,19 @@ on:
   push:
     branches: [main]
 
+env:
+  IMAGE: ghcr.io/cynkra/blockyard
+
 jobs:
-  publish-latest:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            platform: linux/amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
     permissions:
       packages: write
     steps:
@@ -17,9 +27,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/setup-buildx-action@v4
+      - id: slug
+        run: echo "platform=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
       - uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/server.Dockerfile
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.IMAGE }}:build-${{ steps.slug.outputs.platform }}
           push: true
-          tags: ghcr.io/cynkra/blockyard:main
+
+  manifest:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create -t "${{ env.IMAGE }}:main" \
+            "${{ env.IMAGE }}:build-linux-amd64" \
+            "${{ env.IMAGE }}:build-linux-arm64"

--- a/examples/hello-pocketbase/docker-compose.yml
+++ b/examples/hello-pocketbase/docker-compose.yml
@@ -78,7 +78,7 @@ services:
 
   # --- Blockyard: Shiny app hosting platform ---
   blockyard:
-    image: ghcr.io/cynkra/blockyard:latest
+    image: ghcr.io/cynkra/blockyard:main
     depends_on:
       init:
         condition: service_completed_successfully

--- a/examples/hello-postgrest/docker-compose.yml
+++ b/examples/hello-postgrest/docker-compose.yml
@@ -106,7 +106,7 @@ services:
 
   # --- Blockyard: Shiny app hosting platform ---
   blockyard:
-    image: ghcr.io/cynkra/blockyard:latest
+    image: ghcr.io/cynkra/blockyard:main
     depends_on:
       init:
         condition: service_completed_successfully

--- a/examples/hello-shiny/docker-compose.yml
+++ b/examples/hello-shiny/docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
   # --- Blockyard: Shiny app hosting platform ---
   blockyard:
-    image: ghcr.io/cynkra/blockyard:latest
+    image: ghcr.io/cynkra/blockyard:main
     depends_on:
       dex:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Publish workflow now builds amd64 + arm64 and creates a multi-arch manifest for `:main`, matching the release workflow pattern
- All example docker-compose files switched from `:latest` to `:main` so they track current main
- `:latest` stays reserved for tagged releases only

## Test plan
- [ ] CI green
- [ ] Publish workflow syntax validates (matrix + manifest job)