### PR TITLE
Harden security: gate swagger, fix error leakage, extend gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 
 # Test coverage
 coverage.out
+
+# Secrets and runtime data
+.env
+!.env.example
+.vault-token
+*.db

--- a/internal/api/packages.go
+++ b/internal/api/packages.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 
 	"github.com/cynkra/blockyard/internal/server"
@@ -22,8 +23,9 @@ func PostPackages(srv *server.Server) http.HandlerFunc {
 
 		result, err := srv.InstallPackage(r.Context(), appID, workerID, req)
 		if err != nil {
+			slog.Error("package install failed", "worker_id", workerID, "error", err)
 			writeJSON(w, http.StatusInternalServerError,
-				server.PackageResponse{Status: "error", Message: err.Error()})
+				server.PackageResponse{Status: "error", Message: "internal error"})
 			return
 		}
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -162,7 +162,12 @@ func NewRouter(srv *server.Server) http.Handler {
 	})
 
 	// Swagger UI — serves OpenAPI spec and interactive documentation.
-	r.Get("/swagger/*", httpSwagger.WrapHandler)
+	// Gated behind API auth to prevent unauthenticated mapping of the
+	// API surface.
+	r.Group(func(r chi.Router) {
+		r.Use(APIAuth(srv))
+		r.Get("/swagger/*", httpSwagger.WrapHandler)
+	})
 
 	// Auth endpoints — strict rate limit to prevent brute-force.
 	r.Group(func(r chi.Router) {


### PR DESCRIPTION
## Summary
- Gate `/swagger/*` behind API auth to prevent unauthenticated API surface mapping
- Stop leaking internal error details in the packages endpoint (log server-side, return generic message)
- Extend `.gitignore` to exclude `.env`, `.vault-token`, and `*.db` files