### PR TITLE
Add Dependabot config for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,12 +18,10 @@ updates:
         patterns: ["*"]
 
   - package-ecosystem: docker
-    directory: /docker
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: docker
-    directory: /.devcontainer
+    directories:
+      - /docker
+      - /.devcontainer
+      - /examples/*
     schedule:
       interval: weekly
 


### PR DESCRIPTION
## Summary
- Enable Dependabot version updates for gomod, npm, Docker base images, and GitHub Actions
- Group minor/patch bumps per ecosystem to keep PR volume manageable
- Security updates enabled via API to auto-create PRs for the 13 open vulnerability alerts