### PR TITLE
Fix #106: hide bootstrap-redeemed token from Profile

### DIFF
--- a/cmd/blockyard/main.go
+++ b/cmd/blockyard/main.go
@@ -283,6 +283,9 @@ func main() {
 		hash := auth.HashPAT(token)
 		if database.PATHashExists(hash) {
 			slog.Info("bootstrap token already redeemed")
+			// Ensure the sentinel is marked revoked (back-compat for
+			// deployments that created it before we set revoked = 1).
+			database.RevokePAT("bootstrap-redeemed", cfg.OIDC.InitialAdmin) //nolint:errcheck
 		} else {
 			srv.BootstrapTokenHash = hash
 			slog.Warn("bootstrap token active — exchange via POST /api/v1/bootstrap")

--- a/internal/api/bootstrap.go
+++ b/internal/api/bootstrap.go
@@ -101,6 +101,7 @@ func ExchangeBootstrapToken(srv *server.Server) http.HandlerFunc {
 		// revoked PAT sentinel so it survives server restarts.
 		revoked := time.Now().UTC().Format(time.RFC3339)
 		srv.DB.CreatePAT("bootstrap-redeemed", hash, sub, "bootstrap-redeemed", &revoked) //nolint:errcheck
+		srv.DB.RevokePAT("bootstrap-redeemed", sub)                                       //nolint:errcheck
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1130,7 +1130,7 @@ func (db *DB) ListPATsByUser(userSub string) ([]PATRow, error) {
 	err := db.DB.Select(&pats, db.rebind(
 		`SELECT id, user_sub, name, created_at, expires_at, last_used_at, revoked
 		 FROM personal_access_tokens
-		 WHERE user_sub = ?
+		 WHERE user_sub = ? AND revoked = 0
 		 ORDER BY created_at DESC`),
 		userSub,
 	)


### PR DESCRIPTION
## Summary
- Filter revoked tokens from `ListPATsByUser` query (`AND revoked = 0`)
- Mark bootstrap-redeemed sentinel as revoked immediately after creation
- Backfill on startup for existing deployments where the sentinel has `revoked = 0`