### PR TITLE
ci: harden workflows — pin versions, add timeouts, tighten permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ on:
           - pak
           - ui
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -28,7 +31,8 @@ concurrency:
 jobs:
   unit:
     if: github.event_name != 'merge_group' && (inputs.job == '' || inputs.job == 'unit')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     services:
       postgres:
         image: postgres:17
@@ -70,9 +74,11 @@ jobs:
         with:
           name: coverage-unit
           path: coverage-unit.out
+          retention-days: 1
 
   cli:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     needs: [unit]
     if: github.event_name != 'merge_group' && github.event_name != 'push' && (inputs.job == '' || inputs.job == 'cli')
     steps:
@@ -89,9 +95,11 @@ jobs:
         with:
           name: coverage-cli
           path: coverage-cli.out
+          retention-days: 1
 
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     needs: [unit]
     if: github.event_name != 'merge_group' && github.event_name != 'push' && (inputs.job == '' || inputs.job == 'docker')
     steps:
@@ -103,15 +111,17 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - run: docker pull alpine:latest
+      - run: docker pull alpine:3.21
       - run: sudo GOCACHE=$(go env GOCACHE) GOMODCACHE=$(go env GOMODCACHE) go test -tags docker_test -coverprofile=coverage-docker.out -coverpkg=./internal/... ./internal/backend/docker/... ./internal/proxy/...
       - uses: actions/upload-artifact@v7
         with:
           name: coverage-docker
           path: coverage-docker.out
+          retention-days: 1
 
   pak:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     needs: [unit]
     if: github.event_name != 'merge_group' && github.event_name != 'push' && (inputs.job == '' || inputs.job == 'pak')
     steps:
@@ -129,9 +139,11 @@ jobs:
         with:
           name: coverage-pak
           path: coverage-pak.out
+          retention-days: 1
 
   idp:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     needs: [unit]
     if: github.event_name != 'merge_group' && github.event_name != 'push' && (inputs.job == '' || inputs.job == 'idp')
     steps:
@@ -145,9 +157,11 @@ jobs:
         with:
           name: coverage-idp
           path: coverage-idp.out
+          retention-days: 1
 
   openbao:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     needs: [unit]
     if: github.event_name != 'merge_group' && github.event_name != 'push' && (inputs.job == '' || inputs.job == 'openbao')
     steps:
@@ -155,15 +169,17 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - run: docker pull ghcr.io/openbao/openbao:latest
+      - run: docker pull ghcr.io/openbao/openbao:2.5.2
       - run: go test -tags openbao_test -coverprofile=coverage-openbao.out -coverpkg=./internal/... ./internal/integration/...
       - uses: actions/upload-artifact@v7
         with:
           name: coverage-openbao
           path: coverage-openbao.out
+          retention-days: 1
 
   ui:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     needs: [unit]
     if: github.event_name != 'merge_group' && github.event_name != 'push' && (inputs.job == '' || inputs.job == 'ui')
     steps:
@@ -176,9 +192,11 @@ jobs:
         with:
           name: coverage-ui
           path: coverage-ui.out
+          retention-days: 1
 
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
     if: github.event_name != 'merge_group' && github.event_name != 'push' && inputs.job == ''
     needs: [unit, cli, docker, idp, openbao, pak, ui]
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: docs
@@ -37,7 +37,7 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -16,10 +16,13 @@ on:
           - TestHelloPocketbase
           - TestHelloPostgrest
 
