### PR TITLE
Add rolling update design and v3 operations track

### DIFF
--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -44,16 +44,16 @@ IDs to network addresses. Both are concrete in-memory structs for v0 (map +
 `sync.RWMutex`). Load balancing (v1) sits on top — it picks a worker and
 writes the mapping; the stores just hold the data.
 
-When v4 needs PostgreSQL-backed implementations for multi-node HA, extracting
-an interface in Go is a low-cost refactor — define the interface at the call
-site and the existing struct already satisfies it.
+v3 extracts interfaces and adds Redis-backed implementations — needed for
+rolling updates (two servers sharing state during the overlap) and reused
+in v4 for multi-node HA. See [update.md](update.md) for the full design.
 
 ## Task Store
 
 An in-memory task store manages restore tasks. It provides a create/subscribe
 pattern: background restore goroutines write log lines; HTTP handlers read
-buffered output and optionally follow live lines via a channel. Same interface
-extraction story as session/worker routing for v4 HA.
+buffered output and optionally follow live lines via a channel. Same
+interface extraction story as session/worker routing (v3).
 
 ## Network Isolation
 
@@ -302,24 +302,36 @@ On SIGTERM the server shuts down cleanly in this order:
 7. **Flush and close** — flush structured logs and audit log, close the DB
    connection
 
-All active user sessions are killed on shutdown. This is intentional — a
-server restart is a rare, disruptive operational event, not a rolling update.
+All active user sessions are killed on SIGTERM shutdown. This is the
+default behavior for operators who are not using rolling updates.
 
 No hot reload. Config changes require a restart.
 
+### Drain Mode (v3)
+
+`SIGUSR1` triggers an alternative shutdown path for rolling updates.
+Health endpoints (`/healthz`, `/readyz`) return 503 immediately — this
+is the proxy-agnostic cutover signal. In-flight requests drain, background
+goroutines stop, but workers and networks are left intact for the new
+server to adopt via Redis. See [update.md](update.md) for the full
+rolling update design.
+
+`SIGTERM` retains the full-shutdown behavior described above. `docker
+stop` sends SIGTERM, so operators who are not using rolling updates are
+unaffected.
+
 ### State on Restart
 
-The server makes no attempt to recover or reconnect to containers after a
-restart — clean or otherwise.
+**Without Redis (default):** the server makes no attempt to recover or
+reconnect to containers after a restart. Clean shutdown removes all
+containers and networks. Unclean shutdown (crash, OOM kill) leaves
+orphans; startup cleanup removes them. All sessions are lost.
 
-**Clean shutdown:** all containers and networks are stopped and removed before
-exit. Next startup begins with an empty slate.
-
-**Unclean shutdown** (crash, OOM kill, power loss): containers may still be
-running on the host. Orphan cleanup on startup removes them. End state is the
-same as a clean shutdown.
-
-In both cases all active user sessions are lost. Simplicity over resilience.
+**With Redis (v3):** session routing and worker state are in Redis, not
+in-memory. After a drain-mode shutdown, the new server finds existing
+workers via Redis and resumes serving. After an unclean shutdown, the
+new server reconciles Redis state against Docker (evicting workers that
+no longer exist). Sessions survive across server restarts.
 
 ## Database Schema
 

--- a/docs/design/roadmap.md
+++ b/docs/design/roadmap.md
@@ -35,11 +35,13 @@ required to call the product useful. v2 adds single-node production
 completeness (CLI, scale-to-zero, pre-warming, build pipeline
 modernization with pak, a content-addressable package store, board
 storage via PostgreSQL + PostgREST + vault Identity OIDC, cold-start
-loading page). v3 adds a pre-fork worker model for the Docker backend (per-user forked
-processes with CoW memory sharing and post-fork sandboxing), the
-lightweight process backend, and deferred single-node features (data
-mounts, Docker daemon hardening, multiple execution environment images,
-UI branding). v4 adds Kubernetes for multi-node scaling.
+loading page). v3 has two tracks: operations (rolling updates via Redis
+shared state, interface extraction for session/worker stores, `by admin
+update` CLI command) and runtime (pre-fork worker model for the Docker
+backend, lightweight process backend, deferred single-node features).
+The operations track runs first — it enables low-friction iteration on
+deployed v2 instances and front-loads the shared state layer needed for
+v4 clustering. v4 adds Kubernetes for multi-node scaling.
 
 **The one deliberate exception to "no premature abstraction"** is the `Backend`
 interface (Docker vs. process vs. Kubernetes). This abstraction is worth its
