### PR TITLE
Align docs site colors with UI theme

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -29,6 +29,7 @@ export default defineConfig({
 	integrations: [
 		starlight({
 			title: 'Blockyard',
+			customCss: ['./src/styles/custom.css'],
 			social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/cynkra/blockyard' }],
 			sidebar: [
 				{

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -1,0 +1,40 @@
+/* Align Starlight docs theme with the Blockyard UI color palette.
+   UI source: internal/ui/static/style.css */
+
+/* ──────────────────────── Dark mode ──────────────────────── */
+:root {
+	/* Gray scale — Tailwind Slate (matches UI dark-mode surfaces & text) */
+	--sl-color-white: #f1f5f9;  /* slate-100  — brightest text */
+	--sl-color-gray-1: #e2e8f0; /* slate-200 */
+	--sl-color-gray-2: #94a3b8; /* slate-400  — secondary text */
+	--sl-color-gray-3: #64748b; /* slate-500  — muted text */
+	--sl-color-gray-4: #475569; /* slate-600 */
+	--sl-color-gray-5: #334155; /* slate-700  — borders / muted bg */
+	--sl-color-gray-6: #1e293b; /* slate-800  — nav / sidebar bg */
+	--sl-color-black: #0f172a;  /* slate-900  — page bg */
+
+	/* Accent — Blue (UI --accent in dark mode) */
+	--sl-color-accent-low: #172554;
+	--sl-color-accent: #3b82f6;
+	--sl-color-accent-high: #bfdbfe;
+}
+
+/* ──────────────────────── Light mode ──────────────────────── */
+:root[data-theme='light'],
+[data-theme='light'] ::backdrop {
+	/* Gray scale — matches UI light-mode CSS variables */
+	--sl-color-white: #1a1a1a;  /* --text-primary */
+	--sl-color-gray-1: #333333;
+	--sl-color-gray-2: #555555; /* --text-secondary */
+	--sl-color-gray-3: #888888; /* --text-muted */
+	--sl-color-gray-4: #cccccc; /* --border-input */
+	--sl-color-gray-5: #e5e7eb; /* --border-default */
+	--sl-color-gray-6: #f3f4f6; /* --bg-muted */
+	--sl-color-gray-7: #fafafa; /* --bg-body */
+	--sl-color-black: #ffffff;  /* --bg-surface */
+
+	/* Accent — Blue (UI --accent in light mode) */
+	--sl-color-accent-low: #eef2ff;
+	--sl-color-accent: #2563eb;
+	--sl-color-accent-high: #1e40af;
+}


### PR DESCRIPTION
## Summary
- Add custom CSS overriding Starlight's default gray and accent color scales
- Dark mode uses the same Tailwind slate palette as the UI (`#0f172a` through `#f1f5f9`)
- Light mode maps to the UI's light-mode variables (`#fafafa` body, `#2563eb` accent)
- Replaces Starlight's purple-ish hue-224 accent with our blue-600/blue-500