+permissions:
+  contents: read
+
 jobs:
   run:
     name: ${{ matrix.example }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
     strategy:
       fail-fast: false
@@ -50,7 +53,7 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           docker pull dexidp/dex:v2.41.1
-          docker pull ghcr.io/openbao/openbao:latest
+          docker pull ghcr.io/openbao/openbao:2.5.2
           docker pull ghcr.io/rocker-org/r-ver:4.4.3
           docker pull postgres:17
           docker pull postgrest/postgrest:v12.2.3
@@ -80,6 +83,7 @@ jobs:
           name: coverage-e2e-${{ matrix.test }}
           path: coverage-e2e-*.out
           if-no-files-found: ignore
+          retention-days: 1
       - name: Dump compose logs on failure
         if: failure()
         run: |
@@ -89,7 +93,8 @@ jobs:
   e2e:
     if: always()
     needs: [run]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
       - if: needs.run.result != 'success'
         run: |
@@ -100,7 +105,8 @@ jobs:
   coverage:
     if: github.event_name == 'merge_group'
     needs: [run]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -169,6 +175,8 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           curl -fsSL https://cli.codecov.io/latest/linux/codecov -o ./codecov
+          curl -fsSL https://cli.codecov.io/latest/linux/codecov.SHA256SUM -o ./codecov.SHA256SUM
+          sha256sum -c codecov.SHA256SUM
           chmod +x ./codecov
           for f in coverage-*.out; do
             [ -f "$f" ] || continue

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,42 +4,20 @@ on:
   push:
     branches: [main]
 
+permissions:
+  packages: write
+
 env:
   IMAGE: ghcr.io/cynkra/blockyard
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        include:
-          - runner: ubuntu-24.04
-            platform: linux/amd64
-          - runner: ubuntu-24.04-arm
-            platform: linux/arm64
-    runs-on: ${{ matrix.runner }}
-    permissions:
-      packages: write
-    steps:
-      - uses: actions/checkout@v6
-      - uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-buildx-action@v4
-      - id: slug
-        run: echo "platform=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
-      - uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: docker/server.Dockerfile
-          platforms: ${{ matrix.platform }}
-          tags: ${{ env.IMAGE }}:build-${{ steps.slug.outputs.platform }}
-          push: true
+  server-image:
+    uses: ./.github/workflows/server-image.yml
 
   manifest:
-    needs: build
-    runs-on: ubuntu-latest
+    needs: server-image
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
     permissions:
       packages: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,39 +22,12 @@ jobs:
 
   server-image:
     needs: e2e
-    strategy:
-      matrix:
-        include:
-          - runner: ubuntu-24.04
-            platform: linux/amd64
-          - runner: ubuntu-24.04-arm
-            platform: linux/arm64
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/setup-buildx-action@v4
-
-      - id: slug
-        run: echo "platform=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
-
-      - uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: docker/server.Dockerfile
-          platforms: ${{ matrix.platform }}
-          tags: ${{ env.SERVER_IMAGE }}:build-${{ steps.slug.outputs.platform }}
-          push: true
+    uses: ./.github/workflows/server-image.yml
 
   server-manifest:
     needs: server-image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
       - uses: docker/login-action@v4
         with:
@@ -82,9 +55,14 @@ jobs:
               "${{ env.SERVER_IMAGE }}:build-linux-arm64"
           done <<< "$TAGS"
 
-  github-release:
-    needs: server-manifest
-    runs-on: ubuntu-latest
+  binaries:
+    needs: e2e
+    strategy:
+      fail-fast: false
+      matrix:
+        goarch: [amd64, arm64]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -92,17 +70,31 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Build release binaries
+      - name: Build release binary
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          LDFLAGS="-s -w -X main.version=${VERSION}"
-          CGO_ENABLED=0 GOARCH=amd64 go build -ldflags "$LDFLAGS" -o blockyard-linux-amd64 ./cmd/blockyard
-          CGO_ENABLED=0 GOARCH=arm64 go build -ldflags "$LDFLAGS" -o blockyard-linux-arm64 ./cmd/blockyard
+          CGO_ENABLED=0 GOARCH=${{ matrix.goarch }} go build \
+            -ldflags "-s -w -X main.version=${VERSION}" \
+            -o blockyard-linux-${{ matrix.goarch }} ./cmd/blockyard
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: binary-${{ matrix.goarch }}
+          path: blockyard-linux-${{ matrix.goarch }}
+          retention-days: 1
+
+  github-release:
+    needs: [server-manifest, binaries]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: binary-*
+          merge-multiple: true
 
       # TODO: bump to v3 once released with node24 support
       - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: |
-            blockyard-linux-amd64
-            blockyard-linux-arm64
+          files: blockyard-linux-*

--- a/.github/workflows/server-image.yml
+++ b/.github/workflows/server-image.yml
@@ -1,0 +1,39 @@
+name: Server Image
+
+on:
+  workflow_call:
+
+env:
+  IMAGE: ghcr.io/cynkra/blockyard
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            platform: linux/amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v4
+      - id: slug
+        run: echo "platform=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/server.Dockerfile
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.IMAGE }}:build-${{ steps.slug.outputs.platform }}
+          push: true

--- a/examples/hello-pocketbase/docker-compose.yml
+++ b/examples/hello-pocketbase/docker-compose.yml
@@ -22,7 +22,7 @@ services:
 
   # --- OpenBao: secrets management ---
   openbao:
-    image: ghcr.io/openbao/openbao:latest
+    image: ghcr.io/openbao/openbao:2.5.2
     command: ["server", "-dev", "-dev-root-token-id=root-dev-token", "-dev-listen-address=0.0.0.0:8200"]
     environment:
       BAO_DEV_ROOT_TOKEN_ID: root-dev-token

--- a/examples/hello-postgrest/docker-compose.yml
+++ b/examples/hello-postgrest/docker-compose.yml
@@ -45,7 +45,7 @@ services:
 
   # --- OpenBao: secrets management + Identity OIDC provider ---
   openbao:
-    image: ghcr.io/openbao/openbao:latest
+    image: ghcr.io/openbao/openbao:2.5.2
     command: ["server", "-dev", "-dev-root-token-id=root-dev-token", "-dev-listen-address=0.0.0.0:8200"]
     environment:
       BAO_DEV_ROOT_TOKEN_ID: root-dev-token

