### PR TITLE
Switch Go builder stage from bookworm to alpine

### DIFF
--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine AS builder
+FROM golang:1.25.8-alpine AS builder
 
 ENV GOTOOLCHAIN=local
 WORKDIR /src


### PR DESCRIPTION
## Summary
- Switch builder stage from `golang:1.25.8-bookworm` to `golang:1.26.1-alpine`
- Runtime stage was already alpine; bookworm in the builder was unnecessary since `CGO_ENABLED=0` bypasses the system libc
- Supersedes #87 (dependabot Go bump) — closes that PR