### PR TITLE
Add bootstrap token, replace curl deploy scripts with CLI

### DIFF
--- a/cmd/blockyard/main.go
+++ b/cmd/blockyard/main.go
@@ -272,6 +272,23 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Bootstrap token — a one-time token that can be exchanged for a real
+	// PAT via POST /api/v1/bootstrap. The token itself never grants API
+	// access; it can only be traded once for a properly scoped PAT.
+	if token := cfg.Server.BootstrapToken; token != "" {
+		if cfg.OIDC == nil || cfg.OIDC.InitialAdmin == "" {
+			slog.Error("bootstrap_token requires oidc.initial_admin to be set")
+			os.Exit(1)
+		}
+		hash := auth.HashPAT(token)
+		if database.PATHashExists(hash) {
+			slog.Info("bootstrap token already redeemed")
+		} else {
+			srv.BootstrapTokenHash = hash
+			slog.Warn("bootstrap token active — exchange via POST /api/v1/bootstrap")
+		}
+	}
+
 	// Clean up orphaned worker library directories from previous runs.
 	if srv.PkgStore != nil {
 		workersDir := filepath.Join(srv.PkgStore.Root(), ".workers")

--- a/docs/src/content/docs/reference/api.md
+++ b/docs/src/content/docs/reference/api.md
@@ -84,6 +84,31 @@ OIDC callback endpoint. Completes the login flow and sets a session cookie.
 
 Clears the session cookie and logs the user out.
 
+### `POST /api/v1/bootstrap`
+
+Exchange a one-time bootstrap token for a Personal Access Token. The
+bootstrap token is configured on the server via `server.bootstrap_token`
+(`BLOCKYARD_SERVER_BOOTSTRAP_TOKEN`). After a single successful exchange the
+bootstrap token is permanently burned — subsequent calls return `410 Gone`.
+
+No API authentication required — the bootstrap token itself is the credential.
+
+**Request:**
+
+```bash
+curl -X POST "$BLOCKYARD/api/v1/bootstrap" \
+  -H "Authorization: Bearer $BOOTSTRAP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"deploy","expires_in":"1h"}'
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | No | Token name (default: `"bootstrap"`) |
+| `expires_in` | `string` | No | Token TTL, e.g. `"1h"`, `"7d"` (default: no expiry) |
+
+**Response:** `201 Created` with the PAT (same schema as `POST /api/v1/users/me/tokens`).
+
 ---
 
 ## Apps

--- a/docs/src/content/docs/reference/config.md
+++ b/docs/src/content/docs/reference/config.md
@@ -48,6 +48,7 @@ shutdown_timeout = "30s"
 | `session_secret` | `string` | — | When `[oidc]` is set without `[openbao]` | Secret for signing session cookies. Supports [vault references](#vault-references). Auto-generated and stored in vault when `[openbao]` is configured. |
 | `external_url` | `string` | — | No | Public-facing URL of the server (used for OIDC redirect URIs) |
 | `trusted_proxies` | `string[]` | — | No | CIDRs whose `X-Forwarded-For` headers to trust (e.g. `["10.0.0.0/8"]`). Each entry must be a valid CIDR. Set via env as comma-separated: `BLOCKYARD_SERVER_TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12`. |
+| `bootstrap_token` | `string` | — | No | One-time token that can be exchanged for a real PAT via `POST /api/v1/bootstrap`. Requires `oidc.initial_admin` to be set. Intended for dev/CI bootstrapping — do not use in production. See [Bootstrap tokens](/reference/api/#post-apiv1bootstrap). |
 
 <Aside type="note">
   API authentication uses [Personal Access Tokens](/guides/authorization/#personal-access-tokens)

--- a/examples/hello-pocketbase/deploy.sh
+++ b/examples/hello-pocketbase/deploy.sh
@@ -2,174 +2,39 @@
 #
 # Deploy the hello-pocketbase app to blockyard.
 #
-# Automates the full flow:
-#   1. OIDC login via Dex (using static demo credentials)
-#   2. PAT creation via the blockyard API
-#   3. App creation, bundle upload, and start
-#
 # Prerequisites:
-#   - docker compose up -d
+#   - docker compose up -d --wait
+#   - by CLI installed
 #
 set -euo pipefail
 
-BASE_URL="${BLOCKYARD_URL:-http://localhost:8080}"
-DEX_URL="${DEX_URL:-http://localhost:5556}"
+export BLOCKYARD_URL="${BLOCKYARD_URL:-http://localhost:8080}"
+BOOTSTRAP_TOKEN="${BLOCKYARD_BOOTSTRAP_TOKEN:-by_bootstrap_for_examples}"
+APP_NAME="hello-pocketbase"
 DEX_EMAIL="demo@example.com"
 DEX_PASSWORD="password"
-APP_NAME="hello-pocketbase"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 APP_DIR="${SCRIPT_DIR}/app"
-COOKIE_JAR="$(mktemp /tmp/blockyard-cookies-XXXXXX)"
-trap 'rm -f "${COOKIE_JAR}"' EXIT
 
-# -- Wait for services -------------------------------------------------------
-
-echo "==> Waiting for blockyard to be ready..."
-for i in $(seq 1 30); do
-  if curl -sf "${BASE_URL}/healthz" > /dev/null 2>&1; then break; fi
-  if [ "$i" -eq 30 ]; then
-    echo "ERROR: blockyard did not become healthy" >&2; exit 1
-  fi
-  sleep 1
-done
-echo "    OK"
-
-# -- Automated OIDC login ----------------------------------------------------
-#
-# Replicate what a browser does:
-#   GET /login -> 302 to Dex auth -> Dex login form -> POST credentials
-#   -> 302 back to /callback -> session cookie set
-#
-
-echo "==> Logging in via Dex..."
-
-LOGIN_PAGE=$(curl -sS -L -c "${COOKIE_JAR}" -b "${COOKIE_JAR}" \
-  -w '\n%{url_effective}' \
-  "${BASE_URL}/login")
-
-EFFECTIVE_URL=$(echo "$LOGIN_PAGE" | tail -1)
-LOGIN_HTML=$(echo "$LOGIN_PAGE" | sed '$d')
-
-FORM_ACTION=$(echo "$LOGIN_HTML" | grep -o 'action="[^"]*"' | head -1 | cut -d'"' -f2 | sed 's/&amp;/\&/g')
-
-if [ -z "$FORM_ACTION" ]; then
-  echo "ERROR: Could not find login form on Dex page" >&2
-  echo "    Effective URL: ${EFFECTIVE_URL}" >&2
-  exit 1
-fi
-
-if [[ "$FORM_ACTION" == /* ]]; then
-  FORM_ACTION="${DEX_URL}${FORM_ACTION}"
-fi
-
-CALLBACK_RESP=$(curl -sS -L -c "${COOKIE_JAR}" -b "${COOKIE_JAR}" \
-  -w '\n%{http_code}' \
-  -d "login=${DEX_EMAIL}&password=${DEX_PASSWORD}" \
-  "${FORM_ACTION}")
-
-CALLBACK_CODE=$(echo "$CALLBACK_RESP" | tail -1)
-if ! grep -q 'blockyard_session' "${COOKIE_JAR}" 2>/dev/null; then
-  echo "ERROR: Login failed -- no session cookie received (HTTP ${CALLBACK_CODE})" >&2
-  exit 1
-fi
-
-echo "    OK"
-
-# -- Create a Personal Access Token ------------------------------------------
-
-echo "==> Creating Personal Access Token..."
-TOKEN_RESP=$(curl -sS -b "${COOKIE_JAR}" \
-  -X POST -H "Content-Type: application/json" \
-  -d '{"name":"deploy-script","expires_in":"1d"}' \
-  "${BASE_URL}/api/v1/users/me/tokens")
-
-TOKEN=$(echo "$TOKEN_RESP" | grep -o '"token":"[^"]*' | cut -d'"' -f4)
-if [ -z "$TOKEN" ]; then
-  echo "ERROR: Failed to create PAT" >&2
-  echo "    Response: ${TOKEN_RESP}" >&2
-  exit 1
-fi
-
-echo "    OK (expires in 24h)"
-
-# -- Helper: authenticated curl -----------------------------------------------
-
-auth() {
-  curl -sf -H "Authorization: Bearer ${TOKEN}" "$@"
-}
-
-# -- Create the app (ignore 409 if it already exists) -------------------------
-
-echo "==> Creating app '${APP_NAME}'..."
-create_resp=$(auth -w "\n%{http_code}" -X POST "${BASE_URL}/api/v1/apps" \
+# Exchange bootstrap token for a real PAT.
+export BLOCKYARD_TOKEN=$(curl -sS -X POST \
+  -H "Authorization: Bearer ${BOOTSTRAP_TOKEN}" \
   -H "Content-Type: application/json" \
-  -d "{\"name\": \"${APP_NAME}\"}" 2>/dev/null || true)
-http_code=$(echo "$create_resp" | tail -1)
-body=$(echo "$create_resp" | sed '$d')
+  -d '{"name":"deploy-script","expires_in":"1h"}' \
+  "${BLOCKYARD_URL}/api/v1/bootstrap" | grep -o '"token":"[^"]*' | cut -d'"' -f4)
 
-if [ "$http_code" = "201" ]; then
-  APP_ID=$(echo "$body" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
-  echo "    Created (id=${APP_ID})"
-elif [ "$http_code" = "409" ]; then
-  echo "    Already exists, fetching..."
-  list_resp=$(auth "${BASE_URL}/api/v1/apps")
-  APP_ID=$(echo "$list_resp" | grep -o "\"id\":\"[^\"]*\",\"name\":\"${APP_NAME}\"" | head -1 | cut -d'"' -f4)
-  echo "    Found (id=${APP_ID})"
-else
-  echo "ERROR: Failed to create app (HTTP ${http_code})" >&2
-  echo "$body" >&2
+if [ -z "${BLOCKYARD_TOKEN}" ]; then
+  echo "ERROR: failed to exchange bootstrap token" >&2
   exit 1
 fi
 
-# -- Make the app accessible to all authenticated users ----------------------
-
-echo "==> Setting app access to logged_in..."
-auth -X PATCH "${BASE_URL}/api/v1/apps/${APP_ID}" \
-  -H "Content-Type: application/json" \
-  -d '{"access_type":"logged_in"}' > /dev/null
-echo "    OK"
-
-# -- Bundle the app as tar.gz ------------------------------------------------
-
-echo "==> Bundling app..."
-BUNDLE_FILE="$(mktemp /tmp/blockr-XXXXXX).tar.gz"
-tar -czf "${BUNDLE_FILE}" -C "${APP_DIR}" .
-echo "    ${BUNDLE_FILE} ($(wc -c < "${BUNDLE_FILE}" | tr -d ' ') bytes)"
-
-# -- Upload the bundle --------------------------------------------------------
-
-echo "==> Uploading bundle..."
-upload_resp=$(auth -X POST "${BASE_URL}/api/v1/apps/${APP_ID}/bundles" \
-  -H "Content-Type: application/octet-stream" \
-  --data-binary "@${BUNDLE_FILE}")
-rm -f "${BUNDLE_FILE}"
-
-TASK_ID=$(echo "$upload_resp" | grep -o '"task_id":"[^"]*"' | head -1 | cut -d'"' -f4)
-BUNDLE_ID=$(echo "$upload_resp" | grep -o '"bundle_id":"[^"]*"' | head -1 | cut -d'"' -f4)
-echo "    bundle=${BUNDLE_ID}"
-echo "    task=${TASK_ID}"
-
-# -- Stream build logs until the task finishes --------------------------------
-
-echo "==> Restoring dependencies (this may take a while on first run)..."
-auth "${BASE_URL}/api/v1/tasks/${TASK_ID}/logs"
-
-task_resp=$(auth "${BASE_URL}/api/v1/tasks/${TASK_ID}" 2>/dev/null || true)
-status=$(echo "$task_resp" | grep -o '"status":"[^"]*"' | head -1 | cut -d'"' -f4)
-if [ "$status" != "completed" ]; then
-  echo "ERROR: Restore failed (status=${status})" >&2
-  exit 1
-fi
-echo "    Restore complete!"
-
-# -- Start the app ------------------------------------------------------------
-
-echo "==> Starting app..."
-auth -X POST "${BASE_URL}/api/v1/apps/${APP_ID}/start" > /dev/null
+by deploy "${APP_DIR}" --yes --wait --name "${APP_NAME}"
+by access set-type "${APP_NAME}" logged_in
+by enable "${APP_NAME}"
 
 echo ""
-echo "Done! Open ${BASE_URL}/app/${APP_NAME}/ in your browser."
+echo "Done! Open ${BLOCKYARD_URL}/app/${APP_NAME}/ in your browser."
 echo "You will be redirected to Dex to log in."
 echo ""
 echo "  User 1:  ${DEX_EMAIL} / ${DEX_PASSWORD}"

--- a/examples/hello-pocketbase/docker-compose.yml
+++ b/examples/hello-pocketbase/docker-compose.yml
@@ -98,6 +98,7 @@ services:
       BLOCKYARD_OIDC_CLIENT_ID: blockyard
       BLOCKYARD_OIDC_CLIENT_SECRET: blockyard-dex-secret
       BLOCKYARD_OIDC_INITIAL_ADMIN: Cg1kZW1vLXVzZXItMDAxEgVsb2NhbA
+      BLOCKYARD_SERVER_BOOTSTRAP_TOKEN: by_bootstrap_for_examples
       # OpenBao (AppRole auth — session_secret is auto-generated via vault)
       BLOCKYARD_OPENBAO_ADDRESS: http://openbao:8200
       BLOCKYARD_OPENBAO_ROLE_ID: blockyard-server

--- a/examples/hello-postgrest/deploy.sh
+++ b/examples/hello-postgrest/deploy.sh
@@ -2,174 +2,39 @@
 #
 # Deploy the hello-postgrest app to blockyard (PostgREST board storage).
 #
-# Automates the full flow:
-#   1. OIDC login via Dex (using static demo credentials)
-#   2. PAT creation via the blockyard API
-#   3. App creation, bundle upload, and start
-#
 # Prerequisites:
-#   - docker compose up -d
+#   - docker compose up -d --wait
+#   - by CLI installed
 #
 set -euo pipefail
 
-BASE_URL="${BLOCKYARD_URL:-http://localhost:8080}"
-DEX_URL="${DEX_URL:-http://localhost:5556}"
+export BLOCKYARD_URL="${BLOCKYARD_URL:-http://localhost:8080}"
+BOOTSTRAP_TOKEN="${BLOCKYARD_BOOTSTRAP_TOKEN:-by_bootstrap_for_examples}"
+APP_NAME="hello-postgrest"
 DEX_EMAIL="demo@example.com"
 DEX_PASSWORD="password"
-APP_NAME="hello-postgrest"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 APP_DIR="${SCRIPT_DIR}/app"
-COOKIE_JAR="$(mktemp /tmp/blockyard-cookies-XXXXXX)"
-trap 'rm -f "${COOKIE_JAR}"' EXIT
 
-# -- Wait for services -------------------------------------------------------
-
-echo "==> Waiting for blockyard to be ready..."
-for i in $(seq 1 30); do
-  if curl -sf "${BASE_URL}/healthz" > /dev/null 2>&1; then break; fi
-  if [ "$i" -eq 30 ]; then
-    echo "ERROR: blockyard did not become healthy" >&2; exit 1
-  fi
-  sleep 1
-done
-echo "    OK"
-
-# -- Automated OIDC login ----------------------------------------------------
-#
-# Replicate what a browser does:
-#   GET /login -> 302 to Dex auth -> Dex login form -> POST credentials
-#   -> 302 back to /callback -> session cookie set
-#
-
-echo "==> Logging in via Dex..."
-
-LOGIN_PAGE=$(curl -sS -L -c "${COOKIE_JAR}" -b "${COOKIE_JAR}" \
-  -w '\n%{url_effective}' \
-  "${BASE_URL}/login")
-
-EFFECTIVE_URL=$(echo "$LOGIN_PAGE" | tail -1)
-LOGIN_HTML=$(echo "$LOGIN_PAGE" | sed '$d')
-
-FORM_ACTION=$(echo "$LOGIN_HTML" | grep -o 'action="[^"]*"' | head -1 | cut -d'"' -f2 | sed 's/&amp;/\&/g')
-
-if [ -z "$FORM_ACTION" ]; then
-  echo "ERROR: Could not find login form on Dex page" >&2
-  echo "    Effective URL: ${EFFECTIVE_URL}" >&2
-  exit 1
-fi
-
-if [[ "$FORM_ACTION" == /* ]]; then
-  FORM_ACTION="${DEX_URL}${FORM_ACTION}"
-fi
-
-CALLBACK_RESP=$(curl -sS -L -c "${COOKIE_JAR}" -b "${COOKIE_JAR}" \
-  -w '\n%{http_code}' \
-  -d "login=${DEX_EMAIL}&password=${DEX_PASSWORD}" \
-  "${FORM_ACTION}")
-
-CALLBACK_CODE=$(echo "$CALLBACK_RESP" | tail -1)
-if ! grep -q 'blockyard_session' "${COOKIE_JAR}" 2>/dev/null; then
-  echo "ERROR: Login failed -- no session cookie received (HTTP ${CALLBACK_CODE})" >&2
-  exit 1
-fi
-
-echo "    OK"
-
-# -- Create a Personal Access Token ------------------------------------------
-
-echo "==> Creating Personal Access Token..."
-TOKEN_RESP=$(curl -sS -b "${COOKIE_JAR}" \
-  -X POST -H "Content-Type: application/json" \
-  -d '{"name":"deploy-script","expires_in":"1d"}' \
-  "${BASE_URL}/api/v1/users/me/tokens")
-
-TOKEN=$(echo "$TOKEN_RESP" | grep -o '"token":"[^"]*' | cut -d'"' -f4)
-if [ -z "$TOKEN" ]; then
-  echo "ERROR: Failed to create PAT" >&2
-  echo "    Response: ${TOKEN_RESP}" >&2
-  exit 1
-fi
-
-echo "    OK (expires in 24h)"
-
-# -- Helper: authenticated curl -----------------------------------------------
-
-auth() {
-  curl -sf -H "Authorization: Bearer ${TOKEN}" "$@"
-}
-
-# -- Create the app (ignore 409 if it already exists) -------------------------
-
-echo "==> Creating app '${APP_NAME}'..."
-create_resp=$(auth -w "\n%{http_code}" -X POST "${BASE_URL}/api/v1/apps" \
+# Exchange bootstrap token for a real PAT.
+export BLOCKYARD_TOKEN=$(curl -sS -X POST \
+  -H "Authorization: Bearer ${BOOTSTRAP_TOKEN}" \
   -H "Content-Type: application/json" \
-  -d "{\"name\": \"${APP_NAME}\"}" 2>/dev/null || true)
-http_code=$(echo "$create_resp" | tail -1)
-body=$(echo "$create_resp" | sed '$d')
+  -d '{"name":"deploy-script","expires_in":"1h"}' \
+  "${BLOCKYARD_URL}/api/v1/bootstrap" | grep -o '"token":"[^"]*' | cut -d'"' -f4)
 
-if [ "$http_code" = "201" ]; then
-  APP_ID=$(echo "$body" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
-  echo "    Created (id=${APP_ID})"
-elif [ "$http_code" = "409" ]; then
-  echo "    Already exists, fetching..."
-  list_resp=$(auth "${BASE_URL}/api/v1/apps")
-  APP_ID=$(echo "$list_resp" | grep -o "\"id\":\"[^\"]*\",\"name\":\"${APP_NAME}\"" | head -1 | cut -d'"' -f4)
-  echo "    Found (id=${APP_ID})"
-else
-  echo "ERROR: Failed to create app (HTTP ${http_code})" >&2
-  echo "$body" >&2
+if [ -z "${BLOCKYARD_TOKEN}" ]; then
+  echo "ERROR: failed to exchange bootstrap token" >&2
   exit 1
 fi
 
-# -- Make the app accessible to all authenticated users ----------------------
-
-echo "==> Setting app access to logged_in..."
-auth -X PATCH "${BASE_URL}/api/v1/apps/${APP_ID}" \
-  -H "Content-Type: application/json" \
-  -d '{"access_type":"logged_in"}' > /dev/null
-echo "    OK"
-
-# -- Bundle the app as tar.gz ------------------------------------------------
-
-echo "==> Bundling app..."
-BUNDLE_FILE="$(mktemp /tmp/blockr-XXXXXX).tar.gz"
-tar -czf "${BUNDLE_FILE}" -C "${APP_DIR}" .
-echo "    ${BUNDLE_FILE} ($(wc -c < "${BUNDLE_FILE}" | tr -d ' ') bytes)"
-
-# -- Upload the bundle --------------------------------------------------------
-
-echo "==> Uploading bundle..."
-upload_resp=$(auth -X POST "${BASE_URL}/api/v1/apps/${APP_ID}/bundles" \
-  -H "Content-Type: application/octet-stream" \
-  --data-binary "@${BUNDLE_FILE}")
-rm -f "${BUNDLE_FILE}"
-
-TASK_ID=$(echo "$upload_resp" | grep -o '"task_id":"[^"]*"' | head -1 | cut -d'"' -f4)
-BUNDLE_ID=$(echo "$upload_resp" | grep -o '"bundle_id":"[^"]*"' | head -1 | cut -d'"' -f4)
-echo "    bundle=${BUNDLE_ID}"
-echo "    task=${TASK_ID}"
-
-# -- Stream build logs until the task finishes --------------------------------
-
-echo "==> Restoring dependencies (this may take a while on first run)..."
-auth "${BASE_URL}/api/v1/tasks/${TASK_ID}/logs"
-
-task_resp=$(auth "${BASE_URL}/api/v1/tasks/${TASK_ID}" 2>/dev/null || true)
-status=$(echo "$task_resp" | grep -o '"status":"[^"]*"' | head -1 | cut -d'"' -f4)
-if [ "$status" != "completed" ]; then
-  echo "ERROR: Restore failed (status=${status})" >&2
-  exit 1
-fi
-echo "    Restore complete!"
-
-# -- Start the app ------------------------------------------------------------
-
-echo "==> Starting app..."
-auth -X POST "${BASE_URL}/api/v1/apps/${APP_ID}/start" > /dev/null
+by deploy "${APP_DIR}" --yes --wait --name "${APP_NAME}"
+by access set-type "${APP_NAME}" logged_in
+by enable "${APP_NAME}"
 
 echo ""
-echo "Done! Open ${BASE_URL}/app/${APP_NAME}/ in your browser."
+echo "Done! Open ${BLOCKYARD_URL}/app/${APP_NAME}/ in your browser."
 echo "You will be redirected to Dex to log in."
 echo ""
 echo "  User 1:  ${DEX_EMAIL} / ${DEX_PASSWORD}"

--- a/examples/hello-postgrest/docker-compose.yml
+++ b/examples/hello-postgrest/docker-compose.yml
@@ -128,6 +128,7 @@ services:
       BLOCKYARD_OIDC_CLIENT_ID: blockyard
       BLOCKYARD_OIDC_CLIENT_SECRET: blockyard-dex-secret
       BLOCKYARD_OIDC_INITIAL_ADMIN: Cg1kZW1vLXVzZXItMDAxEgVsb2NhbA
+      BLOCKYARD_SERVER_BOOTSTRAP_TOKEN: by_bootstrap_for_examples
       # OpenBao (AppRole auth — session_secret is auto-generated via vault)
       BLOCKYARD_OPENBAO_ADDRESS: http://openbao:8200
       BLOCKYARD_OPENBAO_ROLE_ID: blockyard-server

--- a/examples/hello-shiny/deploy.sh
+++ b/examples/hello-shiny/deploy.sh
@@ -2,173 +2,38 @@
 #
 # Deploy the hello-shiny app to blockyard.
 #
-# Automates the full flow:
-#   1. OIDC login via Dex (using static demo credentials)
-#   2. PAT creation via the blockyard API
-#   3. App creation, bundle upload, and start
-#
 # Prerequisites:
-#   - docker compose up -d
+#   - docker compose up -d --wait
+#   - by CLI installed
 #
 set -euo pipefail
 
-BASE_URL="${BLOCKYARD_URL:-http://localhost:8080}"
-DEX_URL="${DEX_URL:-http://localhost:5556}"
+export BLOCKYARD_URL="${BLOCKYARD_URL:-http://localhost:8080}"
+BOOTSTRAP_TOKEN="${BLOCKYARD_BOOTSTRAP_TOKEN:-by_bootstrap_for_examples}"
+APP_NAME="hello"
 DEX_EMAIL="demo@example.com"
 DEX_PASSWORD="password"
-APP_NAME="hello"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 APP_DIR="${SCRIPT_DIR}/app"
-COOKIE_JAR="$(mktemp /tmp/blockyard-cookies-XXXXXX)"
-trap 'rm -f "${COOKIE_JAR}"' EXIT
 
-# -- Wait for services -------------------------------------------------------
-
-echo "==> Waiting for blockyard to be ready..."
-for i in $(seq 1 30); do
-  if curl -sf "${BASE_URL}/healthz" > /dev/null 2>&1; then break; fi
-  if [ "$i" -eq 30 ]; then
-    echo "ERROR: blockyard did not become healthy" >&2; exit 1
-  fi
-  sleep 1
-done
-echo "    OK"
-
-# -- Automated OIDC login ----------------------------------------------------
-#
-# Replicate what a browser does:
-#   GET /login -> 302 to Dex auth -> Dex login form -> POST credentials
-#   -> 302 back to /callback -> session cookie set
-#
-
-echo "==> Logging in via Dex..."
-
-# Step 1: Hit /login, follow all redirects to reach the Dex login form.
-# This sets the blockyard_oidc_state cookie and ends on Dex's login page.
-LOGIN_PAGE=$(curl -sS -L -c "${COOKIE_JAR}" -b "${COOKIE_JAR}" \
-  -w '\n%{url_effective}' \
-  "${BASE_URL}/login")
-
-EFFECTIVE_URL=$(echo "$LOGIN_PAGE" | tail -1)
-LOGIN_HTML=$(echo "$LOGIN_PAGE" | sed '$d')
-
-# Step 2: Extract the form action URL from the Dex login page.
-# Dex renders: <form method="post" action="/auth/local/login?back=...&amp;req=...">
-FORM_ACTION=$(echo "$LOGIN_HTML" | grep -o 'action="[^"]*"' | head -1 | cut -d'"' -f2 | sed 's/&amp;/\&/g')
-
-if [ -z "$FORM_ACTION" ]; then
-  echo "ERROR: Could not find login form on Dex page" >&2
-  echo "    Effective URL: ${EFFECTIVE_URL}" >&2
-  exit 1
-fi
-
-# If the action is a relative path, prepend the Dex origin.
-if [[ "$FORM_ACTION" == /* ]]; then
-  FORM_ACTION="${DEX_URL}${FORM_ACTION}"
-fi
-
-# Step 3: POST credentials to Dex, follow redirects back to blockyard's
-# /callback which sets the blockyard_session cookie.
-CALLBACK_RESP=$(curl -sS -L -c "${COOKIE_JAR}" -b "${COOKIE_JAR}" \
-  -w '\n%{http_code}' \
-  -d "login=${DEX_EMAIL}&password=${DEX_PASSWORD}" \
-  "${FORM_ACTION}")
-
-CALLBACK_CODE=$(echo "$CALLBACK_RESP" | tail -1)
-if ! grep -q 'blockyard_session' "${COOKIE_JAR}" 2>/dev/null; then
-  echo "ERROR: Login failed -- no session cookie received (HTTP ${CALLBACK_CODE})" >&2
-  exit 1
-fi
-
-echo "    OK"
-
-# -- Create a Personal Access Token ------------------------------------------
-
-echo "==> Creating Personal Access Token..."
-TOKEN_RESP=$(curl -sS -b "${COOKIE_JAR}" \
-  -X POST -H "Content-Type: application/json" \
-  -d '{"name":"deploy-script","expires_in":"1d"}' \
-  "${BASE_URL}/api/v1/users/me/tokens")
-
-TOKEN=$(echo "$TOKEN_RESP" | grep -o '"token":"[^"]*' | cut -d'"' -f4)
-if [ -z "$TOKEN" ]; then
-  echo "ERROR: Failed to create PAT" >&2
-  echo "    Response: ${TOKEN_RESP}" >&2
-  exit 1
-fi
-
-echo "    OK (expires in 24h)"
-
-# -- Helper: authenticated curl -----------------------------------------------
-
-auth() {
-  curl -sf -H "Authorization: Bearer ${TOKEN}" "$@"
-}
-
-# -- Create the app (ignore 409 if it already exists) -------------------------
-
-echo "==> Creating app '${APP_NAME}'..."
-create_resp=$(auth -w "\n%{http_code}" -X POST "${BASE_URL}/api/v1/apps" \
+# Exchange bootstrap token for a real PAT.
+export BLOCKYARD_TOKEN=$(curl -sS -X POST \
+  -H "Authorization: Bearer ${BOOTSTRAP_TOKEN}" \
   -H "Content-Type: application/json" \
-  -d "{\"name\": \"${APP_NAME}\"}" 2>/dev/null || true)
-http_code=$(echo "$create_resp" | tail -1)
-body=$(echo "$create_resp" | sed '$d')
+  -d '{"name":"deploy-script","expires_in":"1h"}' \
+  "${BLOCKYARD_URL}/api/v1/bootstrap" | grep -o '"token":"[^"]*' | cut -d'"' -f4)
 
-if [ "$http_code" = "201" ]; then
-  APP_ID=$(echo "$body" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
-  echo "    Created (id=${APP_ID})"
-elif [ "$http_code" = "409" ]; then
-  echo "    Already exists, fetching..."
-  list_resp=$(auth "${BASE_URL}/api/v1/apps")
-  APP_ID=$(echo "$list_resp" | grep -o "\"id\":\"[^\"]*\",\"name\":\"${APP_NAME}\"" | head -1 | cut -d'"' -f4)
-  echo "    Found (id=${APP_ID})"
-else
-  echo "ERROR: Failed to create app (HTTP ${http_code})" >&2
-  echo "$body" >&2
+if [ -z "${BLOCKYARD_TOKEN}" ]; then
+  echo "ERROR: failed to exchange bootstrap token" >&2
   exit 1
 fi
 
-# -- Bundle the app as tar.gz ------------------------------------------------
-
-echo "==> Bundling app..."
-BUNDLE_FILE="$(mktemp /tmp/hello-XXXXXX).tar.gz"
-tar -czf "${BUNDLE_FILE}" -C "${APP_DIR}" .
-echo "    ${BUNDLE_FILE} ($(wc -c < "${BUNDLE_FILE}" | tr -d ' ') bytes)"
-
-# -- Upload the bundle --------------------------------------------------------
-
-echo "==> Uploading bundle..."
-upload_resp=$(auth -X POST "${BASE_URL}/api/v1/apps/${APP_ID}/bundles" \
-  -H "Content-Type: application/octet-stream" \
-  --data-binary "@${BUNDLE_FILE}")
-rm -f "${BUNDLE_FILE}"
-
-TASK_ID=$(echo "$upload_resp" | grep -o '"task_id":"[^"]*"' | head -1 | cut -d'"' -f4)
-BUNDLE_ID=$(echo "$upload_resp" | grep -o '"bundle_id":"[^"]*"' | head -1 | cut -d'"' -f4)
-echo "    bundle=${BUNDLE_ID}"
-echo "    task=${TASK_ID}"
-
-# -- Stream build logs until the task finishes --------------------------------
-
-echo "==> Restoring dependencies (this may take a while on first run)..."
-auth "${BASE_URL}/api/v1/tasks/${TASK_ID}/logs"
-
-task_resp=$(auth "${BASE_URL}/api/v1/tasks/${TASK_ID}" 2>/dev/null || true)
-status=$(echo "$task_resp" | grep -o '"status":"[^"]*"' | head -1 | cut -d'"' -f4)
-if [ "$status" != "completed" ]; then
-  echo "ERROR: Restore failed (status=${status})" >&2
-  exit 1
-fi
-echo "    Restore complete!"
-
-# -- Start the app ------------------------------------------------------------
-
-echo "==> Starting app..."
-auth -X POST "${BASE_URL}/api/v1/apps/${APP_ID}/start" > /dev/null
+by deploy "${APP_DIR}" --yes --wait --name "${APP_NAME}"
+by enable "${APP_NAME}"
 
 echo ""
-echo "Done! Open ${BASE_URL}/app/${APP_NAME}/ in your browser."
+echo "Done! Open ${BLOCKYARD_URL}/app/${APP_NAME}/ in your browser."
 echo "You will be redirected to Dex to log in."
 echo ""
 echo "  Email:    ${DEX_EMAIL}"

--- a/examples/hello-shiny/docker-compose.yml
+++ b/examples/hello-shiny/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       BLOCKYARD_OIDC_CLIENT_ID: blockyard
       BLOCKYARD_OIDC_CLIENT_SECRET: blockyard-dex-secret
       BLOCKYARD_OIDC_INITIAL_ADMIN: Cg1kZW1vLXVzZXItMDAxEgVsb2NhbA
+      BLOCKYARD_SERVER_BOOTSTRAP_TOKEN: by_bootstrap_for_examples
     cap_add:
       - NET_ADMIN
     healthcheck:

--- a/internal/api/bootstrap.go
+++ b/internal/api/bootstrap.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/cynkra/blockyard/internal/auth"
+	"github.com/cynkra/blockyard/internal/server"
+)
+
+// ExchangeBootstrapToken handles POST /api/v1/bootstrap.
+//
+// Exchanges a one-time bootstrap token for a real PAT. The bootstrap
+// token is burned after the first successful exchange.
+func ExchangeBootstrapToken(srv *server.Server) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Is bootstrapping configured?
+		if len(srv.BootstrapTokenHash) == 0 {
+			writeError(w, http.StatusNotFound, "not_found", "bootstrap not available")
+			return
+		}
+
+		// Already redeemed?
+		if srv.BootstrapRedeemed.Load() {
+			writeError(w, http.StatusGone, "gone", "bootstrap token already redeemed")
+			return
+		}
+
+		// Extract bearer token.
+		header := r.Header.Get("Authorization")
+		if !strings.HasPrefix(header, "Bearer ") {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "bearer token required")
+			return
+		}
+		token := strings.TrimPrefix(header, "Bearer ")
+
+		// Constant-time comparison of hashes.
+		hash := auth.HashPAT(token)
+		if subtle.ConstantTimeCompare(hash, srv.BootstrapTokenHash) != 1 {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "invalid bootstrap token")
+			return
+		}
+
+		// Parse request body for PAT parameters.
+		var body struct {
+			Name      string `json:"name"`
+			ExpiresIn string `json:"expires_in"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			badRequest(w, "invalid request body")
+			return
+		}
+		if body.Name == "" {
+			body.Name = "bootstrap"
+		}
+
+		var expiresAt *string
+		if body.ExpiresIn != "" {
+			dur, ok := parseDuration(body.ExpiresIn)
+			if !ok {
+				badRequest(w, "invalid expires_in format, use e.g. '90d', '24h'")
+				return
+			}
+			exp := time.Now().Add(dur).UTC().Format(time.RFC3339)
+			expiresAt = &exp
+		}
+
+		// Ensure the initial admin user exists.
+		sub := srv.Config.OIDC.InitialAdmin
+		if _, err := srv.DB.UpsertUserWithRole(sub, "bootstrap@blockyard.local", "Bootstrap User", "admin"); err != nil {
+			serverError(w, "failed to create bootstrap user")
+			return
+		}
+
+		// Generate a real PAT.
+		plaintext, patHash, err := auth.GeneratePAT()
+		if err != nil {
+			serverError(w, "failed to generate token")
+			return
+		}
+
+		id := uuid.New().String()
+		pat, err := srv.DB.CreatePAT(id, patHash, sub, body.Name, expiresAt)
+		if err != nil {
+			serverError(w, "failed to create token")
+			return
+		}
+
+		// Burn the bootstrap token (atomic — only one caller wins).
+		if !srv.BootstrapRedeemed.CompareAndSwap(false, true) {
+			writeError(w, http.StatusGone, "gone", "bootstrap token already redeemed")
+			return
+		}
+
+		// Persist the redeemed state: store the bootstrap hash as a
+		// revoked PAT sentinel so it survives server restarts.
+		revoked := time.Now().UTC().Format(time.RFC3339)
+		srv.DB.CreatePAT("bootstrap-redeemed", hash, sub, "bootstrap-redeemed", &revoked) //nolint:errcheck
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":         pat.ID,
+			"name":       pat.Name,
+			"token":      plaintext,
+			"created_at": pat.CreatedAt,
+			"expires_at": pat.ExpiresAt,
+		})
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -194,6 +194,13 @@ func NewRouter(srv *server.Server) http.Handler {
 		r.Post("/logout", auth.LogoutHandler(authDeps))
 	})
 
