### PR TITLE
Migrate Docker client to Moby v29 modules (fixes #64)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/coder/websocket v1.8.14
 	github.com/coreos/go-oidc/v3 v3.12.0
 	github.com/docker/docker v28.3.3+incompatible
-	github.com/docker/go-connections v0.6.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/httprate v0.15.0
 	github.com/go-jose/go-jose/v4 v4.1.3
@@ -15,6 +14,9 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/jmoiron/sqlx v1.4.0
+	github.com/moby/moby/api v1.54.0
+	github.com/moby/moby/client v0.3.0
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/prometheus/client_golang v1.20.0
 	github.com/prometheus/client_model v0.6.1
 	github.com/robfig/cron/v3 v3.0.1
@@ -38,6 +40,7 @@ require (
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -62,12 +65,10 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/sys/atomicwriter v0.1.0 // indirect
-	github.com/moby/term v0.5.2 // indirect
 	github.com/morikuni/aec v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
@@ -80,7 +81,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.33.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.42.0 // indirect
 	go.opentelemetry.io/otel/metric v1.42.0 // indirect
 	go.opentelemetry.io/otel/trace v1.42.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
@@ -94,7 +95,6 @@ require (
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	gotest.tools/v3 v3.5.2 // indirect
 	modernc.org/libc v1.55.3 // indirect
 	modernc.org/mathutil v1.6.0 // indirect
 	modernc.org/memory v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/agiledragon/gomonkey/v2 v2.3.1 h1:k+UnUY0EMNYUFUAQVETGY9uUTxjMdnUkP0A
 github.com/agiledragon/gomonkey/v2 v2.3.1/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
-github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -131,6 +129,10 @@ github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
+github.com/moby/moby/api v1.54.0 h1:7kbUgyiKcoBhm0UrWbdrMs7RX8dnwzURKVbZGy2GnL0=
+github.com/moby/moby/api v1.54.0/go.mod h1:8mb+ReTlisw4pS6BRzCMts5M49W5M7bKt1cJy/YbAqc=
+github.com/moby/moby/client v0.3.0 h1:UUGL5okry+Aomj3WhGt9Aigl3ZOxZGqR7XPo+RLPlKs=
+github.com/moby/moby/client v0.3.0/go.mod h1:HJgFbJRvogDQjbM8fqc1MCEm4mIAGMLjXbgwoZp6jCQ=
 github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=
 github.com/moby/sys/atomicwriter v0.1.0/go.mod h1:Ul8oqv2ZMNHOceF643P6FKPXeCmYtlQMvpizfsSoaWs=
 github.com/moby/sys/sequential v0.6.0 h1:qrx7XFUd/5DxtqcoH1h438hF5TmOvzC/lspjy7zgvCU=
@@ -213,8 +215,8 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0 h1:THuZiwpQZuHPul65w4W
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0/go.mod h1:J2pvYM5NGHofZ2/Ru6zw/TNWnEQp5crgyDeSrYpXkAw=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0 h1:zWWrB1U6nqhS/k6zYB74CjRpuiitRtLLi68VcgmOEto=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0/go.mod h1:2qXPNBX1OVRC0IwOnfo1ljoid+RD0QK3443EaqVlsOU=
-go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.33.0 h1:wpMfgF8E1rkrT1Z6meFh1NDtownE9Ii3n3X2GJYjsaU=
-go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.33.0/go.mod h1:wAy0T/dUbs468uOlkT31xjvqQgEVXv58BRFWEgn5v/0=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.42.0 h1:uLXP+3mghfMf7XmV4PkGfFhFKuNWoCvvx5wP/wOXo0o=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.42.0/go.mod h1:v0Tj04armyT59mnURNUJf7RCKcKzq+lgJs6QSjHjaTc=
 go.opentelemetry.io/otel/metric v1.42.0 h1:2jXG+3oZLNXEPfNmnpxKDeZsFI5o4J+nz6xUlaFdF/4=
 go.opentelemetry.io/otel/metric v1.42.0/go.mod h1:RlUN/7vTU7Ao/diDkEpQpnz3/92J9ko05BIwxYa2SSI=
 go.opentelemetry.io/otel/sdk v1.42.0 h1:LyC8+jqk6UJwdrI/8VydAq/hvkFKNHZVIWuslJXYsDo=
@@ -318,3 +320,5 @@ modernc.org/strutil v1.2.0 h1:agBi9dp1I+eOnxXeiZawM8F4LawKv4NzGWSaLfyeNZA=
 modernc.org/strutil v1.2.0/go.mod h1:/mdcBmfOibveCTBxUl5B5l6W+TTH1FXPLHZE6bTosX0=
 modernc.org/token v1.1.0 h1:Xl7Ap9dKaEs5kLoOQeQmPWevfnk/DM5qcLcYlA8ys6Y=
 modernc.org/token v1.1.0/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
+pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
+pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=

--- a/internal/auth/idp_test.go
+++ b/internal/auth/idp_test.go
@@ -16,10 +16,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/client"
-	"github.com/docker/go-connections/nat"
+	"net/netip"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
 
 	"github.com/cynkra/blockyard/internal/auth"
 	"github.com/cynkra/blockyard/internal/config"
@@ -42,7 +43,7 @@ var containerID string
 func TestMain(m *testing.M) {
 	ctx := context.Background()
 
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, err := client.New(client.FromEnv)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "docker client: %v\n", err)
 		os.Exit(1)
@@ -50,13 +51,13 @@ func TestMain(m *testing.M) {
 	defer cli.Close()
 
 	// Pull image (may already be cached from CI pre-pull step).
-	reader, err := cli.ImagePull(ctx, keycloakImage, image.PullOptions{})
+	pullResp, err := cli.ImagePull(ctx, keycloakImage, client.ImagePullOptions{})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "image pull: %v\n", err)
 		os.Exit(1)
 	}
-	io.Copy(io.Discard, reader)
-	reader.Close()
+	io.Copy(io.Discard, pullResp)
+	pullResp.Close()
 
 	// Resolve the absolute path to the realm import file.
 	realmFile, err := filepath.Abs("testdata/blockyard-test-realm.json")
@@ -66,48 +67,48 @@ func TestMain(m *testing.M) {
 	}
 
 	// Create Keycloak container.
-	kcPort := nat.Port("8080/tcp")
-	resp, err := cli.ContainerCreate(ctx,
-		&container.Config{
+	kcPort := network.MustParsePort("8080/tcp")
+	resp, err := cli.ContainerCreate(ctx, client.ContainerCreateOptions{
+		Config: &container.Config{
 			Image: keycloakImage,
 			Cmd:   []string{"start-dev", "--import-realm", "--health-enabled=true"},
 			Env: []string{
 				"KEYCLOAK_ADMIN=admin",
 				"KEYCLOAK_ADMIN_PASSWORD=admin",
 			},
-			ExposedPorts: nat.PortSet{kcPort: struct{}{}},
+			ExposedPorts: network.PortSet{kcPort: struct{}{}},
 			Labels:       map[string]string{"blockyard-test": "idp"},
 		},
-		&container.HostConfig{
-			PortBindings: nat.PortMap{
-				kcPort: []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: "0"}},
+		HostConfig: &container.HostConfig{
+			PortBindings: network.PortMap{
+				kcPort: []network.PortBinding{{HostIP: netip.MustParseAddr("127.0.0.1"), HostPort: "0"}},
 			},
 			Binds: []string{
 				realmFile + ":/opt/keycloak/data/import/blockyard-test-realm.json:ro",
 			},
 		},
-		nil, nil, "blockyard-idp-test",
-	)
+		Name: "blockyard-idp-test",
+	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "container create: %v\n", err)
 		os.Exit(1)
 	}
 	containerID = resp.ID
 
-	if err := cli.ContainerStart(ctx, containerID, container.StartOptions{}); err != nil {
+	if _, err := cli.ContainerStart(ctx, containerID, client.ContainerStartOptions{}); err != nil {
 		fmt.Fprintf(os.Stderr, "container start: %v\n", err)
-		cli.ContainerRemove(ctx, containerID, container.RemoveOptions{Force: true})
+		cli.ContainerRemove(ctx, containerID, client.ContainerRemoveOptions{Force: true})
 		os.Exit(1)
 	}
 
 	// Get the mapped port.
-	inspect, err := cli.ContainerInspect(ctx, containerID)
+	cResult, err := cli.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "container inspect: %v\n", err)
 		cleanup(ctx, cli)
 		os.Exit(1)
 	}
-	bindings := inspect.NetworkSettings.Ports[kcPort]
+	bindings := cResult.Container.NetworkSettings.Ports[kcPort]
 	if len(bindings) == 0 {
 		fmt.Fprintf(os.Stderr, "no port bindings for %s\n", kcPort)
 		cleanup(ctx, cli)
@@ -137,7 +138,7 @@ func TestMain(m *testing.M) {
 	if !ready {
 		fmt.Fprintf(os.Stderr, "keycloak did not become ready within 120s\n")
 		// Dump container logs for debugging.
-		if logReader, logErr := cli.ContainerLogs(ctx, containerID, container.LogsOptions{
+		if logReader, logErr := cli.ContainerLogs(ctx, containerID, client.ContainerLogsOptions{
 			ShowStdout: true, ShowStderr: true,
 		}); logErr == nil {
 			fmt.Fprintf(os.Stderr, "--- keycloak container logs ---\n")
@@ -156,8 +157,8 @@ func TestMain(m *testing.M) {
 
 func cleanup(ctx context.Context, cli *client.Client) {
 	timeout := 10
-	cli.ContainerStop(ctx, containerID, container.StopOptions{Timeout: &timeout})
-	cli.ContainerRemove(ctx, containerID, container.RemoveOptions{Force: true})
+	cli.ContainerStop(ctx, containerID, client.ContainerStopOptions{Timeout: &timeout})
+	cli.ContainerRemove(ctx, containerID, client.ContainerRemoveOptions{Force: true})
 }
 
 // noRedirectClient returns an HTTP client that never follows redirects.

--- a/internal/backend/docker/detect.go
+++ b/internal/backend/docker/detect.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+
+	"github.com/moby/moby/client"
 )
 
 // detectMountMode inspects the server's own container to determine how
@@ -25,7 +27,7 @@ func detectMountMode(ctx context.Context, cli dockerClient, serverID, dataPath s
 		return MountConfig{Mode: MountModeNative}, nil
 	}
 
-	info, err := cli.ContainerInspect(ctx, serverID)
+	cResult, err := cli.ContainerInspect(ctx, serverID, client.ContainerInspectOptions{})
 	if err != nil {
 		return MountConfig{}, fmt.Errorf("mount auto-detect: inspect container %s: %w", serverID, err)
 	}
@@ -35,7 +37,7 @@ func detectMountMode(ctx context.Context, cli dockerClient, serverID, dataPath s
 	var bestCfg MountConfig
 	found := false
 
-	for _, m := range info.Mounts {
+	for _, m := range cResult.Container.Mounts {
 		dest := m.Destination
 		if !pathIsPrefix(dest, dataPath) {
 			continue

--- a/internal/backend/docker/docker.go
+++ b/internal/backend/docker/docker.go
@@ -16,14 +16,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/api/types/mount"
-	"github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/stdcopy"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/mount"
+	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/api/pkg/stdcopy"
+	"github.com/moby/moby/client"
 
 	"github.com/cynkra/blockyard/internal/backend"
 	"github.com/cynkra/blockyard/internal/config"
@@ -36,23 +33,23 @@ var _ backend.Backend = (*DockerBackend)(nil)
 // enabling unit tests to supply a mock instead of a real daemon connection.
 // The concrete *client.Client satisfies this interface.
 type dockerClient interface {
-	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
-	ContainerInspect(ctx context.Context, containerID string) (container.InspectResponse, error)
-	ContainerList(ctx context.Context, options container.ListOptions) ([]container.Summary, error)
-	ContainerLogs(ctx context.Context, container string, options container.LogsOptions) (io.ReadCloser, error)
-	ContainerRemove(ctx context.Context, containerID string, options container.RemoveOptions) error
-	ContainerStart(ctx context.Context, containerID string, options container.StartOptions) error
-	ContainerStatsOneShot(ctx context.Context, containerID string) (container.StatsResponseReader, error)
-	ContainerStop(ctx context.Context, containerID string, options container.StopOptions) error
-	ContainerWait(ctx context.Context, containerID string, condition container.WaitCondition) (<-chan container.WaitResponse, <-chan error)
-	ImageInspect(ctx context.Context, imageID string, opts ...client.ImageInspectOption) (image.InspectResponse, error)
-	ImagePull(ctx context.Context, refStr string, options image.PullOptions) (io.ReadCloser, error)
-	NetworkConnect(ctx context.Context, networkID, containerID string, config *network.EndpointSettings) error
-	NetworkCreate(ctx context.Context, name string, options network.CreateOptions) (network.CreateResponse, error)
-	NetworkDisconnect(ctx context.Context, networkID, containerID string, force bool) error
-	NetworkInspect(ctx context.Context, networkID string, options network.InspectOptions) (network.Inspect, error)
-	NetworkList(ctx context.Context, options network.ListOptions) ([]network.Summary, error)
-	NetworkRemove(ctx context.Context, networkID string) error
+	ContainerCreate(ctx context.Context, options client.ContainerCreateOptions) (client.ContainerCreateResult, error)
+	ContainerInspect(ctx context.Context, containerID string, options client.ContainerInspectOptions) (client.ContainerInspectResult, error)
+	ContainerList(ctx context.Context, options client.ContainerListOptions) (client.ContainerListResult, error)
+	ContainerLogs(ctx context.Context, containerID string, options client.ContainerLogsOptions) (client.ContainerLogsResult, error)
+	ContainerRemove(ctx context.Context, containerID string, options client.ContainerRemoveOptions) (client.ContainerRemoveResult, error)
+	ContainerStart(ctx context.Context, containerID string, options client.ContainerStartOptions) (client.ContainerStartResult, error)
+	ContainerStats(ctx context.Context, containerID string, options client.ContainerStatsOptions) (client.ContainerStatsResult, error)
+	ContainerStop(ctx context.Context, containerID string, options client.ContainerStopOptions) (client.ContainerStopResult, error)
+	ContainerWait(ctx context.Context, containerID string, options client.ContainerWaitOptions) client.ContainerWaitResult
+	ImageInspect(ctx context.Context, imageID string, opts ...client.ImageInspectOption) (client.ImageInspectResult, error)
+	ImagePull(ctx context.Context, refStr string, options client.ImagePullOptions) (client.ImagePullResponse, error)
+	NetworkConnect(ctx context.Context, networkID string, options client.NetworkConnectOptions) (client.NetworkConnectResult, error)
+	NetworkCreate(ctx context.Context, name string, options client.NetworkCreateOptions) (client.NetworkCreateResult, error)
+	NetworkDisconnect(ctx context.Context, networkID string, options client.NetworkDisconnectOptions) (client.NetworkDisconnectResult, error)
+	NetworkInspect(ctx context.Context, networkID string, options client.NetworkInspectOptions) (client.NetworkInspectResult, error)
+	NetworkList(ctx context.Context, options client.NetworkListOptions) (client.NetworkListResult, error)
+	NetworkRemove(ctx context.Context, networkID string, options client.NetworkRemoveOptions) (client.NetworkRemoveResult, error)
 }
 
 // cmdRunner executes a system command and returns its combined output.
@@ -100,15 +97,14 @@ type DockerBackend struct {
 // whether the server is running inside a container, and auto-detecting
 // how the data directory is mounted.
 func New(ctx context.Context, cfg *config.DockerConfig, bundleServerPath string) (*DockerBackend, error) {
-	cli, err := client.NewClientWithOpts(
+	cli, err := client.New(
 		client.WithHost("unix://"+cfg.Socket),
-		client.WithAPIVersionNegotiation(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("docker client: %w", err)
 	}
 
-	if _, err := cli.Ping(ctx); err != nil {
+	if _, err := cli.Ping(ctx, client.PingOptions{}); err != nil {
 		return nil, fmt.Errorf("docker ping: %w", err)
 	}
 
@@ -248,14 +244,14 @@ func (d *DockerBackend) ensureImage(ctx context.Context, img string) error {
 	}
 
 	slog.Info("pulling image", "image", img)
-	reader, err := d.client.ImagePull(ctx, img, image.PullOptions{})
+	pullResp, err := d.client.ImagePull(ctx, img, client.ImagePullOptions{})
 	if err != nil {
 		return fmt.Errorf("pull image %s: %w", img, err)
 	}
-	defer reader.Close()
+	defer pullResp.Close()
 
 	// Must consume the reader for the pull to complete.
-	if _, err := io.Copy(io.Discard, reader); err != nil {
+	if _, err := io.Copy(io.Discard, pullResp); err != nil {
 		return fmt.Errorf("pull image %s: %w", img, err)
 	}
 
@@ -309,7 +305,7 @@ func (d *DockerBackend) createNetwork(
 	ctx context.Context,
 	name, appID, workerID string,
 ) (string, error) {
-	resp, err := d.client.NetworkCreate(ctx, name, network.CreateOptions{
+	resp, err := d.client.NetworkCreate(ctx, name, client.NetworkCreateOptions{
 		Driver: "bridge",
 		Labels: networkLabels(appID, workerID),
 	})
@@ -320,15 +316,20 @@ func (d *DockerBackend) createNetwork(
 }
 
 func (d *DockerBackend) joinNetwork(ctx context.Context, containerID, networkName string, aliases []string) error {
-	var epConfig *network.EndpointSettings
+	opts := client.NetworkConnectOptions{Container: containerID}
 	if len(aliases) > 0 {
-		epConfig = &network.EndpointSettings{Aliases: aliases}
+		opts.EndpointConfig = &network.EndpointSettings{Aliases: aliases}
 	}
-	return d.client.NetworkConnect(ctx, networkName, containerID, epConfig)
+	_, err := d.client.NetworkConnect(ctx, networkName, opts)
+	return err
 }
 
 func (d *DockerBackend) disconnectNetwork(ctx context.Context, containerID, networkName string) error {
-	return d.client.NetworkDisconnect(ctx, networkName, containerID, true)
+	_, err := d.client.NetworkDisconnect(ctx, networkName, client.NetworkDisconnectOptions{
+		Container: containerID,
+		Force:     true,
+	})
+	return err
 }
 
 // connectServiceContainers inspects the configured service network and
@@ -340,25 +341,25 @@ func (d *DockerBackend) connectServiceContainers(ctx context.Context, workerNetw
 		return nil
 	}
 
-	info, err := d.client.NetworkInspect(ctx, svcNet, network.InspectOptions{})
+	netResult, err := d.client.NetworkInspect(ctx, svcNet, client.NetworkInspectOptions{})
 	if err != nil {
 		return fmt.Errorf("inspect service network %s: %w", svcNet, err)
 	}
 
-	for containerID := range info.Containers {
+	for containerID := range netResult.Network.Containers {
 		if containerID == d.serverID {
 			continue // server joins with "blockyard" alias separately
 		}
 
 		// Get DNS aliases from the service network endpoint.
 		var aliases []string
-		cInfo, err := d.client.ContainerInspect(ctx, containerID)
+		cResult, err := d.client.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
 		if err != nil {
 			slog.Warn("service network: cannot inspect container, skipping",
 				"container_id", containerID, "error", err)
 			continue
 		}
-		if ep, ok := cInfo.NetworkSettings.Networks[svcNet]; ok && ep != nil {
+		if ep, ok := cResult.Container.NetworkSettings.Networks[svcNet]; ok && ep != nil {
 			aliases = ep.Aliases
 		}
 
@@ -384,14 +385,14 @@ func (d *DockerBackend) disconnectServiceContainers(ctx context.Context, workerN
 		return
 	}
 
-	info, err := d.client.NetworkInspect(ctx, svcNet, network.InspectOptions{})
+	netResult, err := d.client.NetworkInspect(ctx, svcNet, client.NetworkInspectOptions{})
 	if err != nil {
 		slog.Warn("service network: cannot inspect for disconnect",
 			"service_network", svcNet, "error", err)
 		return
 	}
 
-	for containerID := range info.Containers {
+	for containerID := range netResult.Network.Containers {
 		if containerID == d.serverID {
 			continue
 		}
@@ -446,14 +447,14 @@ func (d *DockerBackend) createWorkerContainer(
 	}
 	resources.PidsLimit = int64Ptr(512)
 
-	resp, err := d.client.ContainerCreate(ctx,
-		&container.Config{
+	resp, err := d.client.ContainerCreate(ctx, client.ContainerCreateOptions{
+		Config: &container.Config{
 			Image:  spec.Image,
 			Cmd:    spec.Cmd,
 			Env:    env,
 			Labels: workerLabels(spec),
 		},
-		&container.HostConfig{
+		HostConfig: &container.HostConfig{
 			NetworkMode:    container.NetworkMode(networkName),
 			Binds:          binds,
 			Mounts:         mounts,
@@ -463,9 +464,8 @@ func (d *DockerBackend) createWorkerContainer(
 			ReadonlyRootfs: true,
 			Resources:      resources,
 		},
-		nil, nil,
-		containerName,
-	)
+		Name: containerName,
+	})
 	if err != nil {
 		return "", fmt.Errorf("create container %s: %w", containerName, err)
 	}
@@ -507,7 +507,7 @@ func (d *DockerBackend) Spawn(ctx context.Context, spec backend.WorkerSpec) erro
 	// 3. Block metadata endpoint (iptables)
 	slog.Debug("spawn: blocking metadata endpoint", "worker_id", spec.WorkerID)
 	if err := d.blockMetadataEndpoint(ctx, networkName, spec.WorkerID); err != nil {
-		_ = d.client.NetworkRemove(ctx, networkID)
+		_, _ = d.client.NetworkRemove(ctx, networkID, client.NetworkRemoveOptions{})
 		return fmt.Errorf("spawn: metadata block: %w", err)
 	}
 
@@ -517,7 +517,7 @@ func (d *DockerBackend) Spawn(ctx context.Context, spec backend.WorkerSpec) erro
 	containerID, err := d.createWorkerContainer(ctx, spec, networkName)
 	if err != nil {
 		d.unblockMetadataForWorker(spec.WorkerID)
-		_ = d.client.NetworkRemove(ctx, networkID)
+		_, _ = d.client.NetworkRemove(ctx, networkID, client.NetworkRemoveOptions{})
 		return fmt.Errorf("spawn: %w", err)
 	}
 
@@ -526,9 +526,9 @@ func (d *DockerBackend) Spawn(ctx context.Context, spec backend.WorkerSpec) erro
 		slog.Debug("spawn: connecting service containers",
 			"worker_id", spec.WorkerID, "service_network", d.config.ServiceNetwork)
 		if err := d.connectServiceContainers(ctx, networkName); err != nil {
-			_ = d.client.ContainerRemove(ctx, containerID, container.RemoveOptions{Force: true})
+			_, _ = d.client.ContainerRemove(ctx, containerID, client.ContainerRemoveOptions{Force: true})
 			d.unblockMetadataForWorker(spec.WorkerID)
-			_ = d.client.NetworkRemove(ctx, networkID)
+			_, _ = d.client.NetworkRemove(ctx, networkID, client.NetworkRemoveOptions{})
 			return fmt.Errorf("spawn: %w", err)
 		}
 	}
@@ -539,23 +539,23 @@ func (d *DockerBackend) Spawn(ctx context.Context, spec backend.WorkerSpec) erro
 			"worker_id", spec.WorkerID, "server_id", d.serverID)
 		if err := d.joinNetwork(ctx, d.serverID, networkName, []string{"blockyard"}); err != nil {
 			d.disconnectServiceContainers(ctx, networkName)
-			_ = d.client.ContainerRemove(ctx, containerID, container.RemoveOptions{Force: true})
+			_, _ = d.client.ContainerRemove(ctx, containerID, client.ContainerRemoveOptions{Force: true})
 			d.unblockMetadataForWorker(spec.WorkerID)
-			_ = d.client.NetworkRemove(ctx, networkID)
+			_, _ = d.client.NetworkRemove(ctx, networkID, client.NetworkRemoveOptions{})
 			return fmt.Errorf("spawn: %w", err)
 		}
 	}
 
 	// 7. Start the container
 	slog.Debug("spawn: starting container", "worker_id", spec.WorkerID, "container_id", containerID)
-	if err := d.client.ContainerStart(ctx, containerID, container.StartOptions{}); err != nil {
+	if _, err := d.client.ContainerStart(ctx, containerID, client.ContainerStartOptions{}); err != nil {
 		if d.serverID != "" {
 			_ = d.disconnectNetwork(ctx, d.serverID, networkName)
 		}
 		d.disconnectServiceContainers(ctx, networkName)
-		_ = d.client.ContainerRemove(ctx, containerID, container.RemoveOptions{Force: true})
+		_, _ = d.client.ContainerRemove(ctx, containerID, client.ContainerRemoveOptions{Force: true})
 		d.unblockMetadataForWorker(spec.WorkerID)
-		_ = d.client.NetworkRemove(ctx, networkID)
+		_, _ = d.client.NetworkRemove(ctx, networkID, client.NetworkRemoveOptions{})
 		return fmt.Errorf("spawn: start container: %w", err)
 	}
 
@@ -585,12 +585,13 @@ func (d *DockerBackend) verifyResourceLimits(
 	containerID string,
 	spec backend.WorkerSpec,
 ) {
-	info, err := d.client.ContainerInspect(ctx, containerID)
+	cResult, err := d.client.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
 	if err != nil {
 		slog.Warn("spawn: failed to verify resource limits",
 			"worker_id", spec.WorkerID, "error", err)
 		return
 	}
+	info := cResult.Container
 
 	if spec.MemoryLimit != "" {
 		expected, ok := ParseMemoryLimit(spec.MemoryLimit)
@@ -631,7 +632,7 @@ func (d *DockerBackend) Stop(ctx context.Context, id string) error {
 
 	// 1. Stop the container (10s timeout)
 	timeout := 10
-	if err := d.client.ContainerStop(ctx, ws.containerID, container.StopOptions{
+	if _, err := d.client.ContainerStop(ctx, ws.containerID, client.ContainerStopOptions{
 		Timeout: &timeout,
 	}); err != nil && firstErr == nil {
 		firstErr = fmt.Errorf("stop container: %w", err)
@@ -639,7 +640,7 @@ func (d *DockerBackend) Stop(ctx context.Context, id string) error {
 	}
 
 	// 2. Remove the container
-	if err := d.client.ContainerRemove(ctx, ws.containerID, container.RemoveOptions{
+	if _, err := d.client.ContainerRemove(ctx, ws.containerID, client.ContainerRemoveOptions{
 		Force: true,
 	}); err != nil {
 		slog.Warn("failed to remove container", "worker_id", id, "error", err)
@@ -659,7 +660,7 @@ func (d *DockerBackend) Stop(ctx context.Context, id string) error {
 	d.unblockMetadataForWorker(id)
 
 	// 6. Remove the network
-	if err := d.client.NetworkRemove(ctx, ws.networkName); err != nil {
+	if _, err := d.client.NetworkRemove(ctx, ws.networkName, client.NetworkRemoveOptions{}); err != nil {
 		slog.Warn("failed to remove network", "worker_id", id, "error", err)
 	}
 
@@ -692,7 +693,7 @@ func (d *DockerBackend) Logs(ctx context.Context, id string) (backend.LogStream,
 		return backend.LogStream{}, fmt.Errorf("logs: unknown worker %s", id)
 	}
 
-	reader, err := d.client.ContainerLogs(ctx, ws.containerID, container.LogsOptions{
+	reader, err := d.client.ContainerLogs(ctx, ws.containerID, client.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
 		Follow:     true,
@@ -732,10 +733,11 @@ func (d *DockerBackend) Addr(ctx context.Context, id string) (string, error) {
 		return "", fmt.Errorf("addr: unknown worker %s", id)
 	}
 
-	info, err := d.client.ContainerInspect(ctx, ws.containerID)
+	cResult, err := d.client.ContainerInspect(ctx, ws.containerID, client.ContainerInspectOptions{})
 	if err != nil {
 		return "", fmt.Errorf("addr: inspect container: %w", err)
 	}
+	info := cResult.Container
 
 	if info.NetworkSettings == nil || info.NetworkSettings.Networks == nil {
 		return "", fmt.Errorf("addr: no networks on container %s", id)
@@ -746,7 +748,7 @@ func (d *DockerBackend) Addr(ctx context.Context, id string) (string, error) {
 		return "", fmt.Errorf("addr: container not on network %s", ws.networkName)
 	}
 
-	if endpoint.IPAddress == "" {
+	if !endpoint.IPAddress.IsValid() {
 		return "", fmt.Errorf("addr: no IP on network %s", ws.networkName)
 	}
 
@@ -766,7 +768,7 @@ func (d *DockerBackend) Build(ctx context.Context, spec backend.BuildSpec) (back
 		return backend.BuildResult{}, fmt.Errorf("build: %w", err)
 	}
 	defer func() {
-		d.client.NetworkRemove(ctx, buildNetworkName) //nolint:errcheck // best-effort cleanup
+		d.client.NetworkRemove(ctx, buildNetworkName, client.NetworkRemoveOptions{}) //nolint:errcheck // best-effort cleanup
 	}()
 
 	if err := d.blockMetadataEndpoint(ctx, buildNetworkName, "build-"+spec.BundleID); err != nil {
@@ -787,15 +789,15 @@ func (d *DockerBackend) Build(ctx context.Context, spec backend.BuildSpec) (back
 		mounts = append(mounts, dm...)
 	}
 
-	resp, err := d.client.ContainerCreate(ctx,
-		&container.Config{
+	resp, err := d.client.ContainerCreate(ctx, client.ContainerCreateOptions{
+		Config: &container.Config{
 			Image:      spec.Image,
 			Cmd:        spec.Cmd,
 			WorkingDir: "/app",
 			Labels:     buildLabels(spec),
 			Env:        spec.Env,
 		},
-		&container.HostConfig{
+		HostConfig: &container.HostConfig{
 			NetworkMode: container.NetworkMode(buildNetworkName),
 			Binds:       binds,
 			Mounts:      mounts,
@@ -809,9 +811,8 @@ func (d *DockerBackend) Build(ctx context.Context, spec backend.BuildSpec) (back
 				PidsLimit: int64Ptr(512),
 			},
 		},
-		nil, nil,
-		containerName,
-	)
+		Name: containerName,
+	})
 	if err != nil {
 		return backend.BuildResult{}, fmt.Errorf("build: create container: %w", err)
 	}
@@ -819,14 +820,14 @@ func (d *DockerBackend) Build(ctx context.Context, spec backend.BuildSpec) (back
 	containerID := resp.ID
 
 	// 4. Start the build container
-	if err := d.client.ContainerStart(ctx, containerID, container.StartOptions{}); err != nil {
-		_ = d.client.ContainerRemove(ctx, containerID, container.RemoveOptions{Force: true})
+	if _, err := d.client.ContainerStart(ctx, containerID, client.ContainerStartOptions{}); err != nil {
+		_, _ = d.client.ContainerRemove(ctx, containerID, client.ContainerRemoveOptions{Force: true})
 		return backend.BuildResult{}, fmt.Errorf("build: start container: %w", err)
 	}
 
 	// 5. Stream logs in real-time while the build runs.
 	var buildLogs strings.Builder
-	if logReader, logErr := d.client.ContainerLogs(ctx, containerID, container.LogsOptions{
+	if logReader, logErr := d.client.ContainerLogs(ctx, containerID, client.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
 		Follow:     true,
@@ -844,13 +845,15 @@ func (d *DockerBackend) Build(ctx context.Context, spec backend.BuildSpec) (back
 	}
 
 	// 6. Wait for exit (container has already stopped since log follow ended).
-	waitCh, errCh := d.client.ContainerWait(ctx, containerID, container.WaitConditionNotRunning)
+	waitResult := d.client.ContainerWait(ctx, containerID, client.ContainerWaitOptions{
+		Condition: container.WaitConditionNotRunning,
+	})
 
 	var exitCode int
 	select {
-	case result := <-waitCh:
+	case result := <-waitResult.Result:
 		exitCode = int(result.StatusCode)
-	case err := <-errCh:
+	case err := <-waitResult.Error:
 		slog.Warn("build container wait error", "error", err)
 		exitCode = -1
 	case <-ctx.Done():
@@ -861,7 +864,7 @@ func (d *DockerBackend) Build(ctx context.Context, spec backend.BuildSpec) (back
 	success := exitCode == 0
 
 	// 7. Remove the build container
-	_ = d.client.ContainerRemove(ctx, containerID, container.RemoveOptions{Force: true})
+	_, _ = d.client.ContainerRemove(ctx, containerID, client.ContainerRemoveOptions{Force: true})
 
 	return backend.BuildResult{
 		Success:  success,
@@ -874,16 +877,14 @@ func (d *DockerBackend) ListManaged(ctx context.Context) ([]backend.ManagedResou
 	var resources []backend.ManagedResource
 
 	// Find managed containers (including stopped)
-	containers, err := d.client.ContainerList(ctx, container.ListOptions{
-		All: true,
-		Filters: filters.NewArgs(
-			filters.Arg("label", "dev.blockyard/managed=true"),
-		),
+	containerResult, err := d.client.ContainerList(ctx, client.ContainerListOptions{
+		All:     true,
+		Filters: make(client.Filters).Add("label", "dev.blockyard/managed=true"),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list managed containers: %w", err)
 	}
-	for _, c := range containers {
+	for _, c := range containerResult.Items {
 		resources = append(resources, backend.ManagedResource{
 			ID:     c.ID,
 			Kind:   backend.ResourceContainer,
@@ -892,15 +893,13 @@ func (d *DockerBackend) ListManaged(ctx context.Context) ([]backend.ManagedResou
 	}
 
 	// Find managed networks
-	networks, err := d.client.NetworkList(ctx, network.ListOptions{
-		Filters: filters.NewArgs(
-			filters.Arg("label", "dev.blockyard/managed=true"),
-		),
+	networkResult, err := d.client.NetworkList(ctx, client.NetworkListOptions{
+		Filters: make(client.Filters).Add("label", "dev.blockyard/managed=true"),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list managed networks: %w", err)
 	}
-	for _, n := range networks {
+	for _, n := range networkResult.Items {
 		resources = append(resources, backend.ManagedResource{
 			ID:     n.ID,
 			Kind:   backend.ResourceNetwork,
@@ -917,7 +916,9 @@ func (d *DockerBackend) ListManaged(ctx context.Context) ([]backend.ManagedResou
 }
 
 func (d *DockerBackend) ContainerStats(ctx context.Context, containerID string) (*backend.ContainerStatsResult, error) {
-	resp, err := d.client.ContainerStatsOneShot(ctx, containerID)
+	resp, err := d.client.ContainerStats(ctx, containerID, client.ContainerStatsOptions{
+		IncludePreviousSample: true,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("container stats: %w", err)
 	}
@@ -971,9 +972,11 @@ func (d *DockerBackend) ContainerStats(ctx context.Context, containerID string) 
 func (d *DockerBackend) RemoveResource(ctx context.Context, r backend.ManagedResource) error {
 	switch r.Kind {
 	case backend.ResourceContainer:
-		return d.client.ContainerRemove(ctx, r.ID, container.RemoveOptions{Force: true})
+		_, err := d.client.ContainerRemove(ctx, r.ID, client.ContainerRemoveOptions{Force: true})
+		return err
 	case backend.ResourceNetwork:
-		return d.client.NetworkRemove(ctx, r.ID)
+		_, err := d.client.NetworkRemove(ctx, r.ID, client.NetworkRemoveOptions{})
+		return err
 	default:
 		return fmt.Errorf("unknown resource kind: %d", r.Kind)
 	}
@@ -1014,20 +1017,20 @@ func (d *DockerBackend) blockMetadataEndpoint(ctx context.Context, networkName, 
 	// First spawn — detect capabilities
 
 	// Inspect network to get subnet CIDR
-	info, err := d.client.NetworkInspect(ctx, networkName, network.InspectOptions{})
+	netResult, err := d.client.NetworkInspect(ctx, networkName, client.NetworkInspectOptions{})
 	if err != nil {
 		return fmt.Errorf("inspect network for metadata rule: %w", err)
 	}
-	if len(info.IPAM.Config) == 0 {
+	if len(netResult.Network.IPAM.Config) == 0 {
 		return fmt.Errorf("network %s has no IPAM config", networkName)
 	}
-	subnet := info.IPAM.Config[0].Subnet
+	subnet := netResult.Network.IPAM.Config[0].Subnet
 
 	// Try inserting iptables rule
 	comment := "blockyard-" + workerID
 	_, insertErr := d.runCmd(ctx, "iptables",
 		"-I", "DOCKER-USER",
-		"-s", subnet,
+		"-s", subnet.String(),
 		"-d", "169.254.169.254/32",
 		"-j", "DROP",
 		"-m", "comment", "--comment", comment,
@@ -1110,19 +1113,19 @@ func dockerUserBlocksMetadataWithRunner(run cmdRunner) bool {
 }
 
 func (d *DockerBackend) insertMetadataRule(ctx context.Context, networkName, workerID string) error {
-	info, err := d.client.NetworkInspect(ctx, networkName, network.InspectOptions{})
+	netResult, err := d.client.NetworkInspect(ctx, networkName, client.NetworkInspectOptions{})
 	if err != nil {
 		return fmt.Errorf("inspect network for metadata rule: %w", err)
 	}
-	if len(info.IPAM.Config) == 0 {
+	if len(netResult.Network.IPAM.Config) == 0 {
 		return fmt.Errorf("network %s has no IPAM config", networkName)
 	}
-	subnet := info.IPAM.Config[0].Subnet
+	subnet := netResult.Network.IPAM.Config[0].Subnet
 
 	comment := "blockyard-" + workerID
 	if _, err := d.runCmd(ctx, "iptables",
 		"-I", "DOCKER-USER",
-		"-s", subnet,
+		"-s", subnet.String(),
 		"-d", "169.254.169.254/32",
 		"-j", "DROP",
 		"-m", "comment", "--comment", comment,

--- a/internal/backend/docker/docker_integration_test.go
+++ b/internal/backend/docker/docker_integration_test.go
@@ -14,9 +14,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/moby/moby/api/pkg/stdcopy"
+	"github.com/moby/moby/client"
 	"github.com/google/uuid"
 
 	"github.com/cynkra/blockyard/internal/backend"
@@ -238,8 +237,8 @@ func TestNetworkIsolation(t *testing.T) {
 	b.mu.Unlock()
 
 	ip2 := strings.Split(addr2, ":")[0]
-	execResp, err := rawClient(t, b).ContainerExecCreate(ctx, ws1.containerID,
-		container.ExecOptions{
+	execResp, err := rawClient(t, b).ExecCreate(ctx, ws1.containerID,
+		client.ExecCreateOptions{
 			Cmd: []string{"sh", "-c", fmt.Sprintf(
 				"wget -q -O /dev/null --timeout=2 http://%s:%d/ 2>&1 || exit 1",
 				ip2, 8080,
@@ -250,12 +249,12 @@ func TestNetworkIsolation(t *testing.T) {
 		t.Fatalf("ExecCreate: %v", err)
 	}
 
-	if err := rawClient(t, b).ContainerExecStart(ctx, execResp.ID, container.ExecStartOptions{}); err != nil {
+	if _, err := rawClient(t, b).ExecStart(ctx, execResp.ID, client.ExecStartOptions{}); err != nil {
 		t.Fatalf("ExecStart: %v", err)
 	}
 
 	time.Sleep(3 * time.Second)
-	inspect, err := rawClient(t, b).ContainerExecInspect(ctx, execResp.ID)
+	inspect, err := rawClient(t, b).ExecInspect(ctx, execResp.ID, client.ExecInspectOptions{})
 	if err != nil {
 		t.Fatalf("ExecInspect: %v", err)
 	}
@@ -296,8 +295,8 @@ func TestMetadataEndpointBlocked(t *testing.T) {
 	ws := b.workers[workerID]
 	b.mu.Unlock()
 
-	execResp, err := rawClient(t, b).ContainerExecCreate(ctx, ws.containerID,
-		container.ExecOptions{
+	execResp, err := rawClient(t, b).ExecCreate(ctx, ws.containerID,
+		client.ExecCreateOptions{
 			Cmd: []string{"wget", "--spider", "--timeout=2",
 				"http://169.254.169.254/"},
 		},
@@ -306,12 +305,12 @@ func TestMetadataEndpointBlocked(t *testing.T) {
 		t.Fatalf("ExecCreate: %v", err)
 	}
 
-	if err := rawClient(t, b).ContainerExecStart(ctx, execResp.ID, container.ExecStartOptions{}); err != nil {
+	if _, err := rawClient(t, b).ExecStart(ctx, execResp.ID, client.ExecStartOptions{}); err != nil {
 		t.Fatalf("ExecStart: %v", err)
 	}
 
 	time.Sleep(3 * time.Second)
-	inspect, err := rawClient(t, b).ContainerExecInspect(ctx, execResp.ID)
+	inspect, err := rawClient(t, b).ExecInspect(ctx, execResp.ID, client.ExecInspectOptions{})
 	if err != nil {
 		t.Fatalf("ExecInspect: %v", err)
 	}
@@ -531,14 +530,14 @@ func TestSpawnWithMemoryLimit(t *testing.T) {
 	ws := b.workers[workerID]
 	b.mu.Unlock()
 
-	info, err := b.client.ContainerInspect(ctx, ws.containerID)
+	cResult, err := b.client.ContainerInspect(ctx, ws.containerID, client.ContainerInspectOptions{})
 	if err != nil {
 		t.Fatalf("ContainerInspect: %v", err)
 	}
 
 	expectedBytes := int64(64 * 1024 * 1024)
-	if info.HostConfig.Memory != expectedBytes {
-		t.Fatalf("expected memory limit %d bytes, got %d", expectedBytes, info.HostConfig.Memory)
+	if cResult.Container.HostConfig.Memory != expectedBytes {
+		t.Fatalf("expected memory limit %d bytes, got %d", expectedBytes, cResult.Container.HostConfig.Memory)
 	}
 }
 
@@ -572,14 +571,14 @@ func TestSpawnWithCPULimit(t *testing.T) {
 	ws := b.workers[workerID]
 	b.mu.Unlock()
 
-	info, err := b.client.ContainerInspect(ctx, ws.containerID)
+	cResult, err := b.client.ContainerInspect(ctx, ws.containerID, client.ContainerInspectOptions{})
 	if err != nil {
 		t.Fatalf("ContainerInspect: %v", err)
 	}
 
 	expectedNanoCPUs := int64(0.5 * 1e9)
-	if info.HostConfig.NanoCPUs != expectedNanoCPUs {
-		t.Fatalf("expected NanoCPUs %d, got %d", expectedNanoCPUs, info.HostConfig.NanoCPUs)
+	if cResult.Container.HostConfig.NanoCPUs != expectedNanoCPUs {
+		t.Fatalf("expected NanoCPUs %d, got %d", expectedNanoCPUs, cResult.Container.HostConfig.NanoCPUs)
 	}
 }
 
@@ -615,8 +614,8 @@ func TestSpawnWithEnvVars(t *testing.T) {
 	ws := b.workers[workerID]
 	b.mu.Unlock()
 
-	execResp, err := rawClient(t, b).ContainerExecCreate(ctx, ws.containerID,
-		container.ExecOptions{
+	execResp, err := rawClient(t, b).ExecCreate(ctx, ws.containerID,
+		client.ExecCreateOptions{
 			Cmd:          []string{"sh", "-c", "echo $TEST_VAR"},
 			AttachStdout: true,
 		},
@@ -625,7 +624,7 @@ func TestSpawnWithEnvVars(t *testing.T) {
 		t.Fatalf("ExecCreate: %v", err)
 	}
 
-	attachResp, err := rawClient(t, b).ContainerExecAttach(ctx, execResp.ID, container.ExecAttachOptions{})
+	attachResp, err := rawClient(t, b).ExecAttach(ctx, execResp.ID, client.ExecAttachOptions{})
 	if err != nil {
 		t.Fatalf("ExecAttach: %v", err)
 	}

--- a/internal/backend/docker/docker_unit_test.go
+++ b/internal/backend/docker/docker_unit_test.go
@@ -5,139 +5,153 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
+	"net/netip"
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/api/types/mount"
-	"github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/client"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/jsonstream"
+	"github.com/moby/moby/api/types/mount"
+	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
 
 	"github.com/cynkra/blockyard/internal/backend"
 	"github.com/cynkra/blockyard/internal/config"
 )
+
+// mockPullResponse satisfies client.ImagePullResponse for tests.
+type mockPullResponse struct {
+	io.ReadCloser
+}
+
+func (m mockPullResponse) JSONMessages(_ context.Context) iter.Seq2[jsonstream.Message, error] {
+	return nil
+}
+
+func (m mockPullResponse) Wait(_ context.Context) error {
+	return nil
+}
 
 // --- mock dockerClient ---
 
 // mockDockerClient implements dockerClient. Only the methods under test need
 // real implementations; the rest panic so unexpected calls surface immediately.
 type mockDockerClient struct {
-	containerInspectFn  func(ctx context.Context, id string) (container.InspectResponse, error)
-	containerListFn     func(ctx context.Context, options container.ListOptions) ([]container.Summary, error)
-	containerRemoveFn   func(ctx context.Context, containerID string, options container.RemoveOptions) error
-	containerStopFn     func(ctx context.Context, containerID string, options container.StopOptions) error
-	imageInspectFn      func(ctx context.Context, imageID string, opts ...client.ImageInspectOption) (image.InspectResponse, error)
-	imagePullFn         func(ctx context.Context, refStr string, options image.PullOptions) (io.ReadCloser, error)
-	networkConnectFn    func(ctx context.Context, networkID, containerID string, config *network.EndpointSettings) error
-	networkCreateFn     func(ctx context.Context, name string, options network.CreateOptions) (network.CreateResponse, error)
-	networkDisconnectFn func(ctx context.Context, networkID, containerID string, force bool) error
-	networkInspectFn    func(ctx context.Context, id string, opts network.InspectOptions) (network.Inspect, error)
-	networkListFn       func(ctx context.Context, options network.ListOptions) ([]network.Summary, error)
-	networkRemoveFn     func(ctx context.Context, networkID string) error
+	containerInspectFn  func(ctx context.Context, id string, opts client.ContainerInspectOptions) (client.ContainerInspectResult, error)
+	containerListFn     func(ctx context.Context, options client.ContainerListOptions) (client.ContainerListResult, error)
+	containerRemoveFn   func(ctx context.Context, containerID string, options client.ContainerRemoveOptions) (client.ContainerRemoveResult, error)
+	containerStopFn     func(ctx context.Context, containerID string, options client.ContainerStopOptions) (client.ContainerStopResult, error)
+	imageInspectFn      func(ctx context.Context, imageID string, opts ...client.ImageInspectOption) (client.ImageInspectResult, error)
+	imagePullFn         func(ctx context.Context, refStr string, options client.ImagePullOptions) (client.ImagePullResponse, error)
+	networkConnectFn    func(ctx context.Context, networkID string, options client.NetworkConnectOptions) (client.NetworkConnectResult, error)
+	networkCreateFn     func(ctx context.Context, name string, options client.NetworkCreateOptions) (client.NetworkCreateResult, error)
+	networkDisconnectFn func(ctx context.Context, networkID string, options client.NetworkDisconnectOptions) (client.NetworkDisconnectResult, error)
+	networkInspectFn    func(ctx context.Context, id string, opts client.NetworkInspectOptions) (client.NetworkInspectResult, error)
+	networkListFn       func(ctx context.Context, options client.NetworkListOptions) (client.NetworkListResult, error)
+	networkRemoveFn     func(ctx context.Context, networkID string, options client.NetworkRemoveOptions) (client.NetworkRemoveResult, error)
 }
 
-func (m *mockDockerClient) ContainerCreate(context.Context, *container.Config, *container.HostConfig, *network.NetworkingConfig, *ocispec.Platform, string) (container.CreateResponse, error) {
+func (m *mockDockerClient) ContainerCreate(context.Context, client.ContainerCreateOptions) (client.ContainerCreateResult, error) {
 	panic("not implemented")
 }
 
-func (m *mockDockerClient) ContainerInspect(ctx context.Context, id string) (container.InspectResponse, error) {
+func (m *mockDockerClient) ContainerInspect(ctx context.Context, id string, opts client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
 	if m.containerInspectFn != nil {
-		return m.containerInspectFn(ctx, id)
+		return m.containerInspectFn(ctx, id, opts)
 	}
 	panic("ContainerInspect not implemented")
 }
 
-func (m *mockDockerClient) ContainerList(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+func (m *mockDockerClient) ContainerList(ctx context.Context, options client.ContainerListOptions) (client.ContainerListResult, error) {
 	if m.containerListFn != nil {
 		return m.containerListFn(ctx, options)
 	}
 	panic("ContainerList not implemented")
 }
 
-func (m *mockDockerClient) ContainerLogs(context.Context, string, container.LogsOptions) (io.ReadCloser, error) {
+func (m *mockDockerClient) ContainerLogs(context.Context, string, client.ContainerLogsOptions) (client.ContainerLogsResult, error) {
 	panic("not implemented")
 }
 
-func (m *mockDockerClient) ContainerRemove(ctx context.Context, containerID string, options container.RemoveOptions) error {
+func (m *mockDockerClient) ContainerRemove(ctx context.Context, containerID string, options client.ContainerRemoveOptions) (client.ContainerRemoveResult, error) {
 	if m.containerRemoveFn != nil {
 		return m.containerRemoveFn(ctx, containerID, options)
 	}
 	panic("ContainerRemove not implemented")
 }
 
-func (m *mockDockerClient) ContainerStart(context.Context, string, container.StartOptions) error {
+func (m *mockDockerClient) ContainerStart(context.Context, string, client.ContainerStartOptions) (client.ContainerStartResult, error) {
 	panic("not implemented")
 }
 
-func (m *mockDockerClient) ContainerStatsOneShot(context.Context, string) (container.StatsResponseReader, error) {
+func (m *mockDockerClient) ContainerStats(context.Context, string, client.ContainerStatsOptions) (client.ContainerStatsResult, error) {
 	panic("not implemented")
 }
 
-func (m *mockDockerClient) ContainerStop(ctx context.Context, containerID string, options container.StopOptions) error {
+func (m *mockDockerClient) ContainerStop(ctx context.Context, containerID string, options client.ContainerStopOptions) (client.ContainerStopResult, error) {
 	if m.containerStopFn != nil {
 		return m.containerStopFn(ctx, containerID, options)
 	}
 	panic("ContainerStop not implemented")
 }
 
-func (m *mockDockerClient) ContainerWait(context.Context, string, container.WaitCondition) (<-chan container.WaitResponse, <-chan error) {
+func (m *mockDockerClient) ContainerWait(context.Context, string, client.ContainerWaitOptions) client.ContainerWaitResult {
 	panic("not implemented")
 }
 
-func (m *mockDockerClient) ImageInspect(ctx context.Context, imageID string, opts ...client.ImageInspectOption) (image.InspectResponse, error) {
+func (m *mockDockerClient) ImageInspect(ctx context.Context, imageID string, opts ...client.ImageInspectOption) (client.ImageInspectResult, error) {
 	if m.imageInspectFn != nil {
 		return m.imageInspectFn(ctx, imageID, opts...)
 	}
 	panic("ImageInspect not implemented")
 }
 
-func (m *mockDockerClient) ImagePull(ctx context.Context, refStr string, options image.PullOptions) (io.ReadCloser, error) {
+func (m *mockDockerClient) ImagePull(ctx context.Context, refStr string, options client.ImagePullOptions) (client.ImagePullResponse, error) {
 	if m.imagePullFn != nil {
 		return m.imagePullFn(ctx, refStr, options)
 	}
 	panic("ImagePull not implemented")
 }
 
-func (m *mockDockerClient) NetworkConnect(ctx context.Context, networkID, containerID string, cfg *network.EndpointSettings) error {
+func (m *mockDockerClient) NetworkConnect(ctx context.Context, networkID string, options client.NetworkConnectOptions) (client.NetworkConnectResult, error) {
 	if m.networkConnectFn != nil {
-		return m.networkConnectFn(ctx, networkID, containerID, cfg)
+		return m.networkConnectFn(ctx, networkID, options)
 	}
 	panic("NetworkConnect not implemented")
 }
 
-func (m *mockDockerClient) NetworkCreate(ctx context.Context, name string, options network.CreateOptions) (network.CreateResponse, error) {
+func (m *mockDockerClient) NetworkCreate(ctx context.Context, name string, options client.NetworkCreateOptions) (client.NetworkCreateResult, error) {
 	if m.networkCreateFn != nil {
 		return m.networkCreateFn(ctx, name, options)
 	}
 	panic("NetworkCreate not implemented")
 }
 
-func (m *mockDockerClient) NetworkDisconnect(ctx context.Context, networkID, containerID string, force bool) error {
+func (m *mockDockerClient) NetworkDisconnect(ctx context.Context, networkID string, options client.NetworkDisconnectOptions) (client.NetworkDisconnectResult, error) {
 	if m.networkDisconnectFn != nil {
-		return m.networkDisconnectFn(ctx, networkID, containerID, force)
+		return m.networkDisconnectFn(ctx, networkID, options)
 	}
 	panic("NetworkDisconnect not implemented")
 }
 
-func (m *mockDockerClient) NetworkInspect(ctx context.Context, id string, opts network.InspectOptions) (network.Inspect, error) {
+func (m *mockDockerClient) NetworkInspect(ctx context.Context, id string, opts client.NetworkInspectOptions) (client.NetworkInspectResult, error) {
 	if m.networkInspectFn != nil {
 		return m.networkInspectFn(ctx, id, opts)
 	}
 	panic("NetworkInspect not implemented")
 }
 
-func (m *mockDockerClient) NetworkList(ctx context.Context, options network.ListOptions) ([]network.Summary, error) {
+func (m *mockDockerClient) NetworkList(ctx context.Context, options client.NetworkListOptions) (client.NetworkListResult, error) {
 	if m.networkListFn != nil {
 		return m.networkListFn(ctx, options)
 	}
 	panic("NetworkList not implemented")
 }
 
-func (m *mockDockerClient) NetworkRemove(ctx context.Context, networkID string) error {
+func (m *mockDockerClient) NetworkRemove(ctx context.Context, networkID string, options client.NetworkRemoveOptions) (client.NetworkRemoveResult, error) {
 	if m.networkRemoveFn != nil {
-		return m.networkRemoveFn(ctx, networkID)
+		return m.networkRemoveFn(ctx, networkID, options)
 	}
 	panic("NetworkRemove not implemented")
 }
@@ -337,12 +351,12 @@ func TestNetworkLabels(t *testing.T) {
 
 func TestDetectMountMode_Volume(t *testing.T) {
 	mock := &mockDockerClient{
-		containerInspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
-			return container.InspectResponse{
+		containerInspectFn: func(_ context.Context, _ string, _ client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+			return client.ContainerInspectResult{Container: container.InspectResponse{
 				Mounts: []container.MountPoint{
 					{Type: mount.TypeVolume, Name: "data-vol", Destination: "/data"},
 				},
-			}, nil
+			}}, nil
 		},
 	}
 	cfg, err := detectMountMode(context.Background(), mock, "server-123", "/data/bundles")
@@ -362,12 +376,12 @@ func TestDetectMountMode_Volume(t *testing.T) {
 
 func TestDetectMountMode_Bind(t *testing.T) {
 	mock := &mockDockerClient{
-		containerInspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
-			return container.InspectResponse{
+		containerInspectFn: func(_ context.Context, _ string, _ client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+			return client.ContainerInspectResult{Container: container.InspectResponse{
 				Mounts: []container.MountPoint{
 					{Type: mount.TypeBind, Source: "/host/data", Destination: "/data"},
 				},
-			}, nil
+			}}, nil
 		},
 	}
 	cfg, err := detectMountMode(context.Background(), mock, "server-123", "/data/bundles")
@@ -384,13 +398,13 @@ func TestDetectMountMode_Bind(t *testing.T) {
 
 func TestDetectMountMode_LongestPrefixWins(t *testing.T) {
 	mock := &mockDockerClient{
-		containerInspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
-			return container.InspectResponse{
+		containerInspectFn: func(_ context.Context, _ string, _ client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+			return client.ContainerInspectResult{Container: container.InspectResponse{
 				Mounts: []container.MountPoint{
 					{Type: mount.TypeBind, Source: "/host/root", Destination: "/"},
 					{Type: mount.TypeVolume, Name: "data-vol", Destination: "/data"},
 				},
-			}, nil
+			}}, nil
 		},
 	}
 	cfg, err := detectMountMode(context.Background(), mock, "server-123", "/data/bundles")
@@ -404,12 +418,12 @@ func TestDetectMountMode_LongestPrefixWins(t *testing.T) {
 
 func TestDetectMountMode_NoMatchingMount(t *testing.T) {
 	mock := &mockDockerClient{
-		containerInspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
-			return container.InspectResponse{
+		containerInspectFn: func(_ context.Context, _ string, _ client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+			return client.ContainerInspectResult{Container: container.InspectResponse{
 				Mounts: []container.MountPoint{
 					{Type: mount.TypeVolume, Name: "other", Destination: "/other"},
 				},
-			}, nil
+			}}, nil
 		},
 	}
 	_, err := detectMountMode(context.Background(), mock, "server-123", "/data/bundles")
@@ -420,8 +434,8 @@ func TestDetectMountMode_NoMatchingMount(t *testing.T) {
 
 func TestDetectMountMode_InspectError(t *testing.T) {
 	mock := &mockDockerClient{
-		containerInspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
-			return container.InspectResponse{}, errors.New("connection refused")
+		containerInspectFn: func(_ context.Context, _ string, _ client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+			return client.ContainerInspectResult{}, errors.New("connection refused")
 		},
 	}
 	_, err := detectMountMode(context.Background(), mock, "server-123", "/data/bundles")
@@ -444,30 +458,30 @@ func TestConnectServiceContainers_ConnectsWithAliases(t *testing.T) {
 	var connected []string
 
 	mock := &mockDockerClient{
-		networkInspectFn: func(_ context.Context, id string, _ network.InspectOptions) (network.Inspect, error) {
-			return network.Inspect{
+		networkInspectFn: func(_ context.Context, id string, _ client.NetworkInspectOptions) (client.NetworkInspectResult, error) {
+			return client.NetworkInspectResult{Network: network.Inspect{
 				Containers: map[string]network.EndpointResource{
 					"db-container":    {},
 					"redis-container": {},
 				},
-			}, nil
+			}}, nil
 		},
-		containerInspectFn: func(_ context.Context, id string) (container.InspectResponse, error) {
+		containerInspectFn: func(_ context.Context, id string, _ client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
 			aliases := map[string][]string{
 				"db-container":    {"postgres", "db"},
 				"redis-container": {"redis"},
 			}
-			return container.InspectResponse{
+			return client.ContainerInspectResult{Container: container.InspectResponse{
 				NetworkSettings: &container.NetworkSettings{
 					Networks: map[string]*network.EndpointSettings{
 						"svc-net": {Aliases: aliases[id]},
 					},
 				},
-			}, nil
+			}}, nil
 		},
-		networkConnectFn: func(_ context.Context, networkID, containerID string, cfg *network.EndpointSettings) error {
-			connected = append(connected, containerID)
-			return nil
+		networkConnectFn: func(_ context.Context, _ string, opts client.NetworkConnectOptions) (client.NetworkConnectResult, error) {
+			connected = append(connected, opts.Container)
+			return client.NetworkConnectResult{}, nil
 		},
 	}
 
@@ -486,24 +500,24 @@ func TestConnectServiceContainers_SkipsServerContainer(t *testing.T) {
 	var connected []string
 
 	mock := &mockDockerClient{
-		networkInspectFn: func(_ context.Context, _ string, _ network.InspectOptions) (network.Inspect, error) {
-			return network.Inspect{
+		networkInspectFn: func(_ context.Context, _ string, _ client.NetworkInspectOptions) (client.NetworkInspectResult, error) {
+			return client.NetworkInspectResult{Network: network.Inspect{
 				Containers: map[string]network.EndpointResource{
 					"server-id":   {},
 					"db-container": {},
 				},
-			}, nil
+			}}, nil
 		},
-		containerInspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
-			return container.InspectResponse{
+		containerInspectFn: func(_ context.Context, _ string, _ client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+			return client.ContainerInspectResult{Container: container.InspectResponse{
 				NetworkSettings: &container.NetworkSettings{
 					Networks: map[string]*network.EndpointSettings{},
 				},
-			}, nil
+			}}, nil
 		},
-		networkConnectFn: func(_ context.Context, _, containerID string, _ *network.EndpointSettings) error {
-			connected = append(connected, containerID)
-			return nil
+		networkConnectFn: func(_ context.Context, _ string, opts client.NetworkConnectOptions) (client.NetworkConnectResult, error) {
+			connected = append(connected, opts.Container)
+			return client.NetworkConnectResult{}, nil
 		},
 	}
 
@@ -523,27 +537,27 @@ func TestConnectServiceContainers_InspectErrorSkipsContainer(t *testing.T) {
 	var connected []string
 
 	mock := &mockDockerClient{
-		networkInspectFn: func(_ context.Context, _ string, _ network.InspectOptions) (network.Inspect, error) {
-			return network.Inspect{
+		networkInspectFn: func(_ context.Context, _ string, _ client.NetworkInspectOptions) (client.NetworkInspectResult, error) {
+			return client.NetworkInspectResult{Network: network.Inspect{
 				Containers: map[string]network.EndpointResource{
 					"bad-container":  {},
 					"good-container": {},
 				},
-			}, nil
+			}}, nil
 		},
-		containerInspectFn: func(_ context.Context, id string) (container.InspectResponse, error) {
+		containerInspectFn: func(_ context.Context, id string, _ client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
 			if id == "bad-container" {
-				return container.InspectResponse{}, errors.New("gone")
+				return client.ContainerInspectResult{}, errors.New("gone")
 			}
-			return container.InspectResponse{
+			return client.ContainerInspectResult{Container: container.InspectResponse{
 				NetworkSettings: &container.NetworkSettings{
 					Networks: map[string]*network.EndpointSettings{},
 				},
-			}, nil
+			}}, nil
 		},
-		networkConnectFn: func(_ context.Context, _, containerID string, _ *network.EndpointSettings) error {
-			connected = append(connected, containerID)
-			return nil
+		networkConnectFn: func(_ context.Context, _ string, opts client.NetworkConnectOptions) (client.NetworkConnectResult, error) {
+			connected = append(connected, opts.Container)
+			return client.NetworkConnectResult{}, nil
 		},
 	}
 
@@ -561,8 +575,8 @@ func TestConnectServiceContainers_InspectErrorSkipsContainer(t *testing.T) {
 
 func TestConnectServiceContainers_NetworkInspectError(t *testing.T) {
 	mock := &mockDockerClient{
-		networkInspectFn: func(_ context.Context, _ string, _ network.InspectOptions) (network.Inspect, error) {
-			return network.Inspect{}, errors.New("network not found")
+		networkInspectFn: func(_ context.Context, _ string, _ client.NetworkInspectOptions) (client.NetworkInspectResult, error) {
+			return client.NetworkInspectResult{}, errors.New("network not found")
 		},
 	}
 
@@ -579,12 +593,12 @@ func TestConnectServiceContainers_NetworkInspectError(t *testing.T) {
 
 func TestInsertMetadataRule_Success(t *testing.T) {
 	mock := &mockDockerClient{
-		networkInspectFn: func(_ context.Context, _ string, _ network.InspectOptions) (network.Inspect, error) {
-			return network.Inspect{
-				IPAM: network.IPAM{
-					Config: []network.IPAMConfig{{Subnet: "172.18.0.0/16"}},
-				},
-			}, nil
+		networkInspectFn: func(_ context.Context, _ string, _ client.NetworkInspectOptions) (client.NetworkInspectResult, error) {
+			return client.NetworkInspectResult{Network: network.Inspect{
+				Network: network.Network{IPAM: network.IPAM{
+					Config: []network.IPAMConfig{{Subnet: netip.MustParsePrefix("172.18.0.0/16")}},
+				}},
+			}}, nil
 		},
 	}
 
@@ -619,8 +633,8 @@ func TestInsertMetadataRule_Success(t *testing.T) {
 
 func TestInsertMetadataRule_NoIPAM(t *testing.T) {
 	mock := &mockDockerClient{
-		networkInspectFn: func(_ context.Context, _ string, _ network.InspectOptions) (network.Inspect, error) {
-			return network.Inspect{IPAM: network.IPAM{}}, nil
+		networkInspectFn: func(_ context.Context, _ string, _ client.NetworkInspectOptions) (client.NetworkInspectResult, error) {
+			return client.NetworkInspectResult{Network: network.Inspect{Network: network.Network{IPAM: network.IPAM{}}}}, nil
 		},
 	}
 	d := newTestBackend(mock)
@@ -632,8 +646,8 @@ func TestInsertMetadataRule_NoIPAM(t *testing.T) {
 
 func TestInsertMetadataRule_NetworkInspectError(t *testing.T) {
 	mock := &mockDockerClient{
-		networkInspectFn: func(_ context.Context, _ string, _ network.InspectOptions) (network.Inspect, error) {
-			return network.Inspect{}, errors.New("not found")
+		networkInspectFn: func(_ context.Context, _ string, _ client.NetworkInspectOptions) (client.NetworkInspectResult, error) {
+			return client.NetworkInspectResult{}, errors.New("not found")
 		},
 	}
 	d := newTestBackend(mock)
@@ -645,12 +659,12 @@ func TestInsertMetadataRule_NetworkInspectError(t *testing.T) {
 
 func TestInsertMetadataRule_IptablesFails(t *testing.T) {
 	mock := &mockDockerClient{
-		networkInspectFn: func(_ context.Context, _ string, _ network.InspectOptions) (network.Inspect, error) {
-			return network.Inspect{
-				IPAM: network.IPAM{
-					Config: []network.IPAMConfig{{Subnet: "172.18.0.0/16"}},
-				},
-			}, nil
+		networkInspectFn: func(_ context.Context, _ string, _ client.NetworkInspectOptions) (client.NetworkInspectResult, error) {
+			return client.NetworkInspectResult{Network: network.Inspect{
+				Network: network.Network{IPAM: network.IPAM{
+					Config: []network.IPAMConfig{{Subnet: netip.MustParsePrefix("172.18.0.0/16")}},
+				}},
+			}}, nil
 		},
 	}
 	runner := func(_ context.Context, _ string, _ ...string) ([]byte, error) {
@@ -668,12 +682,12 @@ func TestInsertMetadataRule_IptablesFails(t *testing.T) {
 
 func TestBlockMetadataEndpoint_FirstCall_IptablesSucceeds(t *testing.T) {
 	mock := &mockDockerClient{
-		networkInspectFn: func(_ context.Context, _ string, _ network.InspectOptions) (network.Inspect, error) {
-			return network.Inspect{
-				IPAM: network.IPAM{
-					Config: []network.IPAMConfig{{Subnet: "172.18.0.0/16"}},
-				},
-			}, nil
+		networkInspectFn: func(_ context.Context, _ string, _ client.NetworkInspectOptions) (client.NetworkInspectResult, error) {
+			return client.NetworkInspectResult{Network: network.Inspect{
+				Network: network.Network{IPAM: network.IPAM{
+					Config: []network.IPAMConfig{{Subnet: netip.MustParsePrefix("172.18.0.0/16")}},
+				}},
+			}}, nil
 		},
 	}
 	runner := func(_ context.Context, _ string, _ ...string) ([]byte, error) {
@@ -692,12 +706,12 @@ func TestBlockMetadataEndpoint_FirstCall_IptablesSucceeds(t *testing.T) {
 
 func TestBlockMetadataEndpoint_FirstCall_IptablesFailsHostBlocks(t *testing.T) {
 	mock := &mockDockerClient{
-		networkInspectFn: func(_ context.Context, _ string, _ network.InspectOptions) (network.Inspect, error) {
-			return network.Inspect{
-				IPAM: network.IPAM{
-					Config: []network.IPAMConfig{{Subnet: "172.18.0.0/16"}},
-				},
-			}, nil
+		networkInspectFn: func(_ context.Context, _ string, _ client.NetworkInspectOptions) (client.NetworkInspectResult, error) {
+			return client.NetworkInspectResult{Network: network.Inspect{
+				Network: network.Network{IPAM: network.IPAM{
+					Config: []network.IPAMConfig{{Subnet: netip.MustParsePrefix("172.18.0.0/16")}},
+				}},
+			}}, nil
 		},
 	}
 
@@ -724,12 +738,12 @@ func TestBlockMetadataEndpoint_FirstCall_IptablesFailsHostBlocks(t *testing.T) {
 
 func TestBlockMetadataEndpoint_FirstCall_NothingWorks(t *testing.T) {
 	mock := &mockDockerClient{
-		networkInspectFn: func(_ context.Context, _ string, _ network.InspectOptions) (network.Inspect, error) {
-			return network.Inspect{
-				IPAM: network.IPAM{
-					Config: []network.IPAMConfig{{Subnet: "172.18.0.0/16"}},
-				},
-			}, nil
+		networkInspectFn: func(_ context.Context, _ string, _ client.NetworkInspectOptions) (client.NetworkInspectResult, error) {
+			return client.NetworkInspectResult{Network: network.Inspect{
+				Network: network.Network{IPAM: network.IPAM{
+					Config: []network.IPAMConfig{{Subnet: netip.MustParsePrefix("172.18.0.0/16")}},
+				}},
+			}}, nil
 		},
 	}
 	runner := func(_ context.Context, _ string, _ ...string) ([]byte, error) {
@@ -746,12 +760,12 @@ func TestBlockMetadataEndpoint_FirstCall_NothingWorks(t *testing.T) {
 
 func TestBlockMetadataEndpoint_SubsequentCall_Blocked(t *testing.T) {
 	mock := &mockDockerClient{
-		networkInspectFn: func(_ context.Context, _ string, _ network.InspectOptions) (network.Inspect, error) {
-			return network.Inspect{
-				IPAM: network.IPAM{
-					Config: []network.IPAMConfig{{Subnet: "172.18.0.0/16"}},
-				},
-			}, nil
+		networkInspectFn: func(_ context.Context, _ string, _ client.NetworkInspectOptions) (client.NetworkInspectResult, error) {
+			return client.NetworkInspectResult{Network: network.Inspect{
+				Network: network.Network{IPAM: network.IPAM{
+					Config: []network.IPAMConfig{{Subnet: netip.MustParsePrefix("172.18.0.0/16")}},
+				}},
+			}}, nil
 		},
 	}
 
@@ -938,8 +952,8 @@ func TestCleanupOrphanRules_NoOrphans(t *testing.T) {
 
 func TestEnsureImage_AlreadyPresent(t *testing.T) {
 	mock := &mockDockerClient{
-		imageInspectFn: func(_ context.Context, _ string, _ ...client.ImageInspectOption) (image.InspectResponse, error) {
-			return image.InspectResponse{}, nil
+		imageInspectFn: func(_ context.Context, _ string, _ ...client.ImageInspectOption) (client.ImageInspectResult, error) {
+			return client.ImageInspectResult{}, nil
 		},
 	}
 	d := newTestBackend(mock)
@@ -951,15 +965,15 @@ func TestEnsureImage_AlreadyPresent(t *testing.T) {
 func TestEnsureImage_PullsWhenMissing(t *testing.T) {
 	var pulled bool
 	mock := &mockDockerClient{
-		imageInspectFn: func(_ context.Context, _ string, _ ...client.ImageInspectOption) (image.InspectResponse, error) {
-			return image.InspectResponse{}, errors.New("not found")
+		imageInspectFn: func(_ context.Context, _ string, _ ...client.ImageInspectOption) (client.ImageInspectResult, error) {
+			return client.ImageInspectResult{}, errors.New("not found")
 		},
-		imagePullFn: func(_ context.Context, ref string, _ image.PullOptions) (io.ReadCloser, error) {
+		imagePullFn: func(_ context.Context, ref string, _ client.ImagePullOptions) (client.ImagePullResponse, error) {
 			pulled = true
 			if ref != "alpine:3.21" {
 				t.Errorf("pulled %q, want alpine:3.21", ref)
 			}
-			return io.NopCloser(strings.NewReader("")), nil
+			return mockPullResponse{io.NopCloser(strings.NewReader(""))}, nil
 		},
 	}
 	d := newTestBackend(mock)
@@ -973,10 +987,10 @@ func TestEnsureImage_PullsWhenMissing(t *testing.T) {
 
 func TestEnsureImage_PullFails(t *testing.T) {
 	mock := &mockDockerClient{
-		imageInspectFn: func(_ context.Context, _ string, _ ...client.ImageInspectOption) (image.InspectResponse, error) {
-			return image.InspectResponse{}, errors.New("not found")
+		imageInspectFn: func(_ context.Context, _ string, _ ...client.ImageInspectOption) (client.ImageInspectResult, error) {
+			return client.ImageInspectResult{}, errors.New("not found")
 		},
-		imagePullFn: func(_ context.Context, _ string, _ image.PullOptions) (io.ReadCloser, error) {
+		imagePullFn: func(_ context.Context, _ string, _ client.ImagePullOptions) (client.ImagePullResponse, error) {
 			return nil, errors.New("registry unavailable")
 		},
 	}
@@ -999,17 +1013,17 @@ func TestDisconnectServiceContainers_DisconnectsExceptServer(t *testing.T) {
 	var disconnected []string
 
 	mock := &mockDockerClient{
-		networkInspectFn: func(_ context.Context, _ string, _ network.InspectOptions) (network.Inspect, error) {
-			return network.Inspect{
+		networkInspectFn: func(_ context.Context, _ string, _ client.NetworkInspectOptions) (client.NetworkInspectResult, error) {
+			return client.NetworkInspectResult{Network: network.Inspect{
 				Containers: map[string]network.EndpointResource{
 					"server-id":    {},
 					"db-container": {},
 				},
-			}, nil
+			}}, nil
 		},
-		networkDisconnectFn: func(_ context.Context, _, containerID string, _ bool) error {
-			disconnected = append(disconnected, containerID)
-			return nil
+		networkDisconnectFn: func(_ context.Context, _ string, opts client.NetworkDisconnectOptions) (client.NetworkDisconnectResult, error) {
+			disconnected = append(disconnected, opts.Container)
+			return client.NetworkDisconnectResult{}, nil
 		},
 	}
 
@@ -1025,8 +1039,8 @@ func TestDisconnectServiceContainers_DisconnectsExceptServer(t *testing.T) {
 
 func TestDisconnectServiceContainers_NetworkInspectError(t *testing.T) {
 	mock := &mockDockerClient{
-		networkInspectFn: func(_ context.Context, _ string, _ network.InspectOptions) (network.Inspect, error) {
-			return network.Inspect{}, errors.New("not found")
+		networkInspectFn: func(_ context.Context, _ string, _ client.NetworkInspectOptions) (client.NetworkInspectResult, error) {
+			return client.NetworkInspectResult{}, errors.New("not found")
 		},
 	}
 
@@ -1042,12 +1056,12 @@ func TestDisconnectServiceContainers_NetworkInspectError(t *testing.T) {
 func TestCreateNetwork_HappyPath(t *testing.T) {
 	var createdName string
 	mock := &mockDockerClient{
-		networkCreateFn: func(_ context.Context, name string, opts network.CreateOptions) (network.CreateResponse, error) {
+		networkCreateFn: func(_ context.Context, name string, opts client.NetworkCreateOptions) (client.NetworkCreateResult, error) {
 			createdName = name
 			if opts.Driver != "bridge" {
 				t.Errorf("expected bridge driver, got %q", opts.Driver)
 			}
-			return network.CreateResponse{ID: "net-new-id"}, nil
+			return client.NetworkCreateResult{ID: "net-new-id"}, nil
 		},
 	}
 
@@ -1066,8 +1080,8 @@ func TestCreateNetwork_HappyPath(t *testing.T) {
 
 func TestCreateNetwork_Error(t *testing.T) {
 	mock := &mockDockerClient{
-		networkCreateFn: func(_ context.Context, _ string, _ network.CreateOptions) (network.CreateResponse, error) {
-			return network.CreateResponse{}, errors.New("quota exceeded")
+		networkCreateFn: func(_ context.Context, _ string, _ client.NetworkCreateOptions) (client.NetworkCreateResult, error) {
+			return client.NetworkCreateResult{}, errors.New("quota exceeded")
 		},
 	}
 
@@ -1082,14 +1096,14 @@ func TestCreateNetwork_Error(t *testing.T) {
 
 func TestAddr_HappyPath(t *testing.T) {
 	mock := &mockDockerClient{
-		containerInspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
-			return container.InspectResponse{
+		containerInspectFn: func(_ context.Context, _ string, _ client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+			return client.ContainerInspectResult{Container: container.InspectResponse{
 				NetworkSettings: &container.NetworkSettings{
 					Networks: map[string]*network.EndpointSettings{
-						"blockyard-w1": {IPAddress: "172.18.0.2"},
+						"blockyard-w1": {IPAddress: netip.MustParseAddr("172.18.0.2")},
 					},
 				},
-			}, nil
+			}}, nil
 		},
 	}
 
@@ -1119,8 +1133,8 @@ func TestAddr_UnknownWorker(t *testing.T) {
 
 func TestAddr_InspectError(t *testing.T) {
 	mock := &mockDockerClient{
-		containerInspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
-			return container.InspectResponse{}, errors.New("gone")
+		containerInspectFn: func(_ context.Context, _ string, _ client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+			return client.ContainerInspectResult{}, errors.New("gone")
 		},
 	}
 
@@ -1135,8 +1149,8 @@ func TestAddr_InspectError(t *testing.T) {
 
 func TestAddr_NoNetworkSettings(t *testing.T) {
 	mock := &mockDockerClient{
-		containerInspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
-			return container.InspectResponse{NetworkSettings: nil}, nil
+		containerInspectFn: func(_ context.Context, _ string, _ client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+			return client.ContainerInspectResult{Container: container.InspectResponse{NetworkSettings: nil}}, nil
 		},
 	}
 
@@ -1151,14 +1165,14 @@ func TestAddr_NoNetworkSettings(t *testing.T) {
 
 func TestAddr_NotOnExpectedNetwork(t *testing.T) {
 	mock := &mockDockerClient{
-		containerInspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
-			return container.InspectResponse{
+		containerInspectFn: func(_ context.Context, _ string, _ client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+			return client.ContainerInspectResult{Container: container.InspectResponse{
 				NetworkSettings: &container.NetworkSettings{
 					Networks: map[string]*network.EndpointSettings{
-						"other-net": {IPAddress: "172.18.0.2"},
+						"other-net": {IPAddress: netip.MustParseAddr("172.18.0.2")},
 					},
 				},
-			}, nil
+			}}, nil
 		},
 	}
 
@@ -1173,14 +1187,14 @@ func TestAddr_NotOnExpectedNetwork(t *testing.T) {
 
 func TestAddr_EmptyIP(t *testing.T) {
 	mock := &mockDockerClient{
-		containerInspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
-			return container.InspectResponse{
+		containerInspectFn: func(_ context.Context, _ string, _ client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+			return client.ContainerInspectResult{Container: container.InspectResponse{
 				NetworkSettings: &container.NetworkSettings{
 					Networks: map[string]*network.EndpointSettings{
-						"blockyard-w1": {IPAddress: ""},
+						"blockyard-w1": {},
 					},
 				},
-			}, nil
+			}}, nil
 		},
 	}
 
@@ -1199,17 +1213,17 @@ func TestStop_HappyPath(t *testing.T) {
 	var stopped, removed, netRemoved bool
 
 	mock := &mockDockerClient{
-		containerStopFn: func(_ context.Context, _ string, _ container.StopOptions) error {
+		containerStopFn: func(_ context.Context, _ string, _ client.ContainerStopOptions) (client.ContainerStopResult, error) {
 			stopped = true
-			return nil
+			return client.ContainerStopResult{}, nil
 		},
-		containerRemoveFn: func(_ context.Context, _ string, _ container.RemoveOptions) error {
+		containerRemoveFn: func(_ context.Context, _ string, _ client.ContainerRemoveOptions) (client.ContainerRemoveResult, error) {
 			removed = true
-			return nil
+			return client.ContainerRemoveResult{}, nil
 		},
-		networkRemoveFn: func(_ context.Context, _ string) error {
+		networkRemoveFn: func(_ context.Context, _ string, _ client.NetworkRemoveOptions) (client.NetworkRemoveResult, error) {
 			netRemoved = true
-			return nil
+			return client.NetworkRemoveResult{}, nil
 		},
 	}
 
@@ -1256,16 +1270,16 @@ func TestStop_ContainerStopErrorStillCleansUp(t *testing.T) {
 	var removeCalled, netRemoveCalled bool
 
 	mock := &mockDockerClient{
-		containerStopFn: func(_ context.Context, _ string, _ container.StopOptions) error {
-			return errors.New("timeout")
+		containerStopFn: func(_ context.Context, _ string, _ client.ContainerStopOptions) (client.ContainerStopResult, error) {
+			return client.ContainerStopResult{}, errors.New("timeout")
 		},
-		containerRemoveFn: func(_ context.Context, _ string, _ container.RemoveOptions) error {
+		containerRemoveFn: func(_ context.Context, _ string, _ client.ContainerRemoveOptions) (client.ContainerRemoveResult, error) {
 			removeCalled = true
-			return nil
+			return client.ContainerRemoveResult{}, nil
 		},
-		networkRemoveFn: func(_ context.Context, _ string) error {
+		networkRemoveFn: func(_ context.Context, _ string, _ client.NetworkRemoveOptions) (client.NetworkRemoveResult, error) {
 			netRemoveCalled = true
-			return nil
+			return client.NetworkRemoveResult{}, nil
 		},
 	}
 
@@ -1294,20 +1308,20 @@ func TestStop_DisconnectsServer(t *testing.T) {
 	var serverDisconnected bool
 
 	mock := &mockDockerClient{
-		containerStopFn: func(_ context.Context, _ string, _ container.StopOptions) error {
-			return nil
+		containerStopFn: func(_ context.Context, _ string, _ client.ContainerStopOptions) (client.ContainerStopResult, error) {
+			return client.ContainerStopResult{}, nil
 		},
-		containerRemoveFn: func(_ context.Context, _ string, _ container.RemoveOptions) error {
-			return nil
+		containerRemoveFn: func(_ context.Context, _ string, _ client.ContainerRemoveOptions) (client.ContainerRemoveResult, error) {
+			return client.ContainerRemoveResult{}, nil
 		},
-		networkDisconnectFn: func(_ context.Context, _, containerID string, _ bool) error {
-			if containerID == "server-id" {
+		networkDisconnectFn: func(_ context.Context, _ string, opts client.NetworkDisconnectOptions) (client.NetworkDisconnectResult, error) {
+			if opts.Container == "server-id" {
 				serverDisconnected = true
 			}
-			return nil
+			return client.NetworkDisconnectResult{}, nil
 		},
-		networkRemoveFn: func(_ context.Context, _ string) error {
-			return nil
+		networkRemoveFn: func(_ context.Context, _ string, _ client.NetworkRemoveOptions) (client.NetworkRemoveResult, error) {
+			return client.NetworkRemoveResult{}, nil
 		},
 	}
 
@@ -1333,15 +1347,15 @@ func TestStop_DisconnectsServer(t *testing.T) {
 
 func TestListManaged_ReturnsContainersAndNetworks(t *testing.T) {
 	mock := &mockDockerClient{
-		containerListFn: func(_ context.Context, _ container.ListOptions) ([]container.Summary, error) {
-			return []container.Summary{
+		containerListFn: func(_ context.Context, _ client.ContainerListOptions) (client.ContainerListResult, error) {
+			return client.ContainerListResult{Items: []container.Summary{
 				{ID: "ctr-1", Labels: map[string]string{"dev.blockyard/managed": "true"}},
-			}, nil
+			}}, nil
 		},
-		networkListFn: func(_ context.Context, _ network.ListOptions) ([]network.Summary, error) {
-			return []network.Summary{
-				{ID: "net-1", Labels: map[string]string{"dev.blockyard/managed": "true"}},
-			}, nil
+		networkListFn: func(_ context.Context, _ client.NetworkListOptions) (client.NetworkListResult, error) {
+			return client.NetworkListResult{Items: []network.Summary{
+				{Network: network.Network{ID: "net-1", Labels: map[string]string{"dev.blockyard/managed": "true"}}},
+			}}, nil
 		},
 	}
 
@@ -1364,8 +1378,8 @@ func TestListManaged_ReturnsContainersAndNetworks(t *testing.T) {
 
 func TestListManaged_ContainerListError(t *testing.T) {
 	mock := &mockDockerClient{
-		containerListFn: func(_ context.Context, _ container.ListOptions) ([]container.Summary, error) {
-			return nil, errors.New("docker down")
+		containerListFn: func(_ context.Context, _ client.ContainerListOptions) (client.ContainerListResult, error) {
+			return client.ContainerListResult{}, errors.New("docker down")
 		},
 	}
 
@@ -1378,11 +1392,11 @@ func TestListManaged_ContainerListError(t *testing.T) {
 
 func TestListManaged_NetworkListError(t *testing.T) {
 	mock := &mockDockerClient{
-		containerListFn: func(_ context.Context, _ container.ListOptions) ([]container.Summary, error) {
-			return nil, nil
+		containerListFn: func(_ context.Context, _ client.ContainerListOptions) (client.ContainerListResult, error) {
+			return client.ContainerListResult{}, nil
 		},
-		networkListFn: func(_ context.Context, _ network.ListOptions) ([]network.Summary, error) {
-			return nil, errors.New("docker down")
+		networkListFn: func(_ context.Context, _ client.NetworkListOptions) (client.NetworkListResult, error) {
+			return client.NetworkListResult{}, errors.New("docker down")
 		},
 	}
 
@@ -1398,9 +1412,9 @@ func TestListManaged_NetworkListError(t *testing.T) {
 func TestRemoveResource_Container(t *testing.T) {
 	var removedID string
 	mock := &mockDockerClient{
-		containerRemoveFn: func(_ context.Context, id string, _ container.RemoveOptions) error {
+		containerRemoveFn: func(_ context.Context, id string, _ client.ContainerRemoveOptions) (client.ContainerRemoveResult, error) {
 			removedID = id
-			return nil
+			return client.ContainerRemoveResult{}, nil
 		},
 	}
 
@@ -1420,9 +1434,9 @@ func TestRemoveResource_Container(t *testing.T) {
 func TestRemoveResource_Network(t *testing.T) {
 	var removedID string
 	mock := &mockDockerClient{
-		networkRemoveFn: func(_ context.Context, id string) error {
+		networkRemoveFn: func(_ context.Context, id string, _ client.NetworkRemoveOptions) (client.NetworkRemoveResult, error) {
 			removedID = id
-			return nil
+			return client.NetworkRemoveResult{}, nil
 		},
 	}
 

--- a/internal/backend/docker/mounts.go
+++ b/internal/backend/docker/mounts.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/docker/docker/api/types/mount"
+	"github.com/moby/moby/api/types/mount"
 
 	"github.com/cynkra/blockyard/internal/backend"
 )

--- a/internal/backend/docker/mounts_test.go
+++ b/internal/backend/docker/mounts_test.go
@@ -3,7 +3,7 @@ package docker
 import (
 	"testing"
 
-	"github.com/docker/docker/api/types/mount"
+	"github.com/moby/moby/api/types/mount"
 
 	"github.com/cynkra/blockyard/internal/backend"
 )

--- a/internal/integration/openbao_integration_test.go
+++ b/internal/integration/openbao_integration_test.go
@@ -13,9 +13,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/client"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
 
 	"github.com/cynkra/blockyard/internal/integration"
 	"github.com/cynkra/blockyard/internal/testutil"
@@ -35,7 +34,7 @@ var (
 func TestMain(m *testing.M) {
 	ctx := context.Background()
 
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, err := client.New(client.FromEnv)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "docker client: %v\n", err)
 		os.Exit(1)
@@ -43,13 +42,13 @@ func TestMain(m *testing.M) {
 	defer cli.Close()
 
 	// Pull image.
-	reader, err := cli.ImagePull(ctx, openbaoImage, image.PullOptions{})
+	pullResp, err := cli.ImagePull(ctx, openbaoImage, client.ImagePullOptions{})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "image pull: %v\n", err)
 		os.Exit(1)
 	}
-	io.Copy(io.Discard, reader)
-	reader.Close()
+	io.Copy(io.Discard, pullResp)
+	pullResp.Close()
 
 	// Start MockIdP for JWT auth configuration.
 	mockIdP = testutil.NewMockIdP()
@@ -60,8 +59,8 @@ func TestMain(m *testing.M) {
 	// Create OpenBao dev server container.
 	// Use host networking so OpenBao can reach the mock IdP on 127.0.0.1.
 	baoPort := "8200"
-	resp, err := cli.ContainerCreate(ctx,
-		&container.Config{
+	resp, err := cli.ContainerCreate(ctx, client.ContainerCreateOptions{
+		Config: &container.Config{
 			Image: openbaoImage,
 			Cmd:   []string{"server", "-dev", "-dev-root-token-id=" + rootToken, "-dev-listen-address=0.0.0.0:" + baoPort},
 			Env: []string{
@@ -69,21 +68,21 @@ func TestMain(m *testing.M) {
 			},
 			Labels: map[string]string{"blockyard-test": "openbao"},
 		},
-		&container.HostConfig{
+		HostConfig: &container.HostConfig{
 			NetworkMode: "host",
 			CapAdd:      []string{"IPC_LOCK"},
 		},
-		nil, nil, "blockyard-openbao-test",
-	)
+		Name: "blockyard-openbao-test",
+	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "container create: %v\n", err)
 		os.Exit(1)
 	}
 	containerID = resp.ID
 
-	if err := cli.ContainerStart(ctx, containerID, container.StartOptions{}); err != nil {
+	if _, err := cli.ContainerStart(ctx, containerID, client.ContainerStartOptions{}); err != nil {
 		fmt.Fprintf(os.Stderr, "container start: %v\n", err)
-		cli.ContainerRemove(ctx, containerID, container.RemoveOptions{Force: true})
+		cli.ContainerRemove(ctx, containerID, client.ContainerRemoveOptions{Force: true})
 		os.Exit(1)
 	}
 
@@ -124,8 +123,8 @@ func TestMain(m *testing.M) {
 
 func cleanup(ctx context.Context, cli *client.Client) {
 	timeout := 10
-	cli.ContainerStop(ctx, containerID, container.StopOptions{Timeout: &timeout})
-	cli.ContainerRemove(ctx, containerID, container.RemoveOptions{Force: true})
+	cli.ContainerStop(ctx, containerID, client.ContainerStopOptions{Timeout: &timeout})
+	cli.ContainerRemove(ctx, containerID, client.ContainerRemoveOptions{Force: true})
 }
 
 // configureJWTAuth sets up the JWT auth method in OpenBao with the mock IdP.

--- a/internal/preflight/docker_checks.go
+++ b/internal/preflight/docker_checks.go
@@ -12,10 +12,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/pkg/stdcopy"
+	"github.com/moby/moby/client"
 
 	"github.com/cynkra/blockyard/internal/backend/docker"
 	"github.com/cynkra/blockyard/internal/config"
@@ -98,14 +97,14 @@ func checkROBindVisibility(ctx context.Context, deps DockerDeps) *Result {
 	}
 
 	// Start a container that sleeps, bind-mounting the empty dir read-only.
-	resp, err := deps.Client.ContainerCreate(ctx,
-		&container.Config{
+	resp, err := deps.Client.ContainerCreate(ctx, client.ContainerCreateOptions{
+		Config: &container.Config{
 			Image: deps.Config.Image,
 			Cmd:   []string{"sleep", "30"},
 		},
-		hostCfg,
-		nil, nil, containerName,
-	)
+		HostConfig: hostCfg,
+		Name:       containerName,
+	})
 	if err != nil {
 		return &Result{
 			Name:     "ro_bind_visibility",
@@ -113,9 +112,9 @@ func checkROBindVisibility(ctx context.Context, deps DockerDeps) *Result {
 			Message:  fmt.Sprintf("failed to create test container: %v", err),
 		}
 	}
-	defer deps.Client.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true}) //nolint:errcheck
+	defer deps.Client.ContainerRemove(ctx, resp.ID, client.ContainerRemoveOptions{Force: true}) //nolint:errcheck
 
-	if err := deps.Client.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
+	if _, err := deps.Client.ContainerStart(ctx, resp.ID, client.ContainerStartOptions{}); err != nil {
 		return &Result{
 			Name:     "ro_bind_visibility",
 			Severity: SeverityError,
@@ -282,12 +281,12 @@ func ensureImage(ctx context.Context, cli *client.Client, img string) error {
 	}
 
 	slog.Info("preflight: pulling image", "image", img)
-	reader, err := cli.ImagePull(ctx, img, image.PullOptions{})
+	pullResp, err := cli.ImagePull(ctx, img, client.ImagePullOptions{})
 	if err != nil {
 		return fmt.Errorf("pull %s: %w", img, err)
 	}
-	defer reader.Close()
-	if _, err := io.Copy(io.Discard, reader); err != nil {
+	defer pullResp.Close()
+	if _, err := io.Copy(io.Discard, pullResp); err != nil {
 		return fmt.Errorf("pull %s: %w", img, err)
 	}
 	return nil
@@ -302,22 +301,28 @@ func runEphemeralContainer(
 	hostCfg *container.HostConfig,
 	name string,
 ) (string, int, error) {
-	resp, err := cli.ContainerCreate(ctx, cfg, hostCfg, nil, nil, name)
+	resp, err := cli.ContainerCreate(ctx, client.ContainerCreateOptions{
+		Config:     cfg,
+		HostConfig: hostCfg,
+		Name:       name,
+	})
 	if err != nil {
 		return "", -1, fmt.Errorf("create container: %w", err)
 	}
-	defer cli.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true}) //nolint:errcheck
+	defer cli.ContainerRemove(ctx, resp.ID, client.ContainerRemoveOptions{Force: true}) //nolint:errcheck
 
-	if err := cli.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
+	if _, err := cli.ContainerStart(ctx, resp.ID, client.ContainerStartOptions{}); err != nil {
 		return "", -1, fmt.Errorf("start container: %w", err)
 	}
 
-	waitCh, errCh := cli.ContainerWait(ctx, resp.ID, container.WaitConditionNotRunning)
+	waitResult := cli.ContainerWait(ctx, resp.ID, client.ContainerWaitOptions{
+		Condition: container.WaitConditionNotRunning,
+	})
 	select {
-	case result := <-waitCh:
+	case result := <-waitResult.Result:
 		output, _ := containerLogs(ctx, cli, resp.ID)
 		return output, int(result.StatusCode), nil
-	case err := <-errCh:
+	case err := <-waitResult.Error:
 		return "", -1, fmt.Errorf("wait: %w", err)
 	case <-ctx.Done():
 		return "", -1, ctx.Err()
@@ -327,7 +332,7 @@ func runEphemeralContainer(
 // containerExec runs a command inside a running container and returns
 // stdout, exit code, and any error.
 func containerExec(ctx context.Context, cli *client.Client, containerID string, cmd []string) (string, int, error) {
-	exec, err := cli.ContainerExecCreate(ctx, containerID, container.ExecOptions{
+	execResult, err := cli.ExecCreate(ctx, containerID, client.ExecCreateOptions{
 		Cmd:          cmd,
 		AttachStdout: true,
 		AttachStderr: true,
@@ -336,7 +341,7 @@ func containerExec(ctx context.Context, cli *client.Client, containerID string, 
 		return "", -1, err
 	}
 
-	attach, err := cli.ContainerExecAttach(ctx, exec.ID, container.ExecAttachOptions{})
+	attach, err := cli.ExecAttach(ctx, execResult.ID, client.ExecAttachOptions{})
 	if err != nil {
 		return "", -1, err
 	}
@@ -348,7 +353,7 @@ func containerExec(ctx context.Context, cli *client.Client, containerID string, 
 		_ = err
 	}
 
-	inspect, err := cli.ContainerExecInspect(ctx, exec.ID)
+	inspect, err := cli.ExecInspect(ctx, execResult.ID, client.ExecInspectOptions{})
 	if err != nil {
 		return stdout.String(), -1, err
 	}
@@ -358,7 +363,7 @@ func containerExec(ctx context.Context, cli *client.Client, containerID string, 
 
 // containerLogs fetches the combined stdout/stderr of a stopped container.
 func containerLogs(ctx context.Context, cli *client.Client, containerID string) (string, error) {
-	reader, err := cli.ContainerLogs(ctx, containerID, container.LogsOptions{
+	reader, err := cli.ContainerLogs(ctx, containerID, client.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
 	})

--- a/internal/preflight/docker_checks_test.go
+++ b/internal/preflight/docker_checks_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/client"
+	"github.com/moby/moby/client"
 
 	"github.com/cynkra/blockyard/internal/backend/docker"
 	"github.com/cynkra/blockyard/internal/config"
@@ -17,14 +17,13 @@ import (
 
 func testDockerClient(t *testing.T) *client.Client {
 	t.Helper()
-	cli, err := client.NewClientWithOpts(
+	cli, err := client.New(
 		client.WithHost("unix:///var/run/docker.sock"),
-		client.WithAPIVersionNegotiation(),
 	)
 	if err != nil {
 		t.Fatalf("docker client: %v", err)
 	}
-	if _, err := cli.Ping(context.Background()); err != nil {
+	if _, err := cli.Ping(context.Background(), client.PingOptions{}); err != nil {
 		t.Skipf("docker not available: %v", err)
 	}
 	return cli


### PR DESCRIPTION
## Summary
- Replace `github.com/docker/docker` v28 with `github.com/moby/moby/client` v0.3.0 and `github.com/moby/moby/api` v1.54.0 to address CVE-2026-34040 (HIGH) and CVE-2026-33997 (MEDIUM)
- Update all 9 affected files (4 production, 5 test) to the new client API: `client.New()`, `client.Filters`, options/result structs in `client` package, `Exec*` method renames, `network.Port` struct replacing `nat.Port` string
- Handle type changes from `string` to `netip.Addr`/`netip.Prefix` for IP addresses and subnets