@@ -211,10 +213,9 @@ plane protected by a single static bearer token in config.
 
 - **Session and worker routing.** Cookie-based session pinning. A session store
   maps session IDs to worker IDs; a worker registry maps worker IDs to network
-  addresses. These start as concrete in-memory structs for v0. When v2 needs
-  PostgreSQL-backed implementations for HA, extracting an interface is a
-  low-cost refactor — define the interface at the call site and any struct with
-  matching methods already satisfies it.
+  addresses. These start as concrete in-memory structs for v0. v3 extracts
+  interfaces and adds Redis-backed implementations for rolling updates;
+  v4 reuses the same shared state layer for multi-node HA.
 
   On first request to `/app/{name}/`, the proxy sets a session cookie containing
   a generated session ID. Subsequent requests — including WebSocket reconnects
@@ -672,13 +673,58 @@ existing Docker deployment. No Kubernetes dependency.
   per-worker hard-linked library views. See [v2 plan](v2/plan.md) for the
   full design.
 
-### v3: Process Backend + Deferred Single-Node Features
+### v3: Operations, Process Backend + Deferred Single-Node Features
 
-A lightweight alternative to Docker for single-host deployments, plus
-features deferred from v2: data mounts, Docker daemon hardening, multiple
-execution environment images, and UI branding / customization.
+Two tracks. The **operations track** adds rolling updates with zero
+downtime — Redis-backed shared state for session/worker routing,
+interface extraction for the in-memory stores, a drain mode for graceful
+server handoff, and the `by admin update` CLI command. This work runs
+first: once v2 is deployed, low-friction updates are immediately needed,
+and the shared state layer directly serves v4 clustering. The **runtime
+track** adds the pre-fork worker model, the lightweight process backend,
+and deferred single-node features.
 
 ---
+
+- **Rolling updates.** Zero-downtime server updates via `by admin update`.
+  Requires Redis and a reverse proxy with Docker service discovery. Old
+  and new server containers run simultaneously during the update; the
+  proxy routes based on container health checks. The old server enters
+  drain mode (health endpoints return 503, in-flight requests complete,
+  workers left alive), the proxy shifts traffic to the new server, and
+  the old server exits. Workers survive the transition — they continue
+  serving existing sessions under the new server. See
+  [update.md](update.md) for the full design. Related: #70
+  (client-server version negotiation), #71 (update notifications).
+
+- **Redis shared state.** Session store, worker registry, and worker map
+  move behind Go interfaces with two implementations: in-memory (default,
+  zero dependencies) and Redis (required for rolling updates). Redis
+  enables the update overlap — both old and new servers read and write
+  the same routing state. The same shared state layer is reused in v4
+  for multi-replica Kubernetes deployments.
+
+- **Interface extraction.** `SessionStore`, `WorkerRegistry`, and
+  `WorkerMap` become interfaces defined at the call sites. The existing
+  concrete types already satisfy the interface shapes — extraction is a
+  mechanical refactor. Redis implementations use GET/SET/HSET with TTLs.
+
+- **Worker token persistence.** The HMAC signing key for worker tokens
+  moves from ephemeral (regenerated on every startup) to persistent.
+  Primary storage in OpenBao (`secret/data/blockyard/worker-signing-key`);
+  file-based fallback on the data volume when OpenBao is not configured.
+
+- **Drain mode.** A new shutdown path triggered by `SIGUSR1`. Health
+  endpoints return 503 immediately (the proxy-agnostic cutover signal),
+  in-flight requests drain, background goroutines stop, but workers and
+  networks are left intact. `SIGTERM` retains the existing full-shutdown
+  behavior. Deployments without rolling updates are unaffected.
+
+- **`by admin update` command.** CLI command that orchestrates the full
+  rolling update flow: pull new image, back up database, start new
+  container, wait for readiness, signal old server to drain, wait for
+  exit, clean up. Detects absence of Redis and falls back to printing
+  manual `docker compose` commands.
 
 - **Pre-fork worker model.** An enhancement to the Docker backend's
   multi-session mode. Instead of multiplexing sessions onto a shared R
@@ -737,7 +783,9 @@ execution environment images, and UI branding / customization.
 
 ### v4: Kubernetes and Multi-Node
 
