### PR TITLE
Fix unhandled writable file close across four call sites

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -95,7 +95,11 @@ func (l *Log) Run(ctx context.Context, path string) {
 		slog.Error("failed to open audit log", "path", path, "error", err)
 		return
 	}
-	defer f.Close()
+	defer func() {
+		if err := f.Close(); err != nil {
+			slog.Error("failed to close audit log", "path", path, "error", err)
+		}
+	}()
 
 	enc := json.NewEncoder(f)
 

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -131,10 +131,13 @@ func UnpackArchive(paths Paths) error {
 			}
 			remaining := maxDecompressedSize - totalWritten
 			n, copyErr := io.Copy(out, io.LimitReader(tr, remaining+1))
-			out.Close()
+			closeErr := out.Close()
 			totalWritten += n
 			if copyErr != nil {
 				return fmt.Errorf("write %s: %w", target, copyErr)
+			}
+			if closeErr != nil {
+				return fmt.Errorf("close %s: %w", target, closeErr)
 			}
 			if totalWritten > maxDecompressedSize {
 				return fmt.Errorf("decompressed content exceeds %d byte limit", maxDecompressedSize)

--- a/internal/bundle/preprocess.go
+++ b/internal/bundle/preprocess.go
@@ -83,9 +83,9 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close()
 
 	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
 		return err
 	}
 	return out.Close()

--- a/internal/server/transfer.go
+++ b/internal/server/transfer.go
@@ -264,7 +264,9 @@ func copyFile(src, dst string) error {
 		return err
 	}
 	if _, err := io.Copy(out, in); err != nil {
-		out.Close()
+		if closeErr := out.Close(); closeErr != nil {
+			err = fmt.Errorf("%w (close: %w)", err, closeErr)
+		}
 		os.Remove(tmp)
 		return err
 	}


### PR DESCRIPTION
## Summary
- Re-apply close-error check in `bundle.go` (regression from merge after #65)
- Check close error in `audit.go` deferred close with `slog.Error`
- Remove redundant `defer out.Close()` in `preprocess.go` `copyFile`, close explicitly in both paths
- Check close error in `transfer.go` `copyFile` error path, join with copy error