### PR TITLE
Add dependency review for PR vulnerability scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/dependency-review-action@v4
         with:
-          fail-on-severity: critical,high
+          fail-on-severity: high
 
   unit:
     if: github.event_name != 'merge_group' && (inputs.job == '' || inputs.job == 'unit')


### PR DESCRIPTION
## Summary
- Add `dependency-review-action` to CI, runs on PRs only
- Blocks when new/updated dependencies introduce critical or high severity CVEs
- Complements govulncheck (reachability analysis) with GitHub advisory DB matching