### PR TITLE
Use Rscript to suppress echo noise in build logs

### DIFF
--- a/internal/bundle/preprocess.go
+++ b/internal/bundle/preprocess.go
@@ -42,7 +42,7 @@ func preProcess(ctx context.Context, be backend.Backend,
 		AppID:    p.AppID,
 		BundleID: p.BundleID + "-preprocess",
 		Image:    p.Image,
-		Cmd:      []string{"R", "--vanilla", "-e", rScript},
+		Cmd:      []string{"Rscript", "--vanilla", "-e", rScript},
 		Mounts: []backend.MountEntry{
 			{Source: p.Paths.Unpacked, Target: "/app", ReadOnly: true},
 			{Source: pakPath, Target: "/pak", ReadOnly: true},

--- a/internal/bundle/restore.go
+++ b/internal/bundle/restore.go
@@ -475,7 +475,7 @@ if (rc != 0L) {
        "); store-manifest.json was not written")
 }
 `
-	return []string{"R", "--vanilla", "-e", rScript}
+	return []string{"Rscript", "--vanilla", "-e", rScript}
 }
 
 // BuildMounts returns the mount entries for the store-aware build container.
@@ -534,7 +534,7 @@ pak::lockfile_create(refs,
   lockfile = "/build-lib/pak.lock", lib = "/build-lib")
 pak::lockfile_install("/build-lib/pak.lock", lib = "/build-lib")
 `
-	return []string{"R", "--vanilla", "-e", rScript}
+	return []string{"Rscript", "--vanilla", "-e", rScript}
 }
 
 // legacyBuildMounts returns mount entries for the phase 2-5 build flow.

--- a/internal/bundle/restore_test.go
+++ b/internal/bundle/restore_test.go
@@ -225,7 +225,7 @@ func TestBuildCommand(t *testing.T) {
 	if len(cmd) != 4 {
 		t.Fatalf("expected 4 parts, got %d", len(cmd))
 	}
-	if cmd[0] != "R" || cmd[1] != "--vanilla" || cmd[2] != "-e" {
+	if cmd[0] != "Rscript" || cmd[1] != "--vanilla" || cmd[2] != "-e" {
 		t.Errorf("prefix = %v", cmd[:3])
 	}
 	// The R script should reference the by-builder store commands.

--- a/internal/pakcache/pakcache.go
+++ b/internal/pakcache/pakcache.go
@@ -87,7 +87,7 @@ func EnsureInstalled(ctx context.Context, be backend.Backend,
 		AppID:    "_system",
 		BundleID: "pak-install-" + uuid.New().String()[:8],
 		Image:    image,
-		Cmd:      []string{"R", "--vanilla", "-e", installCmd},
+		Cmd:      []string{"Rscript", "--vanilla", "-e", installCmd},
 		Mounts: []backend.MountEntry{
 			{Source: tmpDir, Target: "/pak-output", ReadOnly: false},
 		},

--- a/internal/server/packages.go
+++ b/internal/server/packages.go
@@ -221,7 +221,7 @@ if (rc != 0L) {
 		AppID:    p.AppID,
 		BundleID: "runtime-" + p.WorkerID + "-" + uuid.New().String()[:8],
 		Image:    p.Image,
-		Cmd:      []string{"R", "--vanilla", "-e", rScript},
+		Cmd:      []string{"Rscript", "--vanilla", "-e", rScript},
 		Mounts: []backend.MountEntry{
 			{Source: p.WorkerLibDir, Target: "/worker-lib", ReadOnly: true},
 			{Source: p.StagingDir, Target: "/staging", ReadOnly: false},


### PR DESCRIPTION
## Summary
- Switch all R script invocations from `R --vanilla -e` to `Rscript --vanilla -e` across build, preprocess, runtime install, and pak cache paths
- Eliminates the R startup banner (~8 lines) and `>` / `+` prompt echo of every script line (~50+ lines) from user-facing deploy output
- Preserves pak's own progress messages (package resolution, install status) which remain useful