-The Kubernetes backend and the architectural refactors it triggers.
+The Kubernetes backend. Interface extraction and Redis shared state are
+already in place from v3 — v4 builds on that foundation for multi-replica
+deployments.
 
 ---
 
@@ -745,10 +793,6 @@ The Kubernetes backend and the architectural refactors it triggers.
   `k8s.io/client-go` to create Deployments (long-lived apps) and Jobs (tasks).
   Involves pod specs, service creation for routing, PVC management for shared
   caches, and pod status polling.
-
-- **Interface extraction.** `SessionStore`, `WorkerRegistry`, and `TaskStore`
-  become interfaces with swappable implementations (in-memory for single-node,
-  PostgreSQL-backed for multi-node HA).
 
 - **Backend package extraction.** Extract separate Go packages for each backend
   implementation if build-tag sprawl warrants it.

--- a/docs/design/update.md
+++ b/docs/design/update.md
@@ -1,0 +1,331 @@
+# Server Update Design
+
+This document describes how blockyard deployments are updated. Two paths
+exist depending on infrastructure:
+
+- **Basic:** `docker compose pull && docker compose up -d`. Workers die,
+  sessions restart. No additional infrastructure required.
+- **Rolling:** `by admin update`. Zero downtime, workers survive. Requires
+  Redis and a reverse proxy with Docker service discovery.
+
+Related issues: #70 (client-server version negotiation), #71 (update
+notifications).
+
+## Status Quo
+
+The current design explicitly does not support rolling updates.
+`StartupCleanup` force-removes every container labeled
+`dev.blockyard/managed=true`. `GracefulShutdown` drains and evicts all
+workers before exit. The worker token signing key is ephemeral — generated
+from `crypto/rand` on every startup. In-memory session routing is not
+persisted. A restart means all sessions die.
+
+This was the right trade-off for v0–v1: simplicity over resilience. The
+basic update path preserves this — operators who don't need rolling
+updates don't pay for the complexity.
+
+## Basic Update Path
+
+For deployments without Redis or a service-discovery-capable proxy,
+updates are manual:
+
+```sh
+docker compose pull
+docker compose up -d
+```
+
+Workers are killed, sessions restart. The server boots clean. This is the
+current behavior, documented rather than orchestrated.
+
+One improvement applies to the basic path regardless: **health-check-aware
+drain**. When the server receives SIGTERM, it immediately starts returning
+503 on `/healthz` and `/readyz`, then drains in-flight requests before
+exiting. Any health-check-aware proxy (even statically configured) will
+stop routing new traffic to the server as soon as health checks fail,
+making the restart window cleaner even without service discovery. This
+is a small change to the existing shutdown path and benefits all
+deployments.
+
+`by admin update` detects the absence of Redis and prints the manual
+compose commands instead of attempting a rolling update.
+
+## Rolling Update Path
+
+### Prerequisites
+
+Rolling updates require two pieces of infrastructure beyond the server
+itself:
+
+**Redis** — replaces the in-memory session store, worker registry, and
+worker map with shared state accessible to both old and new server
+processes during the overlap. Without shared state, the overlap doesn't
+work: the new server can't route requests to workers it didn't spawn,
+and the old server can't hand off sessions it holds only in memory.
+
+Redis is the right choice over PostgreSQL for this state because it's
+ephemeral and high-frequency: session lookups on every proxied request,
+worker health updates every few seconds, TTL-based expiration. This is
+cache-shaped work, not relational data.
+
+**Reverse proxy with Docker service discovery** — during a rolling
+update, old and new server containers run simultaneously on the same
+Docker network. The proxy must discover both containers and route traffic
+based on health. Two capabilities are required:
+
+1. **Discovery** — the proxy watches Docker for container events and
+   adds/removes backends automatically. This is inherently
+   proxy-specific: Traefik's Docker provider, caddy-docker-proxy,
+   nginx-proxy each use their own label/env conventions. Blockyard does
+   not interact with these labels — the operator configures them once
+   when setting up the proxy, and both containers inherit the same
+   labels during the overlap.
+
+2. **Health-based routing** — the proxy checks backend health and stops
+   routing to unhealthy containers. This is the cutover mechanism: when
+   `by admin update` signals the old server to drain, it starts returning
+   503 on `/healthz`. The proxy detects this and shifts all traffic to
+   the new server. This part is vendor-agnostic — every proxy that does
+   service discovery also does health checking.
+
+The discovery requirement is what distinguishes the rolling path from the
+basic path. A statically configured proxy (e.g. `reverse_proxy
+blockyard:8080` in a Caddyfile) won't discover the new container. It
+only knows about the old one, and the overlap provides no benefit.
+
+### Why Redis Rather Than Reconstruction
+
+The alternative — no Redis, reconstruct state from the database and
+Docker labels on startup — was considered and rejected. It requires a
+"frozen" mode on the old server (stop background goroutines but keep
+proxying), hand-off marker files on the data volume, and careful
+ordering to avoid both servers mutating worker state simultaneously.
+The result is fragile, hard to test, and produces a second code path
+through the entire server lifecycle. Redis eliminates all of this: both
+servers read and write the same state, and the overlap is a non-event.
+
+### Shared State in Redis
+
+Three data structures move from in-memory maps to Redis:
+
+**Session store** (`session.Store`) — maps session ID to worker ID and
+user sub. Currently a Go map with `sync.RWMutex`. In Redis: hash per
+session with TTL matching session expiry. Looked up on every proxied
+request.
+
+**Worker registry** (`registry.Registry`) — maps worker ID to network
+address. Currently a Go map. In Redis: simple key-value with TTL. Looked
+up on every proxied request (cache miss from session store, or direct
+worker routing).
+
+**Worker map** (`server.WorkerMap`) — maps worker ID to active worker
+metadata (app ID, bundle ID, draining flag, idle-since timestamp). Used
+by the autoscaler, health poller, and session routing. In Redis: hash
+per worker.
+
+The in-memory implementations remain as the default when Redis is not
+configured. The server detects Redis availability at startup and selects
+the appropriate backend. Both implement the same Go interface.
+
+### Interface Extraction
+
+The three stores are extracted behind interfaces defined at the call
+sites:
+
+```go
+// Used by proxy, autoscaler, session management
+type SessionStore interface {
+    Get(sessionID string) (session.Entry, bool)
+    Set(sessionID string, entry session.Entry)
+    Delete(sessionID string)
+    DeleteByWorker(workerID string)
+    CountForWorkers(workerIDs []string) int
+}
+
+// Used by proxy for address resolution
+type WorkerRegistry interface {
+    Get(workerID string) (string, bool)
+    Set(workerID string, addr string)
+    Delete(workerID string)
+}
+
+// Used by autoscaler, health poller, proxy, ops
+type WorkerMap interface {
+    Get(workerID string) (server.ActiveWorker, bool)
+    Set(workerID string, w server.ActiveWorker)
+    Delete(workerID string)
+    All() []string
+    MarkDraining(appID string)
+    // ...
+}
+```
+
+This extraction is cheap — the existing concrete types already satisfy
+these shapes. The Redis implementations use the same interface with
+GET/SET/HSET operations and appropriate TTLs.
+
+### v4 Clustering
+
+This interface extraction and Redis integration directly serves the v4
+Kubernetes milestone. Multi-replica server deployments need shared state
+for worker routing; Redis is already in place. The difference between
+"two servers during a rolling update" and "N replicas in a cluster" is
+one of degree, not kind. The same shared state layer handles both.
+
+### Worker Token Persistence
+
+The HMAC signing key used for worker tokens is currently ephemeral. For
+the overlap to work, both old and new servers must sign and verify tokens
+with the same key.
+
+**Primary path (OpenBao configured):** on first startup, generate the
+key and store it at `secret/data/blockyard/worker-signing-key`. On
+subsequent startups, read it back. OpenBao is already in the stack for
+credential management; this is a natural extension.
+
+**Fallback (no OpenBao):** write the key to the data volume at
+`/data/db/.worker-key`. The signing key protects worker-to-server
+communication on a local Docker network — storing it alongside the
+database is acceptable given the threat model.
+
+### Drain Mode
+
+When the old server needs to yield to the new one, it enters drain mode.
+This is triggered by `SIGUSR1` (sent by `by admin update`). `SIGTERM`
+retains the current behavior (full shutdown with worker eviction), so
+`docker stop` remains safe for operators who aren't doing rolling
+updates.
+
+**Drain sequence:**
+
+1. `/healthz` and `/readyz` start returning 503 immediately. The proxy
+   detects this via health checks and stops routing new traffic to the
+   old server. This is the cutover signal — vendor-agnostic, no proxy
+   API calls or label manipulation required.
+2. In-flight requests drain (up to `shutdown_timeout`).
+3. Background goroutines stop (health poller, autoscaler, token
+   refreshers, audit writer).
+4. Database connection closes.
+5. Process exits.
+
+**What does NOT happen:** no `EvictWorker`, no `RemoveResource`, no
+`Backend.Stop`. Workers, networks, and token directories are left
+intact. The new server already manages them via Redis.
+
+### Migration Safety
+
+Database migrations run on startup via `golang-migrate`. During a
+rolling update, the old server is still serving traffic when the new
+server starts and runs migrations.
+
+**Constraint: migrations must be backward-compatible within a major
+version.** The old server continues reading and writing the database
+after migrations run. This means: new columns with defaults, new tables,
+new indexes — never drop, rename, or change column types. This is a
+standard discipline for zero-downtime deployments and not burdensome in
+practice.
+
+**Pre-migration backup:** `by admin update` backs up the database before
+starting the new container. For SQLite: file copy. For PostgreSQL:
+`pg_dump` to a timestamped file. If the new server fails to start, the
+backup and old image tag are available for manual recovery.
+
+**Skip-version upgrades:** migrations are sequential and
+`golang-migrate` runs all pending. Skipping from v1 to v3 applies
+migrations in order. No special handling needed.
+
+### Server-Worker API Compatibility
+
+Rolling updates require that the new server can manage workers spawned
+by the old server. The worker-facing surface is small:
+
+| Surface | Contract |
+|---|---|
+| Token file | JWT at `{token_dir}/token`, read by worker on each API call |
+| `POST /api/v1/packages` | Worker sends package install request, authed via token |
+| Health probe | HTTP GET to worker's Shiny port, expects 200 |
+| Mount layout | App code at `{bundle_worker_path}/`, library at `/blockyard-lib` |
+| Environment variables | `BLOCKYARD_WORKER_ID`, `BLOCKYARD_APP_ID`, etc. |
+| Network topology | Per-worker bridge, server joined to each |
+
+**Within a major version:** this contract is stable. Changes must be
+additive and backward-compatible. Given the small surface, this is not a
+significant constraint.
+
+**Across major versions:** rolling updates are not supported. Major
+upgrades use the basic restart path.
+
+## `by admin update` Command
+
+The CLI command orchestrates the full flow. It requires access to the
+Docker daemon (via socket) and to the blockyard API.
+
+```
+by admin update [--channel stable|main] [--yes]
+```
+
+### Precondition Check
+
+Before doing anything, the command verifies:
+
+1. A newer version is available (GitHub Releases API, respecting
+   channel). If up to date, exit.
+2. Redis is configured and reachable. If not, print the manual compose
+   commands and exit.
+3. The server reports a service-discovery-capable proxy (detected via
+   config). If not, warn and suggest the basic path.
+
+### Rolling Update Flow
+
+```
+by admin update
+  1. Pull         → docker pull ghcr.io/cynkra/blockyard:<tag>
+  2. Backup       → copy SQLite file or pg_dump
+  3. Start new    → start new container (same network, same proxy labels)
+  4. Wait ready   → poll /readyz on new container
+  5. Drain old    → SIGUSR1 old server (health checks fail, proxy shifts)
+  6. Wait exit    → old container drains and exits
+  7. Cleanup      → remove old container, verify health
+```
+
+**Step 3–4:** the new server starts, connects to Redis (finds existing
+worker state), runs any pending migrations, joins worker networks, and
+starts its background goroutines (health poller, autoscaler, token
+refreshers). It becomes ready when `/readyz` returns 200.
+
+During the overlap between steps 3 and 5, the proxy load-balances across
+both servers. This is safe because they share all routing state via
+Redis. Both can serve any request.
+
+**Step 5:** `by admin update` sends SIGUSR1 to the old server process.
+The old server enters drain mode: health endpoints return 503
+immediately, the proxy detects this and stops routing new requests to it.
+No proxy-specific API call or label change is needed — the health check
+is the universal cutover signal.
+
+**Step 6:** the old server finishes draining in-flight requests and
+exits. Workers remain running, managed by the new server via Redis.
+
+### Failure Modes
+
+- **Pull fails** → abort, nothing changed.
+- **New server fails to start** → stop new container, old server still
+  running. Print rollback instructions (backup location, old image tag).
+- **New server never becomes ready** → timeout, stop new container, old
+  server still serving. No user impact.
+- **Old server won't drain** → after timeout, force-kill. Workers are
+  safe — already managed by new server via Redis.
+
+### Rollback
+
+Not automated. The operator restores the database backup and runs the
+old image. `by admin update` prints the exact commands needed.
+Automated rollback is deferred — it requires deciding what to do with
+migrations that already ran and workers that the new server may have
+spawned.
+
+## What This Does Not Cover
+
+- **Automatic rollback** — manual for now, see above.
+- **Config migration** — if `blockyard.toml` schema changes between
+  versions, the operator updates the config manually. The server
+  validates config on startup and fails with clear messages.

