### PR TITLE
Remove path filters from Codecov flags

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,28 +9,20 @@ coverage:
 
 flags:
   unit:
-    paths: [internal/]
     carryforward: true
   cli:
-    paths: [cmd/by/, internal/]
     carryforward: true
   docker:
-    paths: [internal/]
     carryforward: true
   idp:
-    paths: [internal/auth/]
     carryforward: true
   openbao:
-    paths: [internal/integration/]
     carryforward: true
   pak:
-    paths: [internal/]
     carryforward: true
   ui:
-    paths: [internal/ui/]
     carryforward: true
   e2e:
-    paths: [cmd/blockyard/, cmd/by/, internal/]
     carryforward: true
 
 ignore:


### PR DESCRIPTION
## Summary
- Remove `paths` from all Codecov flag definitions so flags purely represent test suites
- Path filters were silently dropping coverage when a test suite exercised code outside its designated paths (e.g. openbao tests covering `internal/auth/`)
- Flags now report the full coverage contribution of each test suite, unfiltered

## Test plan
- [ ] CI green
- [ ] Verify on Codecov dashboard that flag coverage is reported without path restrictions