### PR TITLE
Fix trivy-action version tag in CI workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.31.0
+        uses: aquasecurity/trivy-action@v0.31.0
         with:
           image-ref: ${{ env.IMAGE }}:build-linux-amd64
           format: sarif

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.31.0
+        uses: aquasecurity/trivy-action@v0.31.0
         with:
           image-ref: ${{ env.SERVER_IMAGE }}:build-linux-amd64
           format: sarif


### PR DESCRIPTION
## Summary
- Add missing `v` prefix to `aquasecurity/trivy-action` version tag (`0.31.0` → `v0.31.0`)
- Fixes scan-image job failing at "Set up job" in both `publish.yml` and `release.yml`