### PR TITLE
Add client-server version negotiation

### DIFF
--- a/cmd/by/config.go
+++ b/cmd/by/config.go
@@ -11,7 +11,9 @@ func mustClient(jsonOutput bool) *apiclient.Client {
 	if err != nil {
 		exitError(jsonOutput, err)
 	}
-	return apiclient.New(serverURL, token)
+	c := apiclient.New(serverURL, token)
+	c.Version = version
+	return c
 }
 
 // mustStreamingClient creates a streaming client from resolved credentials.
@@ -20,5 +22,7 @@ func mustStreamingClient(jsonOutput bool) *apiclient.Client {
 	if err != nil {
 		exitError(jsonOutput, err)
 	}
-	return apiclient.NewStreaming(serverURL, token)
+	c := apiclient.NewStreaming(serverURL, token)
+	c.Version = version
+	return c
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -106,6 +106,19 @@ func securityHeaders(externalURL string) func(http.Handler) http.Handler {
 	}
 }
 
+// versionHeader sets the X-Blockyard-Version response header so that
+// clients can detect incompatible server versions.
+func versionHeader(version string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if version != "" {
+				w.Header().Set("X-Blockyard-Version", version)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // apiCSP sets a strict Content-Security-Policy for JSON API endpoints
 // where no HTML rendering occurs, and prevents caching of sensitive
 // API responses by intermediate proxies and browsers.
@@ -129,6 +142,9 @@ func NewRouter(srv *server.Server) http.Handler {
 
 	// Global security headers (HSTS when HTTPS).
 	r.Use(securityHeaders(srv.Config.Server.ExternalURL))
+
+	// Advertise server version to clients.
+	r.Use(versionHeader(srv.Version))
 
 	// OpenTelemetry tracing middleware (only when configured).
 	if srv.Config.Telemetry != nil && srv.Config.Telemetry.OTLPEndpoint != "" {

--- a/internal/api/version_test.go
+++ b/internal/api/version_test.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestVersionHeader(t *testing.T) {
+	handler := versionHeader("v1.2.3")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+
+	got := rec.Header().Get("X-Blockyard-Version")
+	if got != "v1.2.3" {
+		t.Errorf("expected v1.2.3, got %q", got)
+	}
+}
+
+func TestVersionHeader_Empty(t *testing.T) {
+	handler := versionHeader("")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+
+	if got := rec.Header().Get("X-Blockyard-Version"); got != "" {
+		t.Errorf("expected empty header, got %q", got)
+	}
+}

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -7,7 +7,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -16,6 +19,17 @@ type Client struct {
 	BaseURL    string
 	Token      string
 	HTTPClient *http.Client
+
+	// Version is the CLI version. When set, the client checks the
+	// X-Blockyard-Version response header on the first request and
+	// warns on major-version mismatch.
+	Version string
+
+	// Stderr is the writer for version-mismatch warnings.
+	// Defaults to os.Stderr when nil.
+	Stderr io.Writer
+
+	checkVersion sync.Once
 }
 
 // New creates an API client with a 30-second timeout.
@@ -64,7 +78,12 @@ func (c *Client) Do(method, path string, body io.Reader, contentType string) (*h
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
 	}
-	return c.HTTPClient.Do(req)
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	c.warnVersionMismatch(resp)
+	return resp, nil
 }
 
 func (c *Client) Get(path string) (*http.Response, error) {
@@ -127,6 +146,47 @@ func ReadBodyRaw(resp *http.Response) ([]byte, error) {
 		return nil, err
 	}
 	return io.ReadAll(resp.Body)
+}
+
+// warnVersionMismatch prints a one-time warning to stderr if the server's
+// major version differs from the client's.
+func (c *Client) warnVersionMismatch(resp *http.Response) {
+	if c.Version == "" {
+		return
+	}
+	c.checkVersion.Do(func() {
+		sv := resp.Header.Get("X-Blockyard-Version")
+		if sv == "" {
+			return
+		}
+		cm := parseMajor(c.Version)
+		sm := parseMajor(sv)
+		if cm < 0 || sm < 0 {
+			return // non-semver (e.g. "dev"), skip check
+		}
+		if cm != sm {
+			w := c.Stderr
+			if w == nil {
+				w = os.Stderr
+			}
+			fmt.Fprintf(w, "Warning: by %s may be incompatible with server %s (major version mismatch)\n",
+				c.Version, sv)
+		}
+	})
+}
+
+// parseMajor extracts the major version number from a semver-like string.
+// Returns -1 for non-numeric versions like "dev".
+func parseMajor(v string) int {
+	v = strings.TrimPrefix(v, "v")
+	if i := strings.IndexByte(v, '.'); i >= 0 {
+		v = v[:i]
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return -1
+	}
+	return n
 }
 
 // BuildQuery builds a URL path with query parameters.

--- a/internal/apiclient/client_test.go
+++ b/internal/apiclient/client_test.go
@@ -343,6 +343,144 @@ func TestCheckResponse_ErrorWithoutMessage(t *testing.T) {
 	}
 }
 
+func TestParseMajor(t *testing.T) {
+	tests := []struct {
+		version string
+		want    int
+	}{
+		{"v1.2.3", 1},
+		{"v2.0.0", 2},
+		{"1.2.3", 1},
+		{"0.1.0", 0},
+		{"v10.0.0-rc1", 10},
+		{"dev", -1},
+		{"main+abc123", -1},
+		{"", -1},
+	}
+	for _, tt := range tests {
+		if got := parseMajor(tt.version); got != tt.want {
+			t.Errorf("parseMajor(%q) = %d, want %d", tt.version, got, tt.want)
+		}
+	}
+}
+
+func TestVersionMismatchWarning(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Blockyard-Version", "v2.1.0")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var buf strings.Builder
+	c := New(srv.URL, "tok")
+	c.Version = "v1.3.0"
+	c.Stderr = &buf
+
+	resp, err := c.Get("/test")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	resp.Body.Close()
+
+	if !strings.Contains(buf.String(), "major version mismatch") {
+		t.Errorf("expected mismatch warning, got %q", buf.String())
+	}
+}
+
+func TestVersionMismatchWarning_OnlyOnce(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Blockyard-Version", "v2.0.0")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var buf strings.Builder
+	c := New(srv.URL, "tok")
+	c.Version = "v1.0.0"
+	c.Stderr = &buf
+
+	for range 3 {
+		resp, err := c.Get("/test")
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		resp.Body.Close()
+	}
+
+	// Warning should appear exactly once.
+	if n := strings.Count(buf.String(), "major version mismatch"); n != 1 {
+		t.Errorf("expected 1 warning, got %d in %q", n, buf.String())
+	}
+}
+
+func TestVersionCompatible_NoWarning(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Blockyard-Version", "v1.5.0")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var buf strings.Builder
+	c := New(srv.URL, "tok")
+	c.Version = "v1.3.0"
+	c.Stderr = &buf
+
+	resp, err := c.Get("/test")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	resp.Body.Close()
+
+	if buf.Len() > 0 {
+		t.Errorf("expected no warning, got %q", buf.String())
+	}
+}
+
+func TestVersionCheck_NoHeader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var buf strings.Builder
+	c := New(srv.URL, "tok")
+	c.Version = "v1.0.0"
+	c.Stderr = &buf
+
+	resp, err := c.Get("/test")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	resp.Body.Close()
+
+	if buf.Len() > 0 {
+		t.Errorf("expected no warning, got %q", buf.String())
+	}
+}
+
+func TestVersionCheck_DevVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Blockyard-Version", "v1.0.0")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var buf strings.Builder
+	c := New(srv.URL, "tok")
+	c.Version = "dev"
+	c.Stderr = &buf
+
+	resp, err := c.Get("/test")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	resp.Body.Close()
+
+	if buf.Len() > 0 {
+		t.Errorf("expected no warning for dev version, got %q", buf.String())
+	}
+}
+
 func TestBuildQuery(t *testing.T) {
 	got := BuildQuery("/api/v1/apps", map[string]string{
 		"search": "hello",


### PR DESCRIPTION
## Summary
- Server sets `X-Blockyard-Version` header on every API response via new middleware
- CLI checks the header on its first request and warns on stderr when major versions differ
- Non-semver versions (e.g. `dev`) skip the check gracefully

Closes #70