--- a/docs/design/v3/draft.md
+++ b/docs/design/v3/draft.md
@@ -1,9 +1,72 @@
 # blockyard v3 — Draft Notes
 
-v3 has two tracks: the lightweight process backend (the headline feature)
-and deferred single-node features that didn't make the v2 cut. The process
-backend is the architectural work; the deferred items are scoped extensions
-to the existing Docker deployment.
+v3 has two tracks: **operations** (rolling updates, Redis shared state,
+interface extraction) and **runtime** (process backend, pre-fork worker
+model, deferred single-node features). The operations track runs first —
+once v2 is deployed, low-friction updates are immediately needed, and the
+shared state layer directly serves v4 clustering.
+
+## Operations Track
+
+### Rolling Updates
+
+Zero-downtime server updates for production deployments. The full design
+is in [update.md](../update.md). Summary of the approach:
+
+**Two update paths** depending on infrastructure:
+
+- **Basic** (no prerequisites): `docker compose pull && docker compose
+  up -d`. Workers die, sessions restart. The existing behavior,
+  documented rather than orchestrated.
+- **Rolling** (requires Redis + reverse proxy with Docker service
+  discovery): `by admin update`. Old and new server containers overlap,
+  share routing state via Redis, and the proxy shifts traffic based on
+  health checks. Zero downtime, workers survive.
+
+**Key components:**
+
+- **Redis shared state** — session store, worker registry, and worker
+  map move behind Go interfaces with in-memory (default) and Redis
+  implementations. Redis enables the overlap: both servers read/write
+  the same state. This is the same shared state layer v4 needs for
+  multi-replica Kubernetes deployments.
+
+- **Interface extraction** — `SessionStore`, `WorkerRegistry`, and
+  `WorkerMap` become interfaces defined at call sites. Mechanical
+  refactor — existing concrete types already satisfy the shapes. Moved
+  forward from v4 because rolling updates need it now.
+
+- **Worker token persistence** — the HMAC signing key moves from
+  ephemeral to persistent. Primary storage in OpenBao; file-based
+  fallback on the data volume.
+
+- **Drain mode** — `SIGUSR1` triggers a new shutdown path: health
+  endpoints return 503 (proxy-agnostic cutover signal), in-flight
+  requests drain, but workers are left alive. `SIGTERM` retains the
+  existing full-shutdown behavior.
+
+- **`by admin update`** — CLI command orchestrating the full flow: pull,
+  backup, start new container, wait ready, drain old, clean up. Falls
+  back to printing manual compose commands when Redis is absent.
+
+- **Health-check-aware shutdown** — even on the basic path (SIGTERM),
+  the server returns 503 on health endpoints before draining. Any
+  health-check-aware proxy benefits, even without service discovery.
+
+### Client-Server Version Negotiation (#70)
+
+Server exposes its version via a response header or endpoint. CLI checks
+compatibility on connect and warns/errors on mismatch. Compatibility
+policy: CLI major version must match server major version.
+
+### Update Notifications (#71)
+
+Server periodically checks GitHub Releases API and surfaces available
+updates in logs and/or the health endpoint. CLI checks on invocation
+(throttled to once per day) and prints a one-line notice. Both respect
+the update channel (stable vs main).
+
+## Runtime Track
 
 ## Process Backend
 


### PR DESCRIPTION
## Summary
- Add `docs/design/update.md` — full design for zero-downtime rolling updates via Redis shared state + health-check-based proxy cutover
- Add operations track to v3 in roadmap and draft (rolling updates, Redis, interface extraction, drain mode, `by admin update` CLI)
- Move interface extraction from v4 to v3; update stale forward-references in architecture.md
- File #70 (version negotiation) and #71 (update notifications) as standalone issues