### PR TITLE
Refresh user docs after phases 3-7 and 3-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,18 @@ A containerized hosting platform for [Shiny](https://shiny.posit.co/) applicatio
 
 ## Overview
 
-Blockyard acts as a container-orchestrated reverse proxy and application server. Each Shiny app runs in its own Docker container with resource limits, health checks, and automatic lifecycle management.
+Blockyard acts as a reverse proxy and application server that spawns an isolated worker per user session. Workers run in one of two backends:
+
+- **Docker/Podman** (default) — each worker is a container with a private bridge network and cgroup resource limits.
+- **Process (bubblewrap)** — each worker is a `bwrap`-sandboxed child process with PID/mount/user namespaces and capability dropping, no container runtime required.
+
+The server is generic over a `Backend` interface, so the two runtimes are interchangeable. See [Backend Security](docs/content/docs/guides/backend-security.md) for the trade-offs.
 
 **Key design choices:**
 
-- One content type: Shiny apps only (not Plumber APIs, static sites, or scheduled tasks)
-- Single R version configured server-wide
-- Docker/Podman required — no bare-metal processes
-- Per-container session isolation by default
+- One content type: Shiny / [blockr](https://github.com/blockr-org/blockr) apps (not Plumber APIs, static sites, or scheduled tasks)
+- Linux host required (bubblewrap is Linux-only; Docker/Podman usable on macOS via Docker Desktop)
+- Per-session worker isolation by default
 
 ## Architecture
 
@@ -23,19 +27,19 @@ graph LR
     Client[Client Request] --> Router[Chi Router]
     Router --> Auth["Auth (OIDC)"]
     Auth --> Proxy[Reverse Proxy]
-    Proxy --> Shiny["Shiny Container<br>(per session)"]
+    Proxy --> Worker["Worker<br>(Docker container or<br>bwrap process)"]
     Router --> DB["SQLite/Postgres<br>(app & bundle metadata)"]
-    Shiny --> Bao["OpenBao<br>(credentials)"]
+    Worker --> Bao["OpenBao<br>(credentials)"]
 ```
-
-The server is generic over a `Backend` interface, allowing the Docker runtime to be swapped for a mock backend during testing.
 
 ## Tech Stack
 
 - **Go** 1.25 with standard library `net/http`
 - **Chi** — HTTP router with middleware support
-- **Docker SDK** — Docker API client (`github.com/docker/docker`)
+- **Docker SDK** — Docker API client (`github.com/docker/docker`), used by the Docker backend
+- **bubblewrap** — `bwrap` sandbox helper, used by the process backend
 - **modernc.org/sqlite** — pure-Go SQLite driver
+- **Redis** — optional shared state for rolling updates and multi-server coordination (`redis/go-redis`)
 - **OIDC** — OpenID Connect authentication (`coreos/go-oidc/v3`)
 - **OpenBao** — credential management (Vault-compatible)
 - **Prometheus** — metrics (`prometheus/client_golang`)
@@ -47,8 +51,11 @@ The server is generic over a `Backend` interface, allowing the Docker runtime to
 ### Prerequisites
 
 - Go 1.25+
-- Docker or Podman
-- SQLite 3
+- A Linux host (Windows and macOS supported for the Docker backend via Docker Desktop)
+- Either:
+  - **Docker backend:** Docker or Podman with a Docker-compatible socket, or
+  - **Process backend:** `bubblewrap` and `R` on the host. See [Process Backend (Native)](docs/content/docs/guides/process-backend.md).
+- SQLite 3 (bundled in-binary via `modernc.org/sqlite`)
 
 ### Configuration
 
@@ -90,84 +97,47 @@ container (e.g. the devcontainer) instead.
 
 ## Project Layout
 
-- `cmd/blockyard/` — Entry point.
+- `cmd/blockyard/` — Server entry point.
+- `cmd/by/` — CLI client (`by`) for deploying apps, managing access, and server administration.
+- `cmd/by-builder/` — Helper binary mounted into build containers to run dependency restores.
+- `cmd/seccomp-compile/` — Build-time tool that compiles JSON seccomp profiles to the BPF blob shipped inside the `blockyard-process` image.
+- `docker/` — Dockerfiles for the three image variants (`server.Dockerfile`, `server-process.Dockerfile`, `server-everything.Dockerfile`).
 - `internal/` — All application code, organized by domain:
-  - `api/` — HTTP handlers for the management API (apps, bundles, users, tags, etc.)
+  - `api/` — HTTP handlers for the management API (apps, bundles, users, tags, admin update, etc.)
   - `auth/`, `authz/` — OIDC authentication, session management, RBAC, and per-app ACLs.
   - `proxy/` — Reverse proxy, WebSocket forwarding, cold-start, session routing, autoscaling.
-  - `backend/` — Container runtime abstraction (`docker/` for Docker/Podman, `mock/` for tests).
+  - `backend/` — Worker runtime abstraction:
+    - `docker/` — Docker/Podman backend.
+    - `process/` — bubblewrap process backend.
+    - `mock/` — in-memory backend for tests.
   - `bundle/` — Bundle archive storage, unpacking, and R dependency restoration.
   - `db/` — SQLite/PostgreSQL database layer, migrations, and CRUD queries.
+  - `drain/` — Graceful drain mode used by the rolling-update orchestrator.
   - `integration/` — OpenBao (Vault) client, bootstrapping, and credential enrollment.
+  - `orchestrator/` — Rolling-update state machine with Docker (container clone) and process (fork+exec) variants.
+  - `preflight/` — Shared startup-check plumbing; backend-specific checks live under each backend.
+  - `redisstate/` — Redis-backed implementations of session/worker/resource stores.
+  - `seccomp/` — Embedded seccomp profiles (outer-container and bwrap-inner) and the merge tool.
   - `config/`, `server/` — TOML/env configuration and shared server state.
   - `ops/` — Health polling, log capture, orphan cleanup.
   - `audit/`, `telemetry/` — Audit logging, Prometheus metrics, OpenTelemetry tracing.
 - `migrations/` — SQL migration files.
 
-## Configuration Reference
+## Documentation
 
-```toml
-[server]
-bind             = "0.0.0.0:8080"
-shutdown_timeout = "30s"
-# management_bind = "127.0.0.1:9100"  # separate listener for /healthz, /readyz, /metrics
-# log_level      = "info"   # trace, debug, info, warn, error
-# session_secret = "random-secret"   # required when [oidc] is set without [openbao]
-# external_url   = "https://blockyard.example.com"
+Operator and user documentation lives under [`docs/content/docs/`](docs/content/docs/) and is rendered with Hugo. Highlights:
 
-[docker]
-socket     = "/var/run/docker.sock"
-image      = "ghcr.io/rocker-org/r-ver:4.4.3"
-shiny_port = 3838
-pak_version = "stable"
+- [Installation](docs/content/docs/getting-started/installation.md), [Quick Start](docs/content/docs/getting-started/quickstart.md)
+- [Deploying an app](docs/content/docs/guides/deploying.md)
+- [Authorization](docs/content/docs/guides/authorization.md), [Credential management](docs/content/docs/guides/credentials.md)
+- [Backend Security](docs/content/docs/guides/backend-security.md) — Docker vs. process backend trade-offs
+- [Process Backend (Native)](docs/content/docs/guides/process-backend.md) / [(Containerized)](docs/content/docs/guides/process-backend-container.md)
+- [Observability](docs/content/docs/guides/observability.md)
+- Reference: [configuration](docs/content/docs/reference/config.md), [CLI](docs/content/docs/reference/cli.md), [REST API](docs/content/docs/reference/api.md)
 
-[storage]
-bundle_server_path = "/data/bundles"
-bundle_worker_path = "/app"
-bundle_retention   = 50
-max_bundle_size    = 104857600
-
-[database]
-driver = "sqlite"
-path   = "/data/db/blockyard.db"
-
-[proxy]
-ws_cache_ttl         = "60s"
-health_interval      = "15s"
-worker_start_timeout = "60s"
-max_workers          = 100
-log_retention        = "1h"
-# session_idle_ttl   = "0"
-idle_worker_timeout  = "5m"
-
-# Optional: OIDC authentication
-# When enabled, server.session_secret is required unless [openbao] is also
-# configured (in which case it is auto-generated and stored in vault).
-# [oidc]
-# issuer_url           = "https://idp.example.com/realms/myapp"
-# issuer_discovery_url = ""      # optional: internal URL for OIDC discovery (e.g. Docker DNS)
-# client_id            = "blockyard"
-# client_secret        = "oidc-client-secret"
-# cookie_max_age       = "24h"   # default: "24h"
-# initial_admin        = "google-oauth2|abc123"
-
-# Optional: OpenBao credential management (requires [oidc])
-# [openbao]
-# address       = "http://openbao:8200"
-# role_id       = "blockyard-server"       # AppRole role identifier (recommended)
-# # admin_token = "vault-admin-token"      # deprecated: use role_id instead
-# token_ttl     = "1h"             # default: "1h"
-# jwt_auth_path = "jwt"            # default: "jwt"
-
-# Optional: Audit logging
-# [audit]
-# path = "/data/audit/blockyard.jsonl"
-
-# Optional: Telemetry
-# [telemetry]
-# metrics_enabled = true
-# otlp_endpoint   = "http://otel-collector:4317"
-```
+See [`blockyard.toml`](blockyard.toml) for a commented example
+configuration and [Configuration File](docs/content/docs/reference/config.md)
+for the full field-by-field reference.
 
 ## Status
 

--- a/blockyard.toml
+++ b/blockyard.toml
@@ -44,6 +44,21 @@ log_retention        = "1h"
 idle_worker_timeout  = "5m"
 # session_max_lifetime = "0"  # hard cap on session duration; 0 = unlimited
 
+# Optional: Redis-backed shared state. Required for rolling updates
+# (by admin update) — old and new server processes coordinate via Redis.
+# Single-node deployments without rolling updates can omit this section.
+# [redis]
+# url        = "redis://localhost:6379"
+# key_prefix = "blockyard:"
+
+# Optional: Rolling update orchestrator. Uses [redis] for coordination.
+# [update]
+# schedule        = ""          # cron expression; empty = no scheduled updates
+# channel         = "stable"    # "stable" or "main"
+# watch_period    = "15m"
+# alt_bind_range  = "8090-8099"  # process backend: alternate bind pool
+# drain_idle_wait = "5m"         # process backend: max session drain wait
+
 # Optional: OIDC authentication
 # When enabled, server.session_secret is required unless [openbao] is also
 # configured (in which case it is auto-generated and stored in vault).

--- a/docs/content/docs/getting-started/installation.md
+++ b/docs/content/docs/getting-started/installation.md
@@ -8,13 +8,30 @@ weight: 2
 
 ### Prerequisites
 
-- **Docker** (or Podman with a Docker-compatible socket)
 - A Linux host (Blockyard runs as a container or native binary)
+- One of:
+  - **Docker backend:** Docker or Podman with a Docker-compatible socket, or
+  - **Process backend:** `bubblewrap` (`bwrap`) and `R` installed on the host. Linux only.
 
-### Running with Docker (recommended)
+See [Backend Security](/docs/guides/backend-security/) for the
+trade-offs between the two backends and guidance on which to pick.
 
-The easiest way to run Blockyard is as a Docker container with access to the
-host's Docker socket:
+### Image variants
+
+Three pre-built images are published to `ghcr.io/cynkra/`:
+
+| Image | Backends compiled in | When to use |
+|---|---|---|
+| `blockyard:<version>` | Docker + process | Default. The "everything" image; switch backends via `[server] backend` in TOML. |
+| `blockyard-docker:<version>` | Docker only | Slim image for Docker-only deployments — the Docker SDK is the only backend dependency. |
+| `blockyard-process:<version>` | Process only | For containerized process-backend deployments. Ships `bubblewrap`, R, and the compiled bwrap seccomp profile. No Docker SDK. |
+
+`:latest` tracks the most recent release on each variant.
+
+### Running with Docker (Docker backend)
+
+The easiest way to run the Docker-backend variant is as a container with
+access to the host's Docker socket:
 
 ```bash
 docker run -d \
@@ -23,11 +40,26 @@ docker run -d \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v blockyard-data:/data \
   -e BLOCKYARD_DOCKER_IMAGE=ghcr.io/rocker-org/r-ver:4.4.3 \
-  ghcr.io/cynkra/blockyard:latest
+  ghcr.io/cynkra/blockyard-docker:latest
 ```
 
 This gives Blockyard access to Docker for spawning worker containers, and
 persists application data (bundles, database) in a named volume.
+
+### Running with the process backend
+
+The process backend avoids the Docker socket mount entirely by
+sandboxing workers with `bubblewrap` instead. It has two deployment
+modes:
+
+- [Process Backend (Native)](/docs/guides/process-backend/) — run
+  `blockyard` directly on a Linux host with `bwrap` and `R` installed.
+- [Process Backend (Containerized)](/docs/guides/process-backend-container/) —
+  run the `blockyard-process` image with a custom seccomp profile. No
+  Docker socket, no `CAP_SYS_ADMIN`.
+
+The containerized variant is the recommended choice for deployments
+that cannot bind-mount the Docker socket.
 
 API authentication requires OIDC configuration and
 [Personal Access Tokens](/docs/guides/authorization/#personal-access-tokens).

--- a/docs/content/docs/getting-started/overview.md
+++ b/docs/content/docs/getting-started/overview.md
@@ -8,8 +8,9 @@ Blockyard is a self-hosted platform for running
 [blockr](https://github.com/blockr-org/blockr) applications in production.
 blockr apps evaluate user-supplied R expressions inside every session,
 which is a security model no general-purpose
-[Shiny](https://shiny.posit.co/) host was designed for. Blockyard provides
-hardened container-per-session isolation, per-user credential management
+[Shiny](https://shiny.posit.co/) host was designed for. Blockyard
+provides hardened per-session worker isolation (as a Docker container
+or a `bubblewrap`-sandboxed process), per-user credential management
 via [OpenBao](https://openbao.org/), server-side dependency resolution,
 and built-in board storage — the full blockr stack as a single binary.
 
@@ -23,17 +24,25 @@ and built-in board storage — the full blockr stack as a single binary.
    container and uses [pak](https://pak.r-lib.org/) to install packages.
    Unpinned bundles can be refreshed in place later without a redeploy.
 3. **Users visit the app** — when a request hits `/app/<name>/`, Blockyard
-   spawns a worker container on demand and reverse-proxies HTTP and
-   WebSocket traffic to it. Each session gets its own container.
+   spawns a worker on demand and reverse-proxies HTTP and WebSocket
+   traffic to it. Each session gets its own isolated worker.
 
-Workers are isolated from each other via per-container bridge networks.
-Containers run with a read-only filesystem, all Linux capabilities dropped,
-`no-new-privileges` set, and cloud metadata endpoint access blocked
-(`169.254.169.254`). For high-security deployments, workers can run under
-the [Kata](https://katacontainers.io/) runtime, which gives each session
-its own lightweight VM. See
-[Deploying an App](/docs/guides/deploying/#container-security)
-for the full list of security settings.
+Workers run in one of two backends:
+
+- **Docker backend** (default). Each worker is a container with a
+  private bridge network, read-only filesystem, all Linux capabilities
+  dropped, `no-new-privileges` set, and cloud metadata endpoint access
+  blocked. High-security deployments can run workers under the
+  [Kata](https://katacontainers.io/) runtime for per-session VMs.
+- **Process backend.** Each worker is a `bubblewrap`-sandboxed child
+  process with PID/mount/user namespaces, capability dropping, and
+  seccomp filtering. No container runtime required. Suitable for
+  hosts where the Docker socket is unacceptable or where cold-start
+  latency matters.
+
+See [Backend Security](/docs/guides/backend-security/) for the full
+comparison and [Docker worker hardening](/docs/guides/deploying/#docker-worker-hardening)
+for the Docker backend's baseline settings.
 
 ## Authentication & Authorization
 
@@ -60,8 +69,10 @@ and object storage.
     through a build step (dependency restore) before becoming ready to serve.
 
 **Worker**
-:   A running container serving a Shiny app. Workers are spawned on-demand
-    and pinned to user sessions via cookies.
+:   A running process serving a Shiny app. Implemented as a Docker
+    container or a bubblewrap-sandboxed child process depending on the
+    configured backend. Workers are spawned on-demand and pinned to
+    user sessions via cookies.
 
 **Session**
 :   A user's connection to a running worker. Sessions are tracked

--- a/docs/content/docs/guides/backend-security.md
+++ b/docs/content/docs/guides/backend-security.md
@@ -50,7 +50,7 @@ are blocked on both backends. The open questions are *network*,
 |---|---|---|
 | **Per-worker network** | Each worker gets a private bridge network. Inter-worker traffic is impossible at the kernel level; cloud metadata (`169.254.169.254`) is blocked via iptables per network. | Workers share the host network stack. Worker A can TCP-connect to worker B's loopback Shiny port, reach services on the host network, and (without operator firewall rules) hit cloud metadata. |
 | **Per-worker resource limits** | Memory and CPU limits are enforced by the kernel via cgroups. PID limits prevent fork bombs. | No cgroup delegation. The outer container's (or systemd slice's) limits act as a shared ceiling — one runaway worker can starve its siblings. |
-| **Syscall filtering** | Docker's default seccomp profile is applied automatically. | `process.seccomp_profile` accepts a pre-compiled BPF profile and `bwrap` applies it via `--seccomp`. No default profile is shipped yet — set the field explicitly, or rely on the other isolation layers (namespaces and capability dropping) in the meantime. |
+| **Syscall filtering** | Docker's default seccomp profile is applied automatically. | The `blockyard` and `blockyard-process` images ship a compiled BPF profile at `/etc/blockyard/seccomp.bpf` and point `process.seccomp_profile` at it by default; `bwrap` applies it via `--seccomp`. Native deployments can install the same profile from the release tarball or extract it from the image. |
 | **Server privilege model** | Server needs `/var/run/docker.sock`, which grants root-equivalent access to the host. | Server needs only a `bwrap` binary. In containerized mode, the outer container needs a custom seccomp profile that allows `CLONE_NEWUSER`, but no capabilities, no socket, and no daemon dependency. |
 
 The first three rows are strengths of the Docker backend. The last row is
@@ -94,7 +94,7 @@ Picking the process backend is the start of the work, not the end. The
 backend provides the per-worker sandbox; the operator provides the
 network and resource boundaries around it. Three controls matter.
 
-### 1. Run blockyard in a container
+### 1. Prefer containerized mode
 
 Native (bare-host) mode is supported for dedicated single-purpose VMs,
 but containerized mode is the default recommendation:
@@ -105,17 +105,11 @@ but containerized mode is the default recommendation:
 - Portability is better — the same image runs on Linux, macOS via Docker
   Desktop, or any OCI runtime.
 
-Run with a custom seccomp profile that allows `CLONE_NEWUSER` (Docker's
-default profile blocks it without `CAP_SYS_ADMIN`):
-
-```bash
-docker run \
-  --security-opt seccomp=blockyard-seccomp.json \
-  --read-only \
-  ghcr.io/cynkra/blockyard:latest
-```
-
-No `--privileged`, no `--cap-add SYS_ADMIN`, no Docker socket mount.
+See [Process Backend (Containerized)](/docs/guides/process-backend-container/)
+for the image layout, the custom seccomp profile Docker needs to allow
+`CLONE_NEWUSER`, and the Docker Compose recipe. The containerized
+deployment runs with no `--privileged`, no `--cap-add SYS_ADMIN`, and
+no Docker socket mount.
 
 ### 2. Install a destination-scoped egress firewall
 
@@ -213,6 +207,12 @@ Two classes of risk remain regardless of backend choice:
 
 ## Further reading
 
+- [Process Backend (Native)](/docs/guides/process-backend/) — operator
+  walkthrough for bare-Linux deployments: prerequisites, firewall
+  rules, systemd unit, rolling updates.
+- [Process Backend (Containerized)](/docs/guides/process-backend-container/)
+  — operator walkthrough for the `blockyard-process` image: seccomp
+  profile extraction, Docker Compose recipe, network segmentation.
 - [Docker worker hardening in the deploying guide](/docs/guides/deploying/#docker-worker-hardening)
   — the Docker backend's baseline hardening.
 - [Configuration reference](/docs/reference/config/) — `[server] backend`,

--- a/docs/content/docs/guides/configuration.md
+++ b/docs/content/docs/guides/configuration.md
@@ -12,144 +12,66 @@ Blockyard is configured via a TOML file. By default, it looks for
 blockyard --config /etc/blockyard/config.toml
 ```
 
-Every config field can also be overridden via environment variables using the
-pattern `BLOCKYARD_<SECTION>_<FIELD>` (uppercased). For example:
+Every field can also be overridden via environment variables using the
+pattern `BLOCKYARD_<SECTION>_<FIELD>` (uppercased). For example,
+`server.bind` becomes `BLOCKYARD_SERVER_BIND`. Environment variables
+take precedence over the TOML file.
 
-```bash
-BLOCKYARD_SERVER_BIND=0.0.0.0:9090
-BLOCKYARD_DOCKER_IMAGE=ghcr.io/rocker-org/r-ver:4.4.0
-```
+For the full, field-by-field reference see
+[Configuration File](/docs/reference/config/).
 
-## Sections
+## Choosing a worker backend
 
-### `[server]`
-
-| Field | Default | Description |
-|---|---|---|
-| `bind` | `127.0.0.1:8080` | Address and port the server listens on |
-| `shutdown_timeout` | `30s` | Time to drain in-flight requests on shutdown |
-| `log_level` | `info` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error` |
-| `management_bind` | — | Separate listener for `/healthz`, `/readyz`, `/metrics`. See [Observability](/docs/guides/observability/#management-listener). |
-| `session_secret` | — | Secret for signing session cookies. Required when `[oidc]` is set without `[openbao]`; auto-generated and stored in vault when `[openbao]` is configured. |
-| `external_url` | — | Public-facing URL of the server (used for OIDC redirect URIs) |
-| `trusted_proxies` | — | CIDRs whose `X-Forwarded-For` to trust (e.g. `["10.0.0.0/8"]`) |
-
-### `[docker]`
-
-| Field | Default | Description |
-|---|---|---|
-| `socket` | `/var/run/docker.sock` | Path to the Docker (or Podman) socket |
-| `image` | *(required)* | Base container image for workers and builds |
-| `shiny_port` | `3838` | Port Shiny listens on inside the container |
-| `pak_version` | `stable` | [pak](https://pak.r-lib.org/) release channel (`stable`, `rc`, or `devel`) |
-| `service_network` | — | Docker network whose containers are reachable from workers |
-| `store_retention` | `0` | Package store eviction duration (`0` = disabled) |
-| `default_memory_limit` | — | Fallback memory limit for workers (e.g. `"2g"`). Applies when no per-app limit is set. |
-| `default_cpu_limit` | — | Fallback CPU limit for workers (e.g. `4.0`). Applies when no per-app limit is set. |
-
-### `[storage]`
-
-| Field | Default | Description |
-|---|---|---|
-| `bundle_server_path` | `/data/bundles` | Directory for uploaded bundles |
-| `bundle_worker_path` | `/app` | Mount point inside worker containers |
-| `bundle_retention` | `50` | Max bundles to keep per app before cleanup |
-| `max_bundle_size` | `104857600` | Maximum upload size in bytes (default 100 MB) |
-| `soft_delete_retention` | `0` | How long to keep soft-deleted apps (e.g. `720h` for 30 days). `0` means immediate hard delete. |
-
-### `[database]`
-
-| Field | Default | Description |
-|---|---|---|
-| `driver` | `sqlite` | Database driver: `sqlite` or `postgres` |
-| `path` | `/data/db/blockyard.db` | Path to the SQLite database file (when `driver = "sqlite"`) |
-| `url` | — | PostgreSQL connection string (when `driver = "postgres"`) |
-
-### `[proxy]`
-
-| Field | Default | Description |
-|---|---|---|
-| `ws_cache_ttl` | `60s` | How long to keep a backend WebSocket open after client disconnect. Enables transparent reconnection on network blips — see [Reconnection on network interruptions](/docs/guides/deploying/#reconnection-on-network-interruptions). |
-| `health_interval` | `15s` | Interval between worker health checks |
-| `worker_start_timeout` | `60s` | Max time to wait for a worker to become healthy |
-| `max_workers` | `100` | Maximum number of concurrent worker containers |
-| `log_retention` | `1h` | How long to keep worker log entries before cleanup |
-| `session_idle_ttl` | `0` | Idle timeout for sessions and WebSocket connections. When non-zero, idle WebSocket connections are closed and stale sessions are swept. `0` = disabled. |
-| `idle_worker_timeout` | `5m` | Time before an idle worker container is stopped |
-| `http_forward_timeout` | `5m` | Timeout for forwarding HTTP requests to workers |
-| `max_cpu_limit` | `16.0` | Max CPU limit settable per app |
-| `transfer_timeout` | `60s` | Timeout for bundle transfers to workers |
-| `session_max_lifetime` | `0` | Hard cap on session duration. `0` (default) means unlimited — sessions only end via idle timeout or worker shutdown. |
-
-### `[oidc]` *(optional)*
-
-Enable OIDC authentication. When configured, `server.session_secret` is required unless `[openbao]` is also configured (in which case it can be auto-generated).
-
-| Field | Default | Description |
-|---|---|---|
-| `issuer_url` | *(required)* | OIDC provider issuer URL (must match the `iss` claim in tokens) |
-| `issuer_discovery_url` | — | Internal URL for OIDC discovery when the IdP is at a different address server-side (e.g. Docker DNS). See [Configuration Reference](/docs/reference/config/#split-url-oidc). |
-| `client_id` | *(required)* | OIDC client ID |
-| `client_secret` | *(required)* | OIDC client secret |
-| `cookie_max_age` | `24h` | Max lifetime of session cookies |
-| `initial_admin` | — | OIDC `sub` of the first admin user. Checked only on first login. See [First Admin Setup](/docs/guides/authorization/#first-admin-setup). |
-
-### `[openbao]` *(optional)*
-
-Enable OpenBao credential management. Requires `[oidc]` to be configured.
-
-| Field | Default | Description |
-|---|---|---|
-| `address` | *(required)* | OpenBao server address |
-| `role_id` | One of `role_id` or `admin_token` | AppRole role identifier. The `secret_id` is delivered via `BLOCKYARD_OPENBAO_SECRET_ID` env var at bootstrap. |
-| `admin_token` | One of `role_id` or `admin_token` | **Deprecated.** Static admin token. Use `role_id` with AppRole auth instead. |
-| `token_ttl` | `1h` | TTL for issued tokens |
-| `jwt_auth_path` | `jwt` | Auth method path in OpenBao |
-| `skip_policy_scope_check` | `false` | Skip vault policy scope verification during bootstrap. Useful when the OpenBao policy format differs from what Blockyard expects. |
-
-#### `[[openbao.services]]`
-
-Define third-party services whose API keys users can enroll via OpenBao.
+`[server] backend` selects how workers run. The default is `docker`;
+set it to `process` to use the bubblewrap-sandboxed process backend.
 
 ```toml
-[[openbao.services]]
-id    = "openai"
-label = "OpenAI"
+[server]
+backend = "process"    # or "docker" (default)
 ```
 
-Credentials are stored at `secret/data/users/{sub}/apikeys/{id}`.
+The decision affects which other sections are required:
 
-| Field | Default | Description |
-|---|---|---|
-| `id` | *(required)* | Unique identifier (also the vault path segment) |
-| `label` | *(required)* | Human-readable label |
+- **`docker` backend** — requires `[docker] image` and access to the
+  Docker/Podman socket.
+- **`process` backend** — requires a `[process]` section (bwrap path,
+  R path, port and UID ranges, worker GID). Linux only.
 
-### `[board_storage]` *(optional)*
+See [Backend Security](/docs/guides/backend-security/) for the security
+trade-offs between the two, and
+[Process Backend (Native)](/docs/guides/process-backend/) /
+[Process Backend (Containerized)](/docs/guides/process-backend-container/)
+for end-to-end process-backend deployment walkthroughs.
 
-Enable board storage via PostgREST. Requires `database.driver = "postgres"` and `[openbao]`.
+## Common scenarios
 
-| Field | Default | Description |
-|---|---|---|
-| `postgrest_url` | *(required)* | URL of the PostgREST instance (e.g. `http://postgrest:3000`) |
+### Authentication
 
-Workers receive a `POSTGREST_URL` environment variable when this is configured.
+Add an `[oidc]` section to require users to log in before accessing
+apps. When OIDC is enabled, `server.session_secret` is required unless
+`[openbao]` is also configured (in which case the secret is
+auto-generated and stored in vault). See the
+[Authorization guide](/docs/guides/authorization/).
 
-### `[audit]` *(optional)*
+### Credential management
 
-Enable append-only audit logging.
+Add an `[openbao]` section to enroll per-user API keys that Shiny apps
+read at runtime. Requires `[oidc]`. See the
+[Credential Management guide](/docs/guides/credentials/).
 
-| Field | Default | Description |
-|---|---|---|
-| `path` | *(required)* | Path to the JSONL audit log file |
+### Rolling updates
 
-### `[telemetry]` *(optional)*
+Add `[redis]` (shared state) and `[update]` (alt bind range, drain
+timeout, optional schedule) to enable `by admin update`. See the
+[process backend rolling update walkthrough](/docs/guides/process-backend/#rolling-update-walkthrough)
+for prerequisites.
 
-Enable Prometheus metrics and OpenTelemetry tracing.
+### Observability
 
-| Field | Default | Description |
-|---|---|---|
-| `metrics_enabled` | `false` | Expose a `/metrics` endpoint for Prometheus |
-| `otlp_endpoint` | — | OpenTelemetry collector endpoint (e.g. `http://otel-collector:4317`) |
+Add `[telemetry]` to expose Prometheus metrics and forward traces to an
+OpenTelemetry collector. Add `[audit]` for an append-only JSONL audit
+log. Configure `server.management_bind` to move health and metrics to a
+dedicated loopback listener — see [Observability](/docs/guides/observability/).
 
 ## Example
 
@@ -157,6 +79,9 @@ Enable Prometheus metrics and OpenTelemetry tracing.
 [server]
 bind             = "127.0.0.1:8080"
 shutdown_timeout = "30s"
+# backend        = "docker"              # or "process"
+# default_memory_limit = "2g"            # fallback per worker
+# default_cpu_limit    = 4.0             # fallback per worker
 
 [docker]
 socket     = "/var/run/docker.sock"
@@ -169,7 +94,6 @@ bundle_server_path    = "/data/bundles"
 bundle_worker_path    = "/app"
 bundle_retention      = 50
 max_bundle_size       = 104857600
-# soft_delete_retention = "720h"   # 30 days; omit or 0 = immediate hard delete
 
 [database]
 driver = "sqlite"
@@ -181,42 +105,15 @@ health_interval      = "15s"
 worker_start_timeout = "60s"
 max_workers          = 100
 log_retention        = "1h"
-# session_idle_ttl   = "0"
 idle_worker_timeout  = "5m"
 
-# Optional: OIDC authentication
-# When enabled, server.session_secret is required unless [openbao] is also
-# configured (in which case it is auto-generated and stored in vault).
-# [oidc]
-# issuer_url           = "https://idp.example.com/realms/myapp"
-# issuer_discovery_url = ""      # optional: internal URL for OIDC discovery (e.g. Docker DNS)
-# client_id            = "blockyard"
-# client_secret        = "oidc-client-secret"
-# cookie_max_age       = "24h"
-# initial_admin        = "google-oauth2|abc123"   # OIDC sub of the first admin
-
-# Optional: OpenBao credential management (requires [oidc])
-# [openbao]
-# address       = "http://openbao:8200"
-# role_id       = "blockyard-server"       # AppRole role identifier (recommended)
-# # admin_token = "vault-admin-token"      # deprecated: use role_id instead
-# token_ttl     = "1h"
-# jwt_auth_path = "jwt"
+# Optional sections — see the reference for every field.
 #
-# [[openbao.services]]
-# id    = "openai"
-# label = "OpenAI"
-
-# Optional: Board storage via PostgREST (requires postgres + openbao)
-# [board_storage]
-# postgrest_url = "http://postgrest:3000"
-
-# Optional: Audit logging
-# [audit]
-# path = "/data/audit/blockyard.jsonl"
-
-# Optional: Telemetry
-# [telemetry]
-# metrics_enabled = true
-# otlp_endpoint   = "http://otel-collector:4317"
+# [process]    — process backend; required when server.backend = "process"
+# [redis]      — Redis-backed shared state; required for rolling updates
+# [update]     — rolling update orchestrator (schedule, drain, alt bind)
+# [oidc]       — OIDC authentication
+# [openbao]    — OpenBao credential management (requires [oidc])
+# [audit]      — append-only JSONL audit log
+# [telemetry]  — Prometheus metrics and OpenTelemetry tracing
 ```

--- a/docs/content/docs/guides/process-backend-container.md
+++ b/docs/content/docs/guides/process-backend-container.md
@@ -14,7 +14,9 @@ don't want to expose `/var/run/docker.sock` and don't need Docker's
 per-worker bridge networks.
 
 For the native (bare-metal) variant, see
-[Process Backend (Native)]({{< relref "process-backend.md" >}}).
+[Process Backend (Native)]({{< relref "process-backend.md" >}}). For
+the security trade-offs between the Docker and process backends, see
+[Backend Security]({{< relref "backend-security.md" >}}).
 
 ## The image
 
@@ -64,15 +66,15 @@ The `--entrypoint cat` override is required because the image's
 default entrypoint is `blockyard --config ...`; without it the `cat`
 would end up as an argument to blockyard.
 
-**Option 2 — `by admin install-seccomp`** (if you have the `by`
-CLI installed):
+**Option 2 — [`by admin install-seccomp`](/docs/reference/cli/#by-admin-install-seccomp)**
+(if you have the `by` CLI installed):
 
 ```bash
 sudo by admin install-seccomp --target /etc/blockyard/seccomp.json
 ```
 
 The profile is embedded in the `by` binary via `//go:embed`, so no
-network access is required.
+network access or running blockyard server is required.
 
 **Option 3 — download from GitHub Releases:**
 
@@ -144,25 +146,26 @@ additional host privileges.
 
 ## Egress firewall (containerized mode)
 
-The iptables owner-match pattern from the native guide works
-differently here: the outer container has its own UID namespace, and
-worker processes appear as the container's own UID (typically root)
-from the host's perspective. Host-side iptables rules matching
-`--gid-owner 65534` will not fire.
+The iptables owner-match pattern from
+[Backend Security]({{< relref "backend-security.md#2-install-a-destination-scoped-egress-firewall" >}})
+does not work unchanged here: the outer container has its own UID
+namespace, and worker processes appear as the container's own UID
+(typically root) from the host's perspective, so host-side
+`--gid-owner 65534` rules will not fire.
 
-Two approaches:
+Two options:
 
-1. **Run iptables rules inside the container.** The
-   blockyard-process image does not ship `iptables`, so this is not
-   a drop-in option. Use the everything image
-   (`ghcr.io/cynkra/blockyard:<v>`) if you need this.
+1. **Run iptables rules inside the container.** The `blockyard-process`
+   image does not ship `iptables`, so this is not a drop-in option.
+   Use the everything image (`ghcr.io/cynkra/blockyard:<v>`) if you
+   need this.
 
-2. **Use Docker network segmentation.** Put Redis, OpenBao, and the
-   database on an `internal: true` network that the blockyard
-   container joins, and put worker-egress-sensitive services on a
-   separate network that workers cannot reach. This is cleaner than
-   iptables but requires the operator to be deliberate about
-   service topology.
+2. **Use Docker network segmentation** (recommended). Put Redis,
+   OpenBao, and the database on an `internal: true` network that the
+   blockyard container joins, and put worker-egress-sensitive services
+   on a separate network workers cannot reach. Cleaner than iptables
+   but requires deliberate service topology — the Docker Compose
+   example above shows the pattern.
 
 Blockyard's preflight runs the same worker-egress probe in
 containerized mode. Review the startup logs for warnings about

--- a/docs/content/docs/guides/process-backend.md
+++ b/docs/content/docs/guides/process-backend.md
@@ -70,25 +70,22 @@ sudo sysctl --system
 
 ### bwrap setuid requirement (Debian 12+/Ubuntu 24.04+)
 
-Debian 12 and Ubuntu 24.04 ship `bwrap` as a regular (non-setuid) binary.
-With user namespaces enabled, bwrap *can* still enter a new namespace,
-but `--uid <N>` / `--gid <N>` no longer produce a host-visible UID —
-the kernel silently writes a namespace-local mapping that the host's
-iptables `--uid-owner` rules cannot match. Workers then appear as
-regular unprivileged processes from the init namespace, and the
-per-worker egress firewall breaks.
-
-Blockyard's preflight detects this with `checkBwrapHostUIDMapping` and
-refuses to start with a clear error. The fix on those distros is:
+Debian 12 and Ubuntu 24.04 ship `bwrap` as a regular (non-setuid)
+binary. With user namespaces enabled, bwrap *can* still enter a new
+namespace, but `--uid`/`--gid` no longer produce a host-visible UID —
+and the egress firewall relies on host-side UIDs to work. Blockyard's
+preflight detects this and refuses to start; the fix is:
 
 ```bash
 sudo chmod u+s /usr/bin/bwrap
 ```
 
-This is the same configuration Fedora/RHEL ship by default. An
-alternative is to run blockyard as root, which inherits `CAP_SYS_ADMIN`
-and bypasses the restriction; see the containerized guide for that
-path.
+This is the same configuration Fedora/RHEL ship by default. The other
+option is to run blockyard as root, which inherits `CAP_SYS_ADMIN` and
+bypasses the restriction — the containerized image does this.
+
+See [Host UID mapping is load-bearing](/docs/guides/backend-security/#host-uid-mapping-is-load-bearing)
+in the backend security guide for the full explanation.
 
 ## Install blockyard
 
@@ -166,36 +163,35 @@ omit both.
 
 ## Egress firewall
 
-Workers in the process backend run under a shared host GID
-(`[process] worker_gid`). Use `iptables` owner-match rules to block
-workers from reaching internal services:
+Workers run under the shared host GID configured in
+`[process] worker_gid` (default `65534`). Use `iptables` owner-match
+rules to block them from reaching specific internal destinations:
 
 ```bash
-# Block workers from reaching Redis (match by destination IP,
-# not the entire internal subnet).
-sudo iptables -A OUTPUT -m owner --gid-owner 65534 \
-    -d 10.0.0.5 -j REJECT
-
-# Block workers from reaching OpenBao.
-sudo iptables -A OUTPUT -m owner --gid-owner 65534 \
-    -d 10.0.0.6 -j REJECT
-
 # Block cloud metadata.
 sudo iptables -A OUTPUT -m owner --gid-owner 65534 \
     -d 169.254.169.254 -j REJECT
-```
 
-**Do not use a blanket `REJECT`** — workers legitimately need internet
-access (CRAN mirrors, package downloads, `httr` calls from user code).
-Scope each rule to a specific destination.
+# Block workers from reaching Redis, OpenBao, and the database.
+sudo iptables -A OUTPUT -m owner --gid-owner 65534 -d 10.0.0.5 -j REJECT
+sudo iptables -A OUTPUT -m owner --gid-owner 65534 -d 10.0.0.6 -j REJECT
+sudo iptables -A OUTPUT -m owner --gid-owner 65534 -d 10.0.0.7 -j REJECT
+```
 
 Persist the rules across reboots with `iptables-save` /
 `iptables-restore` or your distro's equivalent.
 
-Blockyard's preflight runs a probe binary inside a bwrap sandbox to
-verify the rules are effective. If a worker can reach cloud metadata,
-Redis, OpenBao, or the database at startup, the preflight logs a
-warning or error.
+Blockyard's preflight spawns a probe under the worker UID/GID and
+attempts TCP connections to the same internal endpoints at startup.
+A reachable metadata endpoint is reported as an error; reachable
+Redis/OpenBao/database endpoints are reported as warnings.
+
+> [!IMPORTANT]
+> Rules must be **destination-scoped**, not blanket `REJECT` — workers
+> legitimately need the open internet (CRAN, package downloads, user
+> `httr` calls). For the rationale and the host-UID-mapping requirement
+> that makes `-m owner` actually match, see
+> [Backend Security](/docs/guides/backend-security/#2-install-a-destination-scoped-egress-firewall).
 
 ## systemd unit
 
@@ -283,24 +279,30 @@ health checks pick the live one.
 
 ## Rolling update walkthrough
 
-```bash
-# Trigger the update — blockyard downloads the new version, forks a
-# new process on an alt bind, drains the old server, and exits the
-# old process once sessions have ended.
-by admin update --yes --channel stable
+Use [`by admin update`](/docs/reference/cli/#by-admin-update) to trigger
+a rolling update. Blockyard forks a new process on an alternate bind,
+drains the old server, and exits the old process once sessions have
+ended:
 
-# Watch the update progress (task log streams by default).
+```bash
+by admin update --yes --channel stable
 ```
+
+The command streams the orchestrator task log; `by admin status` shows
+the current state out-of-band.
 
 **Prerequisites:**
 
-- Redis must be configured and reachable.
+- Redis must be configured and reachable (`[redis]` section — see
+  [Configuration reference](/docs/reference/config/#redis-optional)).
 - The reverse proxy must be configured with every port in the
-  `[update] alt_bind_range` as an upstream.
-- The new blockyard binary must be present in the same location
-  (`os.Executable()` resolves the running binary; operators upgrade
-  by replacing `/usr/local/bin/blockyard` *before* running
-  `by admin update`).
+  `[update] alt_bind_range` (see
+  [`[update]`](/docs/reference/config/#update-optional) in the
+  configuration reference) as an upstream.
+- The new blockyard binary must be present in the same location as
+  the running one. Operators upgrade by replacing
+  `/usr/local/bin/blockyard` *before* running `by admin update`;
+  `os.Executable()` resolves the running binary path.
 
 **Failure modes:**
 

--- a/docs/content/docs/reference/api.md
+++ b/docs/content/docs/reference/api.md
@@ -22,9 +22,9 @@ Returns `200 OK` with body `ok`. No authentication required.
 
 ### `GET /readyz`
 
-Readiness probe that checks backend dependencies (database, Docker socket, and
-optionally IdP and OpenBao). No authentication required, but the response
-detail varies based on the caller.
+Readiness probe. Checks the database and the configured worker backend,
+plus — when configured — the IdP, Redis, and OpenBao. No authentication
+required, but the response detail varies based on the caller.
 
 **Response:** `200 OK` when all checks pass, `503 Service Unavailable` otherwise.
 
@@ -41,6 +41,10 @@ results:
 }
 ```
 
+The backend check key is `docker` regardless of whether the
+`[server] backend` is `docker` or `process` — it reports the result
+of the shared `Backend.ListManaged()` call.
+
 **Unauthenticated callers** see only the aggregate status:
 
 ```json
@@ -51,10 +55,11 @@ results:
 
 When not all checks pass, `status` is `"not_ready"` and the HTTP status is `503`.
 
-When OIDC and/or OpenBao are configured, their health is included in the checks
-(as `"idp"` and `"openbao"` respectively). When AppRole auth is used
-(`openbao.role_id`), a `"vault_token"` check reports whether the token renewal
-goroutine is healthy.
+When OIDC, Redis, and/or OpenBao are configured, their health is
+included in the checks (as `"idp"`, `"redis"`, and `"openbao"`
+respectively). When AppRole auth is used (`openbao.role_id`), a
+`"vault_token"` check reports whether the token renewal goroutine is
+healthy.
 
 When served on the [management listener](/docs/guides/observability/#management-listener),
 `/readyz` always returns full per-component check details regardless of
@@ -540,6 +545,83 @@ If the task is still running, the response streams buffered output followed
 by live lines. If the task is complete, the full log is returned.
 
 **Response:** `200 OK` — chunked `text/plain`.
+
+---
+
+## Server administration
+
+Rolling-update orchestration. The CLI equivalents are
+[`by admin update`](/docs/reference/cli/#by-admin-update),
+[`by admin rollback`](/docs/reference/cli/#by-admin-rollback), and
+[`by admin status`](/docs/reference/cli/#by-admin-status). All endpoints
+except `/admin/activate` require admin role.
+
+### `POST /api/v1/admin/update`
+
+Trigger a rolling update of the server. Returns immediately with a task
+ID; use `GET /api/v1/tasks/{task_id}/logs` to stream progress.
+
+**Request body** (all fields optional):
+
+```json
+{ "channel": "stable" }
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `channel` | `string` | server config | Release channel: `"stable"` or `"main"`. |
+
+**Response:** `202 Accepted`
+
+```json
+{ "task_id": "t5678..." }
+```
+
+Returns `409 Conflict` when an update is already in progress, or
+`503 Service Unavailable` when rolling updates are not supported for
+the current backend (e.g. the containerized process backend — see
+[Rolling updates in containerized mode](/docs/guides/process-backend-container/#rolling-updates-in-containerized-mode)).
+
+### `POST /api/v1/admin/rollback`
+
+Roll the server back to the previous version using the stored backup
+metadata. Supported on the Docker backend only — returns
+`501 Not Implemented` on the process backend.
+
+**Response:** `202 Accepted`
+
+```json
+{ "task_id": "t5678..." }
+```
+
+### `GET /api/v1/admin/update/status`
+
+Get the current rolling-update state.
+
+**Response:** `200 OK`
+
+```json
+{
+  "state": "idle",
+  "task_id": "",
+  "version": "",
+  "message": ""
+}
+```
+
+`state` is one of `"idle"`, `"updating"`, `"watching"`, `"rolling_back"`,
+or `"failed"`. When a task is active, `task_id` points to its log
+endpoint.
+
+### `POST /api/v1/admin/activate`
+
+Activate a freshly-started blockyard instance as the live server. Used
+internally by the rolling-update orchestrator to hand over from the
+old server to the new one.
+
+Authenticates via an activation token set as an env var on the new
+process (not a PAT), so this endpoint is reachable without a PAT.
+Operators do not call it directly.
 
 ---
 

--- a/docs/content/docs/reference/cli.md
+++ b/docs/content/docs/reference/cli.md
@@ -416,6 +416,89 @@ recently ended worker is used.
 
 ---
 
+## Server administration
+
+The `by admin` subcommand group manages the blockyard server itself.
+Most commands require the `admin` system role.
+
+### `by admin update`
+
+Trigger a rolling update of the server to the latest release on the
+configured channel. On the Docker backend this clones the blockyard
+container next to the old one; on the process backend it forks a new
+blockyard process on an alternate bind port. The command streams the
+orchestrator task log until the update completes or fails.
+
+```bash
+by admin update
+by admin update --yes --channel stable
+```
+
+| Flag             | Description                                               |
+| ---------------- | --------------------------------------------------------- |
+| `--channel <ch>` | Release channel: `stable` or `main` (default: server config) |
+| `-y, --yes`      | Skip the confirmation prompt                              |
+| `--json`         | Output as JSON                                            |
+
+Prerequisites and failure modes differ per backend — see
+[Process Backend rolling update walkthrough](/docs/guides/process-backend/#rolling-update-walkthrough)
+and the [admin update API](/docs/reference/api/#post-apiv1adminupdate).
+
+### `by admin rollback`
+
+Roll the server back to the previous version. Supported on the Docker
+backend; returns `501 Not Implemented` on the process backend (the
+operator's install scheme owns the binary path).
+
+```bash
+by admin rollback
+by admin rollback --yes
+```
+
+| Flag        | Description                  |
+| ----------- | ---------------------------- |
+| `-y, --yes` | Skip the confirmation prompt |
+| `--json`    | Output as JSON               |
+
+### `by admin status`
+
+Show the current rolling-update state (`idle`, `updating`, `watching`,
+etc.) and the target version if one is in progress.
+
+```bash
+by admin status
+by admin status --json
+```
+
+| Flag     | Description     |
+| -------- | --------------- |
+| `--json` | Output as JSON  |
+
+### `by admin install-seccomp`
+
+Write the embedded outer-container seccomp profile to disk. Used when
+deploying the process backend via the `blockyard-process` Docker image —
+the operator needs a copy of the profile on the host before the
+container starts, because Docker reads `--security-opt seccomp=<path>`
+from the host filesystem. The profile is embedded in the `by` binary,
+so no network access is required.
+
+```bash
+sudo by admin install-seccomp
+sudo by admin install-seccomp --target /etc/blockyard/seccomp.json
+```
+
+| Flag              | Description                                             |
+| ----------------- | ------------------------------------------------------- |
+| `--target <path>` | Output path (default: `/etc/blockyard/seccomp.json`)   |
+
+This command does not talk to a running blockyard server — it only
+writes the profile to disk. No authentication required. See
+[Process Backend (Containerized)](/docs/guides/process-backend-container/)
+for the full extraction workflow.
+
+---
+
 ## User administration
 
 These commands require the `admin` system role.

--- a/docs/content/docs/reference/config.md
+++ b/docs/content/docs/reference/config.md
@@ -31,23 +31,37 @@ Environment variables take precedence over values in the TOML file.
 [server]
 bind             = "127.0.0.1:8080"
 shutdown_timeout = "30s"
-# management_bind = "127.0.0.1:9100"
-# log_level      = "info"
-# session_secret = "random-secret"   # required when [oidc] is configured
-# external_url   = "https://blockyard.example.com"
-# trusted_proxies = ["10.0.0.0/8"]
+# backend              = "docker"       # "docker" (default) or "process"
+# skip_preflight       = false
+# default_memory_limit = "2g"           # fallback per worker; empty = unlimited
+# default_cpu_limit    = 4.0            # fallback per worker; 0 = unlimited
+# management_bind      = "127.0.0.1:9100"
+# log_level            = "info"
+# session_secret       = "random-secret"   # required when [oidc] is configured
+# external_url         = "https://blockyard.example.com"
+# trusted_proxies      = ["10.0.0.0/8"]
 ```
 
 | Field | Type | Default | Required | Description |
 |---|---|---|---|---|
 | `bind` | `string` | `127.0.0.1:8080` | No | Socket address to listen on |
+| `backend` | `string` | `docker` | No | Worker backend: `docker` or `process`. See [Backend Security](/docs/guides/backend-security/) for the trade-offs. `process` requires a `[process]` section. |
+| `skip_preflight` | `boolean` | `false` | No | Skip backend-specific preflight checks at startup. Use for development or when you are certain the environment is correctly configured. |
+| `default_memory_limit` | `string` | — | No | Fallback memory limit for workers when no per-app limit is set (e.g. `"2g"`). Empty means unlimited. Enforced by the Docker backend via cgroups; the process backend emits a warning and does not enforce. |
+| `default_cpu_limit` | `float` | `0` | No | Fallback CPU limit for workers when no per-app limit is set (e.g. `4.0`). `0` means unlimited. Enforced by the Docker backend via cgroups; the process backend emits a warning and does not enforce. |
 | `management_bind` | `string` | — | No | Separate listener for `/healthz`, `/readyz`, `/metrics`. See [Management listener](/docs/guides/observability/#management-listener). |
 | `shutdown_timeout` | `duration` | `30s` | No | Grace period for draining requests on shutdown |
+| `drain_timeout` | `duration` | — | No | Maximum time the old server will wait for sessions to end during a rolling update drain. See the [process backend rolling update walkthrough](/docs/guides/process-backend/#rolling-update-walkthrough). |
 | `log_level` | `string` | `info` | No | Log verbosity. One of `trace`, `debug`, `info`, `warn` (or `warning`), `error`. |
 | `session_secret` | `string` | — | When `[oidc]` is set without `[openbao]` | Secret for signing session cookies. Supports [vault references](#vault-references). Auto-generated and stored in vault when `[openbao]` is configured. |
 | `external_url` | `string` | — | No | Public-facing URL of the server (used for OIDC redirect URIs) |
 | `trusted_proxies` | `string[]` | — | No | CIDRs whose `X-Forwarded-For` headers to trust (e.g. `["10.0.0.0/8"]`). Each entry must be a valid CIDR. Set via env as comma-separated: `BLOCKYARD_SERVER_TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12`. |
 | `bootstrap_token` | `string` | — | No | One-time token that can be exchanged for a real PAT via `POST /api/v1/bootstrap`. Requires `oidc.initial_admin` to be set. Intended for dev/CI bootstrapping — do not use in production. See [Bootstrap tokens](/docs/reference/api/#post-apiv1bootstrap). |
+
+> [!NOTE]
+> `server.skip_docker_preflight` is deprecated and has been renamed to
+> `skip_preflight`. The old name is still accepted for one release with a
+> deprecation warning.
 
 > [!NOTE]
 > API authentication uses [Personal Access Tokens](/docs/guides/authorization/#personal-access-tokens)
@@ -56,16 +70,17 @@ shutdown_timeout = "30s"
 
 ## `[docker]`
 
+Required when `[server] backend = "docker"` (the default). Configures the
+Docker/Podman runtime used for worker and build containers.
+
 ```toml
 [docker]
 socket          = "/var/run/docker.sock"
 image           = "ghcr.io/rocker-org/r-ver:4.4.3"
 shiny_port      = 3838
 pak_version     = "stable"
-# service_network      = ""
-# store_retention      = "0"
-# default_memory_limit = "2g"   # fallback per worker; omit = unlimited
-# default_cpu_limit    = 4.0    # fallback per worker; 0 = unlimited
+# service_network  = ""
+# runtime          = ""          # OCI runtime; empty = Docker daemon default
 ```
 
 | Field | Type | Default | Required | Description |
@@ -75,9 +90,54 @@ pak_version     = "stable"
 | `shiny_port` | `integer` | `3838` | No | Port Shiny listens on inside containers |
 | `pak_version` | `string` | `stable` | No | [pak](https://pak.r-lib.org/) release channel (`stable`, `rc`, or `devel`) |
 | `service_network` | `string` | — | No | Docker network whose containers are made reachable from workers. Used when apps need access to sidecar services (e.g. PocketBase, PostgREST). |
-| `store_retention` | `duration` | `0` | No | How long to keep unused entries in the shared package store. `0` (default) disables eviction — the store grows indefinitely. |
-| `default_memory_limit` | `string` | — | No | Fallback memory limit for workers when no per-app limit is set (e.g. `"2g"`). Empty or omitted means unlimited. |
-| `default_cpu_limit` | `float` | `0` | No | Fallback CPU limit for workers when no per-app limit is set (e.g. `4.0`). `0` means unlimited. |
+| `runtime` | `string` | — | No | Default OCI runtime for worker containers (e.g. `kata-runtime` for stronger isolation). Empty means the Docker daemon's default. |
+| `runtime_defaults` | `map` | — | No | Per-access-type runtime defaults (e.g. `{ public = "kata-runtime" }`). Overrides `runtime` for apps matching the access type. |
+
+> [!NOTE]
+> In earlier releases `default_memory_limit`, `default_cpu_limit`, and
+> `store_retention` lived in `[docker]`. They have moved to `[server]` and
+> `[storage]` respectively because they are backend-neutral. The old
+> names are still parsed for one release with a deprecation warning.
+
+## `[process]`
+
+Required when `[server] backend = "process"`. Configures the
+bubblewrap-based worker sandbox. See the
+[Process Backend (Native)](/docs/guides/process-backend/) and
+[Process Backend (Containerized)](/docs/guides/process-backend-container/)
+guides for deployment walkthroughs, and
+[Backend Security](/docs/guides/backend-security/) for the trade-offs
+compared to the Docker backend.
+
+```toml
+[process]
+bwrap_path             = "/usr/bin/bwrap"
+r_path                 = "/usr/bin/R"
+# seccomp_profile        = "/etc/blockyard/seccomp.bpf"  # empty = no seccomp
+port_range_start       = 10000
+port_range_end         = 10999
+worker_uid_range_start = 60000
+worker_uid_range_end   = 60999
+worker_gid             = 65534
+```
+
+| Field | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `bwrap_path` | `path` | `/usr/bin/bwrap` | No | Path to the `bubblewrap` binary on the host. |
+| `r_path` | `path` | `/usr/bin/R` | No | Path to the R binary. |
+| `seccomp_profile` | `path` | — | No | Path to a compiled BPF seccomp profile applied to the worker R process via `bwrap --seccomp`. The `blockyard` and `blockyard-process` images ship a profile at `/etc/blockyard/seccomp.bpf` and set this via `BLOCKYARD_PROCESS_SECCOMP_PROFILE`. Empty disables in-sandbox seccomp filtering (the outer namespace and capability drops still apply). |
+| `port_range_start` | `integer` | `10000` | No | First localhost port allocated to workers (inclusive). |
+| `port_range_end` | `integer` | `10999` | No | Last localhost port allocated to workers (inclusive). |
+| `worker_uid_range_start` | `integer` | `60000` | No | First host UID assigned to worker sandboxes (inclusive). Must be sized to at least the port range. |
+| `worker_uid_range_end` | `integer` | `60999` | No | Last host UID assigned to worker sandboxes (inclusive). |
+| `worker_gid` | `integer` | `65534` | No | Shared host GID for all workers. Used as the match key for iptables owner-match egress rules. |
+
+> [!WARNING]
+> Per-worker resource limits (`server.default_memory_limit`,
+> `server.default_cpu_limit`, per-app overrides) are **not enforced** by
+> the process backend. Setting them produces a preflight warning. Use
+> systemd `MemoryMax=` / `CPUQuota=` or the outer container's cgroups
+> for a shared ceiling.
 
 ## `[storage]`
 
@@ -88,6 +148,11 @@ bundle_worker_path    = "/app"
 bundle_retention      = 50
 max_bundle_size       = 104857600
 # soft_delete_retention = "720h"   # 30 days; omit or 0 = immediate hard delete
+# store_retention       = "0"      # R library cache eviction; 0 = disabled
+
+# [[storage.data_mounts]]
+# name = "datasets"
+# path = "/srv/shared/datasets"
 ```
 
 | Field | Type | Default | Required | Description |
@@ -97,6 +162,8 @@ max_bundle_size       = 104857600
 | `bundle_retention` | `integer` | `50` | No | Max bundles kept per app (oldest pruned first) |
 | `max_bundle_size` | `integer` | `104857600` | No | Maximum bundle upload size in bytes (default 100 MB) |
 | `soft_delete_retention` | `duration` | `0` | No | How long to keep soft-deleted apps before permanent removal. When `0` (default), `DELETE` is an immediate hard delete. When set (e.g. `"720h"` for 30 days), deleted apps are recoverable during the retention window and purged automatically afterwards. |
+| `store_retention` | `duration` | `0` | No | How long to keep unused entries in the shared R package store. `0` (default) disables eviction — the store grows indefinitely. Moved from `[docker]` in a recent release; the old location is still parsed with a deprecation warning. |
+| `data_mounts` | `array` | — | No | Admin-approved host directories that apps can mount read-only or read-write. Each entry has `name` (referenced by apps) and `path` (host-side location). |
 
 ## `[database]`
 
@@ -143,6 +210,58 @@ idle_worker_timeout  = "5m"
 | `max_cpu_limit` | `float` | `16.0` | No | Maximum CPU limit that can be set per app (caps the `cpu_limit` field on `PATCH /api/v1/apps/{id}`) |
 | `transfer_timeout` | `duration` | `60s` | No | Timeout for transferring bundle files to worker containers |
 | `session_max_lifetime` | `duration` | `0` | No | Hard cap on session duration regardless of activity. `0` (default) means unlimited — sessions only end via idle timeout or worker shutdown. |
+
+## `[redis]` *(optional)*
+
+Enables Redis-backed shared state for the session store, worker
+registry, and the process backend's port/UID allocators. Required for
+rolling updates via `by admin update` — the old and new server
+processes use Redis as the cross-process coordination layer. Single-node
+deployments without rolling updates can omit this section and the
+in-memory implementation is used.
+
+```toml
+[redis]
+url        = "redis://localhost:6379"
+# key_prefix = "blockyard:"
+```
+
+| Field | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `url` | `string` | — | **Yes** (when section is present) | Redis connection URL, e.g. `redis://[:password@]host:port[/db]`. |
+| `key_prefix` | `string` | `blockyard:` | No | Key prefix for every Redis operation. Useful when multiple blockyard deployments share a Redis instance. |
+
+## `[update]` *(optional)*
+
+Configures the rolling-update orchestrator driven by `by admin update`.
+The orchestrator has two variants, picked automatically based on the
+configured backend:
+
+- **Docker variant** — clones the blockyard container next to the old
+  one. Uses only `schedule`, `channel`, and `watch_period`.
+- **Process variant** — forks a new blockyard process on an alternate
+  bind port. Uses `schedule`, `channel`, `watch_period`, plus
+  `alt_bind_range` and `drain_idle_wait`. Requires `[redis]`.
+
+See the [process backend rolling update walkthrough](/docs/guides/process-backend/#rolling-update-walkthrough)
+for the containerized vs. native rules.
+
+```toml
+[update]
+# schedule        = "0 3 * * 0"     # cron; empty = no scheduled updates
+# channel         = "stable"        # "stable" or "main"
+# watch_period    = "15m"           # post-update health monitoring
+# alt_bind_range  = "8090-8099"     # process variant: alternate bind pool
+# drain_idle_wait = "5m"            # process variant: session drain timeout
+```
+
+| Field | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `schedule` | `string` | — | No | Cron expression (5 fields) for automatic rolling updates. Empty disables the scheduler. |
+| `channel` | `string` | `stable` | No | Release channel to pull from: `stable` or `main`. |
+| `watch_period` | `duration` | — | No | Time the orchestrator monitors the new server's health after activation. An unhealthy signal triggers automatic rollback (Docker variant only). |
+| `alt_bind_range` | `string` | `8090-8099` | No | Port range the process orchestrator picks an alternate bind from when spawning the new server. Must not overlap `[process] port_range_start..end`. Ignored by the Docker variant. |
+| `drain_idle_wait` | `duration` | `5m` | No | Maximum time the old server waits for active sessions to end during a rolling drain. Ignored by the Docker variant, which relies on the reverse proxy to drain in-flight requests. |
 
 ## `[oidc]` *(optional)*
 


### PR DESCRIPTION
## Summary

- Fills the user-facing doc gaps left by phases 3-7 and 3-8: adds `[process]`, `[redis]`, `[update]` to the config reference, documents the `by admin` CLI subcommands (`update`, `rollback`, `status`, `install-seccomp`), and the `/api/v1/admin/*` endpoints.
- Consolidates the egress-firewall rationale and host-UID-mapping discussion in `backend-security.md`; `process-backend.md` and `process-backend-container.md` now defer to one canonical source instead of triplicating it.
- Shrinks `guides/configuration.md` (was ~90% duplicated with `reference/config.md`) into a short orientation page that points to the reference for field-by-field details.
- Refreshes the README: backend choice, prerequisites, tech stack, project layout, and documentation index now reflect the two-backend world.
- Adds image-variant guidance (`blockyard`, `blockyard-docker`, `blockyard-process`) to `installation.md` and backend-neutral framing to `overview.md`.
- Cross-links `by admin install-seccomp`, `by admin update`, and the new config sections where operator guides reference them; verified every anchor resolves against the rendered Hugo site.