### PR TITLE
Add WebSocket idle timeout (session_idle_ttl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ health_interval      = "15s"
 worker_start_timeout = "60s"
 max_workers          = 100
 log_retention        = "1h"
-session_idle_ttl     = "1h"
+# session_idle_ttl   = "0"
 idle_worker_timeout  = "5m"
 
 # Optional: OIDC authentication

--- a/blockyard.toml
+++ b/blockyard.toml
@@ -28,7 +28,7 @@ health_interval      = "15s"
 worker_start_timeout = "60s"
 max_workers          = 100
 log_retention        = "1h"
-session_idle_ttl     = "1h"
+# session_idle_ttl   = "0"     # idle timeout for sessions and WebSocket connections; 0 = disabled
 idle_worker_timeout  = "5m"
 # session_max_lifetime = "0"  # hard cap on session duration; 0 = unlimited
 

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -73,7 +73,7 @@ BLOCKYARD_DOCKER_IMAGE=ghcr.io/rocker-org/r-ver:4.4.0
 | `worker_start_timeout` | `60s` | Max time to wait for a worker to become healthy |
 | `max_workers` | `100` | Maximum number of concurrent worker containers |
 | `log_retention` | `1h` | How long to keep worker log entries before cleanup |
-| `session_idle_ttl` | `1h` | Time before an idle session is cleaned up |
+| `session_idle_ttl` | `0` | Idle timeout for sessions and WebSocket connections. When non-zero, idle WebSocket connections are closed and stale sessions are swept. `0` = disabled. |
 | `idle_worker_timeout` | `5m` | Time before an idle worker container is stopped |
 | `http_forward_timeout` | `5m` | Timeout for forwarding HTTP requests to workers |
 | `max_cpu_limit` | `16.0` | Max CPU limit settable per app |
@@ -180,7 +180,7 @@ health_interval      = "15s"
 worker_start_timeout = "60s"
 max_workers          = 100
 log_retention        = "1h"
-session_idle_ttl     = "1h"
+# session_idle_ttl   = "0"
 idle_worker_timeout  = "5m"
 
 # Optional: OIDC authentication

--- a/docs/src/content/docs/reference/config.md
+++ b/docs/src/content/docs/reference/config.md
@@ -123,7 +123,7 @@ health_interval      = "15s"
 worker_start_timeout = "60s"
 max_workers          = 100
 log_retention        = "1h"
-session_idle_ttl     = "1h"
+# session_idle_ttl     = "0"   # idle timeout for sessions and WebSocket connections; 0 = disabled
 idle_worker_timeout  = "5m"
 # http_forward_timeout  = "5m"
 # max_cpu_limit         = 16.0
@@ -138,7 +138,7 @@ idle_worker_timeout  = "5m"
 | `worker_start_timeout` | `duration` | `60s` | No | Max time to wait for a new worker to become healthy |
 | `max_workers` | `integer` | `100` | No | Global cap on concurrent worker containers |
 | `log_retention` | `duration` | `1h` | No | How long to keep worker log entries before cleanup |
-| `session_idle_ttl` | `duration` | `1h` | No | Time before an idle session is cleaned up |
+| `session_idle_ttl` | `duration` | `0` | No | Idle timeout for sessions and WebSocket connections. When non-zero, WebSocket connections with no application-level messages for this duration are closed, and stale session records are swept. `0` (default) means disabled. |
 | `idle_worker_timeout` | `duration` | `5m` | No | Time before an idle worker container is stopped |
 | `http_forward_timeout` | `duration` | `5m` | No | Timeout for forwarding HTTP requests to worker containers |
 | `max_cpu_limit` | `float` | `16.0` | No | Maximum CPU limit that can be set per app (caps the `cpu_limit` field on `PATCH /api/v1/apps/{id}`) |

--- a/examples/hello-pocketbase/blockyard.toml
+++ b/examples/hello-pocketbase/blockyard.toml
@@ -24,7 +24,7 @@ health_interval      = "15s"
 worker_start_timeout = "60s"
 max_workers          = 100
 log_retention        = "1h"
-session_idle_ttl     = "1h"
+# session_idle_ttl   = "0"
 idle_worker_timeout  = "5m"
 
 # OIDC and OpenBao settings are provided via environment variables

--- a/examples/hello-postgrest/blockyard.toml
+++ b/examples/hello-postgrest/blockyard.toml
@@ -21,7 +21,7 @@ health_interval      = "15s"
 worker_start_timeout = "60s"
 max_workers          = 100
 log_retention        = "1h"
-session_idle_ttl     = "1h"
+# session_idle_ttl   = "0"
 idle_worker_timeout  = "5m"
 
 # Database, OIDC, OpenBao, and board_storage settings are provided

--- a/examples/hello-shiny/blockyard.toml
+++ b/examples/hello-shiny/blockyard.toml
@@ -23,7 +23,7 @@ health_interval      = "15s"
 worker_start_timeout = "60s"
 max_workers          = 100
 log_retention        = "1h"
-session_idle_ttl     = "1h"
+# session_idle_ttl   = "0"
 idle_worker_timeout  = "5m"
 
 # OIDC settings are provided via environment variables in docker-compose.yml.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -199,9 +199,9 @@ func applyDefaults(cfg *Config) {
 	if cfg.Proxy.LogRetention.Duration == 0 {
 		cfg.Proxy.LogRetention.Duration = 1 * time.Hour
 	}
-	if cfg.Proxy.SessionIdleTTL.Duration == 0 {
-		cfg.Proxy.SessionIdleTTL.Duration = 1 * time.Hour
-	}
+	// session_idle_ttl defaults to 0 (disabled). When non-zero, idle
+	// WebSocket connections are closed and stale session records are
+	// swept after this duration of inactivity.
 	if cfg.Proxy.IdleWorkerTimeout.Duration == 0 {
 		cfg.Proxy.IdleWorkerTimeout.Duration = 5 * time.Minute
 	}

--- a/internal/proxy/ws.go
+++ b/internal/proxy/ws.go
@@ -134,6 +134,11 @@ func (br *backendReader) Close() {
 // reader is cached and later handed to the next shuttleWS instance
 // without concurrent-reader races or message loss.
 //
+// When session_idle_ttl > 0, an idle timer closes the connection if
+// no application-level messages are exchanged within the configured
+// duration. Ping/pong frames are handled internally by coder/websocket
+// and do not reset the timer.
+//
 // All Read/Write calls use context.Background() because the
 // coder/websocket library closes connections when a Read's context
 // is cancelled (via setupReadTimeout → c.close()).
@@ -210,6 +215,25 @@ func shuttleWS(
 		lifetimeC = t.C
 	}
 
+	// Optional idle timeout. When set, the connection is closed if no
+	// application-level messages are exchanged within the duration.
+	// Ping/pong frames are handled by coder/websocket internally and
+	// never appear here, so only real user activity resets the timer.
+	idleTTL := srv.Config.Proxy.SessionIdleTTL.Duration
+	var idleC <-chan time.Time
+	var idleTimer *time.Timer
+	if idleTTL > 0 {
+		idleTimer = time.NewTimer(idleTTL)
+		defer idleTimer.Stop()
+		idleC = idleTimer.C
+	}
+
+	// Rate-limit Touch calls to avoid lock contention on the session
+	// store. LastAccess may be up to touchInterval stale, which is
+	// fine for a sweep running on 15s ticks with TTLs in minutes/hours.
+	const touchInterval = 30 * time.Second
+	lastTouch := time.Now()
+
 	// Main select loop: shuttle messages between client and backend.
 	cacheBackend := false
 	for {
@@ -227,6 +251,13 @@ func shuttleWS(
 				slog.Debug("ws backend write failed", "error", err)
 				goto done
 			}
+			if idleTimer != nil {
+				idleTimer.Reset(idleTTL)
+			}
+			if time.Since(lastTouch) > touchInterval {
+				srv.Sessions.Touch(sessionID)
+				lastTouch = time.Now()
+			}
 
 		case msg := <-br.msgs:
 			slog.Log(context.Background(), config.LevelTrace,
@@ -236,6 +267,13 @@ func shuttleWS(
 				slog.Debug("ws client write failed", "error", err)
 				cacheBackend = true
 				goto done
+			}
+			if idleTimer != nil {
+				idleTimer.Reset(idleTTL)
+			}
+			if time.Since(lastTouch) > touchInterval {
+				srv.Sessions.Touch(sessionID)
+				lastTouch = time.Now()
 			}
 
 		case <-clientDone:
@@ -250,6 +288,12 @@ func shuttleWS(
 		case <-lifetimeC:
 			// Session exceeded max lifetime — close both sides.
 			slog.Info("ws session max lifetime reached", "session_id", sessionID)
+			goto done
+
+		case <-idleC:
+			// No application-level messages for session_idle_ttl — close.
+			slog.Info("ws session idle timeout", "session_id", sessionID,
+				"idle_ttl", idleTTL)
 			goto done
 		}
 	}

--- a/internal/proxy/ws_idle_test.go
+++ b/internal/proxy/ws_idle_test.go
@@ -1,0 +1,219 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/cynkra/blockyard/internal/config"
+	"github.com/cynkra/blockyard/internal/server"
+	"github.com/cynkra/blockyard/internal/session"
+)
+
+// echoBackend returns an httptest server that echoes WebSocket messages.
+func echoBackend(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.CloseNow()
+		for {
+			typ, data, err := c.Read(context.Background())
+			if err != nil {
+				return
+			}
+			if err := c.Write(context.Background(), typ, data); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newWSTestServer(t *testing.T, idleTTL time.Duration) *server.Server {
+	t.Helper()
+	srv := testColdstartServer(t)
+	srv.Config.Proxy.SessionIdleTTL = config.Duration{Duration: idleTTL}
+	return srv
+}
+
+func TestWSIdleTimeout(t *testing.T) {
+	backend := echoBackend(t)
+	srv := newWSTestServer(t, 100*time.Millisecond)
+
+	sessionID := "idle-sess"
+	srv.Sessions.Set(sessionID, session.Entry{
+		WorkerID:   "w1",
+		LastAccess: time.Now(),
+	})
+	srv.Registry.Set("w1", backend.Listener.Addr().String())
+
+	cache := NewWsCache()
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		shuttleWS(w, r, backend.Listener.Addr().String(), "test-app", sessionID, cache, srv)
+	}))
+	t.Cleanup(proxy.Close)
+
+	conn, _, err := websocket.Dial(context.Background(),
+		"ws://"+proxy.Listener.Addr().String(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.CloseNow()
+
+	// No messages — idle timer should close the connection.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, _, err = conn.Read(ctx)
+	if err == nil {
+		t.Fatal("expected read error after idle timeout")
+	}
+}
+
+func TestWSIdleTimeoutResetOnMessage(t *testing.T) {
+	backend := echoBackend(t)
+	srv := newWSTestServer(t, 150*time.Millisecond)
+
+	sessionID := "active-sess"
+	srv.Sessions.Set(sessionID, session.Entry{
+		WorkerID:   "w1",
+		LastAccess: time.Now(),
+	})
+	srv.Registry.Set("w1", backend.Listener.Addr().String())
+
+	cache := NewWsCache()
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		shuttleWS(w, r, backend.Listener.Addr().String(), "test-app", sessionID, cache, srv)
+	}))
+	t.Cleanup(proxy.Close)
+
+	conn, _, err := websocket.Dial(context.Background(),
+		"ws://"+proxy.Listener.Addr().String(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.CloseNow()
+
+	// Send messages at 60% of idle TTL to keep the connection alive.
+	for i := 0; i < 4; i++ {
+		time.Sleep(90 * time.Millisecond)
+		if err := conn.Write(context.Background(), websocket.MessageText, []byte("ping")); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+		_, _, err := conn.Read(context.Background())
+		if err != nil {
+			t.Fatalf("read %d: unexpected close: %v", i, err)
+		}
+	}
+
+	// Stop sending — idle timer should fire after 150ms.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, _, err = conn.Read(ctx)
+	if err == nil {
+		t.Fatal("expected read error after idle timeout")
+	}
+}
+
+func TestWSIdleTimeoutDisabled(t *testing.T) {
+	backend := echoBackend(t)
+	srv := newWSTestServer(t, 0) // disabled
+
+	sessionID := "no-timeout-sess"
+	srv.Sessions.Set(sessionID, session.Entry{
+		WorkerID:   "w1",
+		LastAccess: time.Now(),
+	})
+	srv.Registry.Set("w1", backend.Listener.Addr().String())
+
+	cache := NewWsCache()
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		shuttleWS(w, r, backend.Listener.Addr().String(), "test-app", sessionID, cache, srv)
+	}))
+	t.Cleanup(proxy.Close)
+
+	conn, _, err := websocket.Dial(context.Background(),
+		"ws://"+proxy.Listener.Addr().String(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.CloseNow()
+
+	// Wait longer than any reasonable idle timeout would be.
+	time.Sleep(300 * time.Millisecond)
+
+	// Connection should still be alive — echo a message to verify.
+	if err := conn.Write(context.Background(), websocket.MessageText, []byte("hello")); err != nil {
+		t.Fatal("write failed, connection should still be open:", err)
+	}
+	_, data, err := conn.Read(context.Background())
+	if err != nil {
+		t.Fatal("read failed, connection should still be open:", err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("expected echo %q, got %q", "hello", data)
+	}
+}
+
+func TestWSTouchDuringMessages(t *testing.T) {
+	backend := echoBackend(t)
+	// Use a long idle TTL so the timer doesn't interfere, but Touch
+	// still fires (touchInterval is 30s, so we test with a short
+	// touchInterval by sending many messages quickly — the first Touch
+	// fires immediately since lastTouch starts at connection time and
+	// we set LastAccess to the past).
+	srv := newWSTestServer(t, 10*time.Second)
+
+	sessionID := "touch-sess"
+	old := time.Now().Add(-5 * time.Minute)
+	srv.Sessions.Set(sessionID, session.Entry{
+		WorkerID:   "w1",
+		LastAccess: old,
+	})
+	srv.Registry.Set("w1", backend.Listener.Addr().String())
+
+	cache := NewWsCache()
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		shuttleWS(w, r, backend.Listener.Addr().String(), "test-app", sessionID, cache, srv)
+	}))
+	t.Cleanup(proxy.Close)
+
+	conn, _, err := websocket.Dial(context.Background(),
+		"ws://"+proxy.Listener.Addr().String(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.CloseNow()
+
+	// Send a message to trigger the message path.
+	if err := conn.Write(context.Background(), websocket.MessageText, []byte("x")); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := conn.Read(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// The first message should have called Touch because lastTouch
+	// starts at time.Now() in shuttleWS and touchInterval is 30s.
+	// However, our initial LastAccess is 5 minutes in the past, so
+	// even without Touch the session record exists. The real test is
+	// that after 30s+ of messages Touch would fire. For a unit test
+	// we verify the session still exists (wasn't swept).
+	entry, ok := srv.Sessions.Get(sessionID)
+	if !ok {
+		t.Fatal("session should still exist")
+	}
+	// LastAccess should NOT have been updated yet (touchInterval=30s,
+	// only ~milliseconds have passed). This confirms Touch is
+	// rate-limited as designed.
+	if entry.LastAccess.After(old.Add(time.Second)) {
+		t.Error("Touch should not have fired yet (rate-limited to 30s)")
+	}
+}


### PR DESCRIPTION
## Summary
- Add idle timer to `shuttleWS` that closes WebSocket connections when no application-level messages flow within `session_idle_ttl`. Ping/pong frames (handled internally by coder/websocket) do not reset the timer.
- Fix latent bug: call `Touch()` during WS message forwarding (rate-limited to 30s) so active WebSocket sessions aren't incorrectly swept by `SweepIdle`.
- Change `session_idle_ttl` default from `1h` to `0` (disabled) to avoid surprising existing deployments. Operators opt in by setting e.g. `session_idle_ttl = "30m"`.

Closes #23