### PR TITLE
Fix unhandled writable file close in archive extraction

### DIFF
--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -131,10 +131,13 @@ func UnpackArchive(paths Paths) error {
 			}
 			remaining := maxDecompressedSize - totalWritten
 			n, copyErr := io.Copy(out, io.LimitReader(tr, remaining+1))
-			out.Close()
+			closeErr := out.Close()
 			totalWritten += n
 			if copyErr != nil {
 				return fmt.Errorf("write %s: %w", target, copyErr)
+			}
+			if closeErr != nil {
+				return fmt.Errorf("close %s: %w", target, closeErr)
 			}
 			if totalWritten > maxDecompressedSize {
 				return fmt.Errorf("decompressed content exceeds %d byte limit", maxDecompressedSize)


### PR DESCRIPTION
## Summary
- Check the error returned by `out.Close()` in `UnpackArchive` to avoid silent data loss when flushing buffered writes fails
- Resolves the `go/unhandled-writable-file-close` code scanning alert