+	// Bootstrap token exchange — one-time use, no auth middleware.
+	r.Group(func(r chi.Router) {
+		r.Use(limitBody)
+		r.Use(apiCSP)
+		r.Post("/api/v1/bootstrap", ExchangeBootstrapToken(srv))
+	})
+
 	// Credential exchange — moderate rate limit.
 	r.Group(func(r chi.Router) {
 		r.Use(httprate.LimitByIP(20, time.Minute))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,7 @@ type ServerConfig struct {
 	LogLevel             string   `toml:"log_level"`              // debug, info, warn, error (default: info)
 	TrustedProxies       []string `toml:"trusted_proxies"`        // CIDRs whose X-Forwarded-For to trust (e.g. ["10.0.0.0/8"])
 	SkipDockerPreflight  bool     `toml:"skip_docker_preflight"`  // skip Docker-dependent preflight checks at startup
+	BootstrapToken       string   `toml:"bootstrap_token"`        // dev only: one-time token exchanged for a real PAT via POST /api/v1/bootstrap
 }
 
 type DockerConfig struct {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1094,6 +1094,14 @@ func (db *DB) CreatePAT(id string, tokenHash []byte, userSub, name string, expir
 	}, nil
 }
 
+// PATHashExists returns true if a PAT with the given hash exists (any state).
+func (db *DB) PATHashExists(tokenHash []byte) bool {
+	var count int
+	err := db.QueryRow(db.rebind(
+		`SELECT COUNT(*) FROM personal_access_tokens WHERE token_hash = ?`), tokenHash).Scan(&count)
+	return err == nil && count > 0
+}
+
 // LookupPATByHash looks up a PAT by its SHA-256 hash, joined with the
 // owning user. Returns nil if not found.
 func (db *DB) LookupPATByHash(tokenHash []byte) (*PATLookupResult, error) {

--- a/internal/server/state.go
+++ b/internal/server/state.go
@@ -69,6 +69,12 @@ type Server struct {
 	// Prevents a second install from starting a parallel transfer.
 	transferring sync.Map // workerID → bool
 
+	// Bootstrap token state — one-time token that can be exchanged for
+	// a real PAT via POST /api/v1/bootstrap. Hash is set at startup;
+	// Redeemed is flipped to true on first successful exchange.
+	BootstrapTokenHash []byte
+	BootstrapRedeemed  atomic.Bool
+
 	// Version is the server version string, set at build time.
 	Version string
 


### PR DESCRIPTION
## Summary

- Add `BLOCKYARD_SERVER_BOOTSTRAP_TOKEN` — a one-time token exchanged for a real PAT via `POST /api/v1/bootstrap`, permanently burned after first use (DB-persisted)
- Rewrite example deploy scripts from ~175 lines of curl (OIDC login, PAT creation, raw API calls) to ~45 lines using the `by` CLI
- Document the new config field and API endpoint