### PR TITLE
Fix v2 documentation gaps and inconsistencies

### DIFF
--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -25,7 +25,7 @@ BLOCKYARD_DOCKER_IMAGE=ghcr.io/rocker-org/r-ver:4.4.0
 
 | Field | Default | Description |
 |---|---|---|
-| `bind` | `0.0.0.0:8080` | Address and port the server listens on |
+| `bind` | `127.0.0.1:8080` | Address and port the server listens on |
 | `shutdown_timeout` | `30s` | Time to drain in-flight requests on shutdown |
 | `log_level` | `info` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error` |
 | `management_bind` | — | Separate listener for `/healthz`, `/readyz`, `/metrics`. See [Observability](/guides/observability/#management-listener). |
@@ -43,6 +43,8 @@ BLOCKYARD_DOCKER_IMAGE=ghcr.io/rocker-org/r-ver:4.4.0
 | `pak_version` | `stable` | [pak](https://pak.r-lib.org/) release channel (`stable`, `rc`, or `devel`) |
 | `service_network` | — | Docker network whose containers are reachable from workers |
 | `store_retention` | `0` | Package store eviction duration (`0` = disabled) |
+| `default_memory_limit` | — | Fallback memory limit for workers (e.g. `"2g"`). Applies when no per-app limit is set. |
+| `default_cpu_limit` | — | Fallback CPU limit for workers (e.g. `4.0`). Applies when no per-app limit is set. |
 
 ### `[storage]`
 
@@ -76,6 +78,7 @@ BLOCKYARD_DOCKER_IMAGE=ghcr.io/rocker-org/r-ver:4.4.0
 | `http_forward_timeout` | `5m` | Timeout for forwarding HTTP requests to workers |
 | `max_cpu_limit` | `16.0` | Max CPU limit settable per app |
 | `transfer_timeout` | `60s` | Timeout for bundle transfers to workers |
+| `session_max_lifetime` | `0` | Hard cap on session duration. `0` (default) means unlimited — sessions only end via idle timeout or worker shutdown. |
 
 ### `[oidc]` *(optional)*
 
@@ -151,7 +154,7 @@ Enable Prometheus metrics and OpenTelemetry tracing.
 
 ```toml
 [server]
-bind             = "0.0.0.0:8080"
+bind             = "127.0.0.1:8080"
 shutdown_timeout = "30s"
 
 [docker]

--- a/docs/src/content/docs/guides/observability.md
+++ b/docs/src/content/docs/guides/observability.md
@@ -188,6 +188,7 @@ Each line is a JSON object with the following fields:
 | `app.stop` | App workers stopped |
 | `app.rollback` | App rolled back to a previous bundle |
 | `app.restore` | Soft-deleted app restored |
+| `app.rename` | App renamed (old name becomes an alias) |
 | `bundle.upload` | Bundle uploaded |
 | `bundle.restore.success` | Dependency restore completed |
 | `bundle.restore.fail` | Dependency restore failed |

--- a/docs/src/content/docs/reference/api.md
+++ b/docs/src/content/docs/reference/api.md
@@ -124,7 +124,7 @@ List apps visible to the caller. Paginated with RBAC filtering.
 |---|---|---|---|
 | `search` | `string` | — | Search by app name or title |
 | `tag` | `string` | — | Filter by tag name |
-| `deleted` | `bool` | `false` | Show soft-deleted apps (admin only) |
+| `deleted` | `bool` | `false` | Show soft-deleted apps (admin only). When `true`, returns a bare JSON array instead of the paginated wrapper. |
 | `page` | `integer` | `1` | Page number |
 | `per_page` | `integer` | `25` | Items per page (clamped to 1–100) |
 
@@ -202,6 +202,7 @@ updated.
 
 ```json
 {
+  "name": "new-slug",
   "max_workers_per_app": 4,
   "max_sessions_per_worker": 1,
   "memory_limit": "512m",
@@ -214,6 +215,7 @@ updated.
 
 | Field | Type | Default | Description |
 |---|---|---|---|
+| `name` | `string` | — | Rename the app (new URL-safe slug). Requires owner or admin. The old name is preserved as an alias so existing links continue to work. |
 | `max_workers_per_app` | `integer` | unlimited | Max concurrent workers (must be >= 1) |
 | `max_sessions_per_worker` | `integer` | `1` | Sessions per worker (must be >= 1). `1` means single-tenant containers. See [Credential Management](/guides/credentials/) for how this affects credential injection. |
 | `memory_limit` | `string` | none | Container memory limit (e.g. `"512m"`, `"2g"`) |
@@ -221,7 +223,7 @@ updated.
 | `access_type` | `string` | `"acl"` | `"acl"`, `"logged_in"`, or `"public"` (requires owner or admin) |
 | `title` | `string` | none | Human-readable title for the catalog |
 | `description` | `string` | none | Description for the catalog |
-| `pre_warmed_seats` | `integer` | `0` | Number of standby workers to keep pre-warmed |
+| `pre_warmed_seats` | `integer` | `0` | Number of standby workers to keep pre-warmed (max 10) |
 | `refresh_schedule` | `string` | none | Cron expression for automatic dependency refresh |
 
 **Response:** `200 OK` — updated app object.
@@ -691,6 +693,18 @@ Create a new tag. Admin only. Tag names follow the same rules as app names
 ```
 
 **Response:** `201 Created`
