### PR TITLE
Fix unsafe int64-to-int conversion in config env parsing

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -331,9 +331,8 @@ func applyEnvToStruct(v reflect.Value, prefix string) {
 					fv.Set(reflect.ValueOf(&f))
 				}
 			case reflect.Int:
-				if n, err := strconv.ParseInt(val, 10, 64); err == nil {
-					v := int(n)
-					fv.Set(reflect.ValueOf(&v))
+				if n, err := strconv.Atoi(val); err == nil {
+					fv.Set(reflect.ValueOf(&n))
 				}
 			case reflect.Int64:
 				if n, err := strconv.ParseInt(val, 10, 64); err == nil {


### PR DESCRIPTION
## Summary
- Replace `strconv.ParseInt(val, 10, 64)` + `int(n)` cast with `strconv.Atoi` in `applyEnvToStruct`, avoiding silent truncation on 32-bit platforms
- Resolves CodeQL alert #157 (`go/incorrect-integer-conversion`)