### PR TITLE
Fix e2e tests pulling stale published image

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -55,7 +55,7 @@ jobs:
             postgrest/postgrest:v12.2.3
       - name: Build blockyard image from source
         if: github.event_name != 'pull_request'
-        run: docker build -t ghcr.io/cynkra/blockyard:latest --build-arg COVER=1 -f docker/server.Dockerfile .
+        run: docker build -t ghcr.io/cynkra/blockyard:latest -t ghcr.io/cynkra/blockyard:main --build-arg COVER=1 -f docker/server.Dockerfile .
       - name: Pull GHCR images used by examples
         if: github.event_name != 'pull_request'
         run: |
@@ -69,9 +69,10 @@ jobs:
         run: mkdir -p /tmp/e2e-coverage/{cli,server}
       - name: Run e2e tests
         if: github.event_name != 'pull_request'
-        run: sudo --preserve-env=PATH,E2E_GOCOVERDIR go test -v -tags e2e -run ${{ matrix.test }} -timeout 20m ./e2e/...
+        run: sudo --preserve-env=PATH,E2E_GOCOVERDIR,E2E_PULL_POLICY go test -v -tags e2e -run ${{ matrix.test }} -timeout 20m ./e2e/...
         env:
           E2E_GOCOVERDIR: /tmp/e2e-coverage
+          E2E_PULL_POLICY: never
       - name: Convert e2e coverage data
         if: github.event_name != 'pull_request'
         run: |

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -42,6 +42,7 @@ func TestMain(m *testing.M) {
 	// Build the blockyard image from source so tests exercise current code.
 	buildArgs := []string{"build",
 		"-t", "ghcr.io/cynkra/blockyard:latest",
+		"-t", "ghcr.io/cynkra/blockyard:main",
 		"-f", "docker/server.Dockerfile"}
 	if covDir != "" {
 		buildArgs = append(buildArgs, "--build-arg", "COVER=1")

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -75,7 +75,11 @@ func composeUp(t *testing.T, composeFile string) {
 		_ = down.Run()
 	})
 
-	run("up", "-d", "--wait")
+	upArgs := []string{"up", "-d", "--wait"}
+	if p := os.Getenv("E2E_PULL_POLICY"); p != "" {
+		upArgs = append(upArgs, "--pull", p)
+	}
+	run(upArgs...)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- E2e compose files reference `blockyard:main` but the build tags as `:latest`, so compose silently pulled the previously published `:main` from GHCR instead of testing current code
- Tag the build as both `:latest` and `:main` in merge.yml and e2e_test.go
- Add `E2E_PULL_POLICY=never` in CI to prevent silent fallback to remote images