+
+### `PATCH /api/v1/tags/{tagID}`
+
+Rename a tag. Requires admin or publisher role.
+
+**Request body:**
+
+```json
+{ "name": "new-tag-name" }
+```
+
+**Response:** `200 OK` — updated tag object.
 
 ### `DELETE /api/v1/tags/{tagID}`
 

--- a/docs/src/content/docs/reference/config.md
+++ b/docs/src/content/docs/reference/config.md
@@ -30,7 +30,7 @@ Environment variables take precedence over values in the TOML file.
 
 ```toml
 [server]
-bind             = "0.0.0.0:8080"
+bind             = "127.0.0.1:8080"
 shutdown_timeout = "30s"
 # management_bind = "127.0.0.1:9100"
 # log_level      = "info"
@@ -41,7 +41,7 @@ shutdown_timeout = "30s"
 
 | Field | Type | Default | Required | Description |
 |---|---|---|---|---|
-| `bind` | `string` | `0.0.0.0:8080` | No | Socket address to listen on |
+| `bind` | `string` | `127.0.0.1:8080` | No | Socket address to listen on |
 | `management_bind` | `string` | — | No | Separate listener for `/healthz`, `/readyz`, `/metrics`. See [Management listener](/guides/observability/#management-listener). |
 | `shutdown_timeout` | `duration` | `30s` | No | Grace period for draining requests on shutdown |
 | `log_level` | `string` | `info` | No | Log verbosity. One of `trace`, `debug`, `info`, `warn` (or `warning`), `error`. |
@@ -63,8 +63,10 @@ socket          = "/var/run/docker.sock"
 image           = "ghcr.io/rocker-org/r-ver:4.4.3"
 shiny_port      = 3838
 pak_version     = "stable"
-# service_network = ""
-# store_retention = "0"
+# service_network      = ""
+# store_retention      = "0"
+# default_memory_limit = "2g"   # fallback per worker; omit = unlimited
+# default_cpu_limit    = 4.0    # fallback per worker; 0 = unlimited
 ```
 
 | Field | Type | Default | Required | Description |
@@ -75,6 +77,8 @@ pak_version     = "stable"
 | `pak_version` | `string` | `stable` | No | [pak](https://pak.r-lib.org/) release channel (`stable`, `rc`, or `devel`) |
 | `service_network` | `string` | — | No | Docker network whose containers are made reachable from workers. Used when apps need access to sidecar services (e.g. PocketBase, PostgREST). |
 | `store_retention` | `duration` | `0` | No | How long to keep unused entries in the shared package store. `0` (default) disables eviction — the store grows indefinitely. |
+| `default_memory_limit` | `string` | — | No | Fallback memory limit for workers when no per-app limit is set (e.g. `"2g"`). Empty or omitted means unlimited. |
+| `default_cpu_limit` | `float` | `0` | No | Fallback CPU limit for workers when no per-app limit is set (e.g. `4.0`). `0` means unlimited. |
 
 ## `[storage]`
 
@@ -121,9 +125,10 @@ max_workers          = 100
 log_retention        = "1h"
 session_idle_ttl     = "1h"
 idle_worker_timeout  = "5m"
-# http_forward_timeout = "5m"
-# max_cpu_limit        = 16.0
-# transfer_timeout     = "60s"
+# http_forward_timeout  = "5m"
+# max_cpu_limit         = 16.0
+# transfer_timeout      = "60s"
+# session_max_lifetime  = "0"    # hard cap on session duration; 0 = unlimited
 ```
 
 | Field | Type | Default | Required | Description |
@@ -138,6 +143,7 @@ idle_worker_timeout  = "5m"
 | `http_forward_timeout` | `duration` | `5m` | No | Timeout for forwarding HTTP requests to worker containers |
 | `max_cpu_limit` | `float` | `16.0` | No | Maximum CPU limit that can be set per app (caps the `cpu_limit` field on `PATCH /api/v1/apps/{id}`) |
 | `transfer_timeout` | `duration` | `60s` | No | Timeout for transferring bundle files to worker containers |
+| `session_max_lifetime` | `duration` | `0` | No | Hard cap on session duration regardless of activity. `0` (default) means unlimited — sessions only end via idle timeout or worker shutdown. |
 
 ## `[oidc]` *(optional)*
 


### PR DESCRIPTION
## Summary
- Fix `server.bind` default from `0.0.0.0:8080` to `127.0.0.1:8080` (matches code and example TOML)
- Document missing config fields: `docker.default_memory_limit`, `docker.default_cpu_limit`, `proxy.session_max_lifetime`
- Document `PATCH /api/v1/tags/{tagID}` (rename) and app rename via `PATCH /api/v1/apps/{id}` `name` field (owner/admin)
- Add `app.rename` audit action, `pre_warmed_seats` max cap of 10, deleted-apps response format note