### PR TITLE
Fix OIDC login: revert session cookie to SameSite=Lax

### DIFF
--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -296,8 +296,13 @@ func CallbackHandler(deps *Deps) http.HandlerFunc {
 		}
 
 		secure := secureFlag(deps.Config)
+		// SameSite=Lax is required here — Strict breaks the OIDC redirect
+		// chain (IdP → /callback → return URL) because browsers won't send
+		// a Strict cookie on the first navigation back from the IdP.
+		// CSRF is already mitigated by the state/nonce parameters verified
+		// above, so Lax provides equivalent protection for this flow.
 		sessionCookie := fmt.Sprintf(
-			"blockyard_session=%s; Path=/; HttpOnly; SameSite=Strict%s; Max-Age=%d",
+			"blockyard_session=%s; Path=/; HttpOnly; SameSite=Lax%s; Max-Age=%d",
 			cookieValue, secure, cookieMaxAge,
 		)
 


### PR DESCRIPTION
## Summary
- Reverts session cookie from `SameSite=Strict` back to `SameSite=Lax`, fixing "Your session has expired" immediately after OIDC login
- `Strict` was introduced in a0d20b3 (security audit) but is incompatible with OIDC redirect chains — browsers may withhold the cookie on the first navigation back from the IdP
- CSRF protection is already provided by the OIDC state/nonce parameters, so `Lax` is equivalent for this flow
- Adds a comment explaining why `Lax` is required so this isn't re-flagged