### PR TITLE
Fix token list not updating after creation (#109)

### DIFF
--- a/internal/ui/templates/profile.html
+++ b/internal/ui/templates/profile.html
@@ -38,28 +38,8 @@
     </form>
     <div id="pat-result"></div>
 
-    {{if .Tokens}}
-    <table class="data-table">
-        <thead>
-            <tr><th>Name</th><th>Created</th><th>Last used</th><th></th></tr>
-        </thead>
-        <tbody>
-        {{range .Tokens}}
-            <tr>
-                <td>{{.Name}}</td>
-                <td>{{.CreatedAt | timeAgo}}</td>
-                <td>{{if .LastUsedAt}}{{.LastUsedAt | timeAgo}}{{else}}Never{{end}}</td>
-                <td><button class="btn btn-sm btn-danger"
-                            hx-delete="/api/v1/users/me/tokens/{{.ID}}"
-                            hx-confirm="Revoke token '{{.Name}}'? This cannot be undone."
-                            hx-target="closest tr"
-                            hx-swap="outerHTML swap:0.2s">Revoke</button></td>
-            </tr>
-        {{end}}
-        </tbody>
-    </table>
-    {{else}}
-    <p class="empty-state">No tokens created.</p>
-    {{end}}
+    <div id="token-list">
+    {{template "tokenList" .Tokens}}
+    </div>
 </div>
 {{end}}

--- a/internal/ui/templates/token_list.html
+++ b/internal/ui/templates/token_list.html
@@ -1,0 +1,25 @@
+{{define "tokenList"}}
+{{if .}}
+<table class="data-table">
+    <thead>
+        <tr><th>Name</th><th>Created</th><th>Last used</th><th></th></tr>
+    </thead>
+    <tbody>
+    {{range .}}
+        <tr>
+            <td>{{.Name}}</td>
+            <td>{{.CreatedAt | timeAgo}}</td>
+            <td>{{if .LastUsedAt}}{{.LastUsedAt | timeAgo}}{{else}}Never{{end}}</td>
+            <td><button class="btn btn-sm btn-danger"
+                        hx-delete="/api/v1/users/me/tokens/{{.ID}}"
+                        hx-confirm="Revoke token '{{.Name}}'? This cannot be undone."
+                        hx-target="closest tr"
+                        hx-swap="outerHTML swap:0.2s">Revoke</button></td>
+        </tr>
+    {{end}}
+    </tbody>
+</table>
+{{else}}
+<p class="empty-state">No tokens created.</p>
+{{end}}
+{{end}}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -145,9 +145,16 @@ func New() *UI {
 		)
 		pages[name] = t
 	}
+	// Re-parse profile.html with the shared token_list fragment.
+	pages["profile.html"] = template.Must(
+		template.New("").Funcs(funcMap).ParseFS(
+			content, "templates/base.html", "templates/profile.html", "templates/token_list.html",
+		),
+	)
 
 	fragments := make(map[string]*template.Template)
 	fragmentNames := []string{
+		"token_list.html",
 		"pat_created.html",
 		"sidebar.html",
 		"tab_overview.html",
@@ -602,7 +609,24 @@ func (ui *UI) createToken(srv *server.Server) http.HandlerFunc {
 		w.Header().Set("Content-Type", "text/html")
 		if err := ui.fragments["pat_created.html"].Execute(w, struct{ Token string }{Token: plaintext}); err != nil {
 			http.Error(w, "Internal error", http.StatusInternalServerError)
+			return
 		}
+
+		// OOB swap: refresh the token list table.
+		pats, _ := srv.DB.ListPATsByUser(caller.Sub)
+		tokens := make([]tokenEntry, len(pats))
+		for i, p := range pats {
+			createdAt := p.CreatedAt
+			tokens[i] = tokenEntry{
+				ID:         p.ID,
+				Name:       p.Name,
+				CreatedAt:  &createdAt,
+				LastUsedAt: p.LastUsedAt,
+			}
+		}
+		fmt.Fprint(w, `<div id="token-list" hx-swap-oob="true">`)
+		_ = ui.fragments["token_list.html"].ExecuteTemplate(w, "tokenList", tokens)
+		fmt.Fprint(w, `</div>`)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Extract token table into a shared `token_list.html` fragment template
- After creating a PAT, return an HTMX OOB swap that refreshes the `#token-list` div with the updated table
- Closes #109