### PR TITLE
Fix broken links on docs site

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,11 +1,31 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
+import { visit } from 'unist-util-visit';
+
+const BASE = '/blockyard';
+
+/** Rehype plugin: prepend base path to internal links in Markdown content. */
+function rehypeBaseLinks() {
+	return (tree) => {
+		visit(tree, 'element', (node) => {
+			if (node.tagName === 'a' && typeof node.properties.href === 'string') {
+				const href = node.properties.href;
+				if (href.startsWith('/') && !href.startsWith(BASE + '/')) {
+					node.properties.href = BASE + href;
+				}
+			}
+		});
+	};
+}
 
 // https://astro.build/config
 export default defineConfig({
 	site: 'https://cynkra.github.io',
-	base: '/blockyard',
+	base: BASE,
+	markdown: {
+		rehypePlugins: [rehypeBaseLinks],
+	},
 	integrations: [
 		starlight({
 			title: 'Blockyard',

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -6,15 +6,15 @@ hero:
   tagline: Deploy and run Shiny applications in isolated containers with zero configuration.
   actions:
     - text: Get Started
-      link: /getting-started/overview/
+      link: /blockyard/getting-started/overview/
       icon: right-arrow
     - text: CLI Reference
-      link: /reference/cli/
+      link: /blockyard/reference/cli/
       icon: open-book
       variant: minimal
 ---
 
-import { Card, CardGrid } from '@astrojs/starlight/components';
+import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 ## Why Blockyard?
 
@@ -39,4 +39,12 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 		Deploy from your terminal with `by deploy` or script with
 		the REST API. One config file. One binary.
 	</Card>
+</CardGrid>
+
+## Documentation
+
+<CardGrid>
+	<LinkCard title="Getting Started" description="Installation and first deployment." href="/blockyard/getting-started/overview/" />
+	<LinkCard title="Guides" description="Configuration, authorization, and operations." href="/blockyard/guides/deploying/" />
+	<LinkCard title="Reference" description="CLI commands, REST API, and configuration file." href="/blockyard/reference/cli/" />
 </CardGrid>


### PR DESCRIPTION
## Summary
- Add rehype plugin to prepend `/blockyard` base path to internal links in markdown content — fixes ~18 broken cross-references across all doc pages
- Hardcode base path in hero action links (frontmatter YAML, not processed by rehype)
- Add Documentation section with LinkCards on the landing page for navigation (splash template hides the sidebar)