--- a/internal/backend/docker/docker_integration_test.go
+++ b/internal/backend/docker/docker_integration_test.go
@@ -25,7 +25,7 @@ import (
 func testConfig() *config.DockerConfig {
 	return &config.DockerConfig{
 		Socket:     "/var/run/docker.sock",
-		Image:      "alpine:latest",
+		Image:      "alpine:3.21",
 		ShinyPort:  8080,
 		PakVersion: "stable",
 	}
@@ -43,7 +43,7 @@ func TestSpawnAndStop(t *testing.T) {
 	spec := backend.WorkerSpec{
 		AppID:       "test-app",
 		WorkerID:    workerID,
-		Image:       "alpine:latest",
+		Image:       "alpine:3.21",
 		Cmd:         []string{"sleep", "300"},
 		BundlePath:  "/tmp",
 		LibraryPath: "",
@@ -88,7 +88,7 @@ func TestHealthCheckNoListener(t *testing.T) {
 	spec := backend.WorkerSpec{
 		AppID:       "test-app",
 		WorkerID:    workerID,
-		Image:       "alpine:latest",
+		Image:       "alpine:3.21",
 		Cmd:         []string{"sleep", "300"},
 		BundlePath:  "/tmp",
 		LibraryPath: "",
@@ -120,7 +120,7 @@ func TestOrphanCleanup(t *testing.T) {
 	spec := backend.WorkerSpec{
 		AppID:       "test-app",
 		WorkerID:    workerID,
-		Image:       "alpine:latest",
+		Image:       "alpine:3.21",
 		Cmd:         []string{"sleep", "300"},
 		BundlePath:  "/tmp",
 		LibraryPath: "",
@@ -186,7 +186,7 @@ func TestNetworkIsolation(t *testing.T) {
 		return backend.WorkerSpec{
 			AppID:       "test-app",
 			WorkerID:    id,
-			Image:       "alpine:latest",
+			Image:       "alpine:3.21",
 			Cmd:         []string{"sleep", "300"},
 			BundlePath:  "/tmp",
 			LibraryPath: "",
@@ -263,7 +263,7 @@ func TestMetadataEndpointBlocked(t *testing.T) {
 	spec := backend.WorkerSpec{
 		AppID:       "test-app",
 		WorkerID:    workerID,
-		Image:       "alpine:latest",
+		Image:       "alpine:3.21",
 		Cmd:         []string{"sleep", "300"},
 		BundlePath:  "/tmp",
 		LibraryPath: "",
@@ -314,7 +314,7 @@ func testSpawn(t *testing.T, b *DockerBackend, cmd []string) (string, backend.Wo
 	spec := backend.WorkerSpec{
 		AppID:       "test-app",
 		WorkerID:    workerID,
-		Image:       "alpine:latest",
+		Image:       "alpine:3.21",
 		Cmd:         cmd,
 		BundlePath:  "/tmp",
 		LibraryPath: "",
@@ -419,7 +419,7 @@ func TestBuildFailsWithBadImage(t *testing.T) {
 	spec := backend.BuildSpec{
 		AppID:    "test-app",
 		BundleID: uuid.New().String()[:8],
-		Image:    "alpine:latest",
+		Image:    "alpine:3.21",
 		Cmd:      []string{"false"},
 		Mounts: []backend.MountEntry{
 			{Source: bundleDir, Target: "/app", ReadOnly: true},
@@ -454,7 +454,7 @@ func TestBuildWithProductionImage(t *testing.T) {
 	spec := backend.BuildSpec{
 		AppID:    "test-app",
 		BundleID: uuid.New().String()[:8],
-		Image:    "alpine:latest",
+		Image:    "alpine:3.21",
 		Cmd:      []string{"true"},
 		Mounts: []backend.MountEntry{
 			{Source: bundleDir, Target: "/app", ReadOnly: true},
@@ -499,7 +499,7 @@ func TestSpawnWithMemoryLimit(t *testing.T) {
 	spec := backend.WorkerSpec{
 		AppID:       "test-app",
 		WorkerID:    workerID,
-		Image:       "alpine:latest",
+		Image:       "alpine:3.21",
 		Cmd:         []string{"sleep", "300"},
 		BundlePath:  "/tmp",
 		LibraryPath: "",
@@ -540,7 +540,7 @@ func TestSpawnWithCPULimit(t *testing.T) {
 	spec := backend.WorkerSpec{
 		AppID:       "test-app",
 		WorkerID:    workerID,
-		Image:       "alpine:latest",
+		Image:       "alpine:3.21",
 		Cmd:         []string{"sleep", "300"},
 		BundlePath:  "/tmp",
 		LibraryPath: "",
@@ -581,7 +581,7 @@ func TestSpawnWithEnvVars(t *testing.T) {
 	spec := backend.WorkerSpec{
 		AppID:       "test-app",
 		WorkerID:    workerID,
-		Image:       "alpine:latest",
+		Image:       "alpine:3.21",
 		Cmd:         []string{"sleep", "300"},
 		BundlePath:  "/tmp",
 		LibraryPath: "",
@@ -644,7 +644,7 @@ func TestBuildLogWriter(t *testing.T) {
 	spec := backend.BuildSpec{
 		AppID:    "test-app",
 		BundleID: uuid.New().String()[:8],
-		Image:    "alpine:latest",
+		Image:    "alpine:3.21",
 		Cmd:      []string{"true"},
 		Mounts: []backend.MountEntry{
 			{Source: bundleDir, Target: "/app", ReadOnly: true},
@@ -686,7 +686,7 @@ func TestBuildExitCodeOnFailure(t *testing.T) {
 	spec := backend.BuildSpec{
 		AppID:    "test-app",
 		BundleID: uuid.New().String()[:8],
-		Image:    "alpine:latest",
+		Image:    "alpine:3.21",
 		Cmd:      []string{"false"},
 		Mounts: []backend.MountEntry{
 			{Source: bundleDir, Target: "/app", ReadOnly: true},
@@ -720,7 +720,7 @@ func TestSpawnAndHealthCheckWithListener(t *testing.T) {
 	spec := backend.WorkerSpec{
 		AppID:       "test-app",
 		WorkerID:    workerID,
-		Image:       "alpine:latest",
+		Image:       "alpine:3.21",
 		Cmd: []string{"sh", "-c",
 			"while true; do echo -e 'HTTP/1.1 200 OK\\r\\nContent-Length: 2\\r\\n\\r\\nok' | nc -l -p 8080; done",
 		},

--- a/internal/backend/docker/pak_integration_test.go
+++ b/internal/backend/docker/pak_integration_test.go
@@ -24,7 +24,7 @@ import (
 func pakTestConfig() *config.DockerConfig {
 	return &config.DockerConfig{
 		Socket:     "/var/run/docker.sock",
-		Image:      "alpine:latest",
+		Image:      "alpine:3.21",
 		ShinyPort:  8080,
 		PakVersion: "stable",
 	}

--- a/internal/integration/openbao_integration_test.go
+++ b/internal/integration/openbao_integration_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	openbaoImage = "ghcr.io/openbao/openbao:latest"
+	openbaoImage = "ghcr.io/openbao/openbao:2.5.2"
 )
 
 var (

--- a/internal/proxy/ws_docker_test.go
+++ b/internal/proxy/ws_docker_test.go
@@ -158,7 +158,7 @@ func buildWSEchoBinary(t *testing.T) string {
 func dockerTestConfig() *config.DockerConfig {
 	return &config.DockerConfig{
 		Socket:    "/var/run/docker.sock",
-		Image:     "alpine:latest",
+		Image:     "alpine:3.21",
 		ShinyPort: 8080,
 		PakVersion: "stable",
 	}
@@ -182,7 +182,7 @@ func dockerWSTestSetup(t *testing.T, wsBinary string) (*server.Server, *httptest
 	cfg := &config.Config{
 		Server: config.ServerConfig{},
 		Docker: config.DockerConfig{
-			Image:     "alpine:latest",
+			Image:     "alpine:3.21",
 			ShinyPort: 8080,
 		},
 		Storage: config.StorageConfig{
@@ -228,7 +228,7 @@ func dockerWSTestSetup(t *testing.T, wsBinary string) (*server.Server, *httptest
 	spec := backend.WorkerSpec{
 		AppID:       app.ID,
 		WorkerID:    workerID,
-		Image:       "alpine:latest",
+		Image:       "alpine:3.21",
 		Cmd:         []string{"/wsecho-bin"},
 		BundlePath:  tmp,
 		LibraryPath: "",


### PR DESCRIPTION
## Summary
- Pin `ubuntu-24.04` on all runners (was mixed `ubuntu-latest`/`ubuntu-24.04`)
- Pin `alpine:3.21` and `openbao:2.5.2` (were floating `:latest`) in workflows, tests, and examples
- Add `timeout-minutes` to every job (prevents 6h hangs on stuck tests)
- Set `permissions: contents: read` on ci.yml/merge.yml, `packages: write` on publish.yml
- Add `retention-days: 1` to all coverage artifacts
- Verify Codecov CLI download with SHA256 checksum
- Extract reusable `server-image.yml` workflow (was duplicated in publish + release)
- Add `fail-fast: false` to Docker build matrix
- Parallelize release: binary builds (matrix) run alongside Docker image builds after e2e

## Test plan
- [ ] CI green
- [ ] Verify reusable server-image workflow is invoked correctly by publish and release