### PR TITLE
Replace rocker/r-ver base with ubuntu:24.04 + rig

### DIFF
--- a/.trivyignore.rego
+++ b/.trivyignore.rego
@@ -1,26 +1,21 @@
 # Trivy ignore policy for blockyard container images.
 #
-# Rationale for suppressing linux-libc-dev: the package ships only
-# kernel header files (/usr/include/linux/*, /usr/include/asm/*) as
-# a transitive dep of libc6-dev -> g++ in the rocker/r-ver base
-# used by server-everything and server-process. The CVEs describe
-# running-kernel vulnerabilities — containers use the host kernel,
-# not a kernel built from these headers, so these CVEs are not
-# container-exploitable.
+# Currently empty — issue #185 replaced the rocker/r-ver base for
+# the server-process and server-everything images with a minimal
+# ubuntu:24.04 + rig build, which drops the compiler toolchain and
+# its transitive dependencies (binutils, libctf*, libgprofng*,
+# linux-libc-dev). That eliminated the kernel-header and binutils
+# CVE noise that previously required per-package suppressions
+# here.
 #
-# We intentionally keep the package because purging it cascades
-# into libc6-dev / g++ / gfortran removal and breaks R package
-# source compilation. See issue #185 for the planned migration off
-# rocker, which makes this policy obsolete.
-#
-# Rule-by-package rather than rule-by-CVE-ID so new kernel-header
-# CVEs are silenced automatically on every base bump — no list of
-# CVE IDs to maintain.
+# If new no-upstream-fix CVEs reappear against runtime libraries
+# we still ship (libpixman-1-0, libexpat1, tar, …), add narrow
+# per-package rules below, each with a one-line rationale.
+# Rule-by-package, not by CVE ID, so future CVEs in the same
+# package silence automatically on every base rebuild.
 
 package trivy
 
 import rego.v1
 
 default ignore := false
-
-ignore if input.PkgName == "linux-libc-dev"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Entrypoint shim for the blockyard server-process and
+# server-everything images. Runs the operator's extras hook
+# (default /etc/blockyard/extras.sh is a no-op baked into the
+# image; override by bind-mounting) and then execs the command
+# passed in by the Dockerfile's ENTRYPOINT array.
+#
+# `set -e` propagates extras failures as container startup errors
+# — a typo in an apt package name or a missing rig version aborts
+# the start cleanly instead of silently producing a running server
+# that fails at first dyn.load or first bwrap spawn.
+#
+# `docker run --entrypoint cat IMAGE /path` still replaces the
+# whole entrypoint chain (including this script), so the seccomp
+# profile extract flow documented in the containerized guide
+# continues to work unchanged.
+set -eu
+
+/etc/blockyard/extras.sh
+
+exec "$@"

--- a/docker/extras.example.sh
+++ b/docker/extras.example.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# Example extras hook for blockyard. Bind-mount this file at
+# /etc/blockyard/extras.sh (read-only) to install additional
+# runtime libraries that R packages in your bundles need, or to
+# pin a specific R version via rig.
+#
+#   docker run \
+#       -v $(pwd)/extras.sh:/etc/blockyard/extras.sh:ro \
+#       ghcr.io/cynkra/blockyard-process:<version>
+#
+# Compose and Kubernetes equivalents are in the containerized
+# process-backend guide.
+#
+# Runs as root before blockyard starts. Failures fail-fast and
+# abort startup — don't try to recover from apt-get failures
+# silently.
+#
+# Package names below target ubuntu:24.04 (noble). When the
+# image's base Ubuntu bumps, names with the "t64" suffix will
+# change and this script will need updating.
+
+set -e
+
+# ─── Optional: pin a specific R version via rig ─────────────────
+#
+# The image ships with the R release current at build time. To
+# pin a specific version instead, uncomment and edit:
+#
+#   rig add 4.4.3
+#   rig default 4.4.3
+#
+# To install a second R version alongside the default (e.g. for
+# side-by-side testing):
+#
+#   rig add 4.5.0
+#
+# R versions persist in /opt/R. Mount a volume there to keep them
+# across container rebuilds.
+
+# ─── Additional system libraries ────────────────────────────────
+
+apt-get update
+
+# Spatial (sf, terra, leaflet extensions)
+apt-get install -y --no-install-recommends \
+    libgdal34t64 \
+    libgeos-c1t64 \
+    libproj25 \
+    libudunits2-0
+
+# Imaging / PDF (magick, pdftools)
+apt-get install -y --no-install-recommends \
+    libpoppler-cpp0v5
+
+# Optimization (nloptr, Rglpk)
+apt-get install -y --no-install-recommends \
+    libnlopt0 \
+    libglpk40
+
+rm -rf /var/lib/apt/lists/*

--- a/docker/extras.sh
+++ b/docker/extras.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Default extras hook for blockyard — intentionally a no-op.
+#
+# Override this file by bind-mounting your own script to
+# /etc/blockyard/extras.sh (read-only is fine). The script runs
+# as root before the blockyard server starts and can:
+#
+#   - install additional system libraries via apt-get
+#   - pin or add R versions via rig (e.g. `rig add 4.4.3`)
+#   - add custom apt sources and GPG keys
+#   - drop .netrc / credentials files into /root
+#
+# Failures propagate via `set -e` in the entrypoint shim, so a
+# non-zero exit here aborts container startup with a clear error
+# — typos and missing packages surface immediately rather than
+# failing at first dyn.load inside a worker session.
+#
+# See docs/content/docs/guides/process-backend-container.md for
+# the full contract, mount patterns (docker/compose/kubernetes),
+# and an example script with commented blocks for common R
+# ecosystem extras (spatial, imaging, optimization).
+exit 0

--- a/docker/server-everything.Dockerfile
+++ b/docker/server-everything.Dockerfile
@@ -1,9 +1,15 @@
 # Everything variant image. Ships the blockyard binary built with
 # both backends compiled in (default `go build` — no `minimal` tag)
-# plus R, bubblewrap, iptables, and the compiled BPF seccomp
-# profile. This is the default `ghcr.io/cynkra/blockyard:<v>` image
-# under phase 3-8; operators who want slim Docker-only pull
+# plus R (via rig), bubblewrap, iptables, and the compiled BPF
+# seccomp profile. This is the default `ghcr.io/cynkra/blockyard:<v>`
+# image under phase 3-8; operators who want slim Docker-only pull
 # `-docker` instead.
+#
+# Base: ubuntu:24.04 + rig + r-release (issue #185). Shares the
+# rationale and runtime-lib list with server-process.Dockerfile;
+# the only additions here are iptables (for the Docker backend's
+# native egress firewall path) and the broader set of build tags
+# on the Go compile step above.
 
 FROM hugomods/hugo:exts-0.147.4 AS docs
 WORKDIR /docs
@@ -50,14 +56,15 @@ RUN CGO_ENABLED=0 go build ${COVER:+-cover} \
     -o /blockyard ./cmd/blockyard
 RUN CGO_ENABLED=0 go build ${COVER:+-cover} -o /by-builder ./cmd/by-builder
 
-# Final stage: rocker/r-ver, same rationale as server-process.
-# iptables is added here because the everything variant also
-# supports the Docker backend (which uses iptables for worker
-# egress in native mode).
-FROM ghcr.io/rocker-org/r-ver:4.4.3
+# Final stage: ubuntu:24.04 + rig + R release. See the header
+# comment and issue #185 for the rationale. iptables is the only
+# addition over the process-variant image — the Docker backend
+# uses it for worker egress in native mode.
+FROM ubuntu:24.04
 
-# `apt-get upgrade` pulls in Ubuntu security patches that the
-# rocker/r-ver base may have missed since its last rebuild.
+ARG RIG_VERSION=0.7.1
+ARG TARGETARCH=amd64
+
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
@@ -65,6 +72,29 @@ RUN apt-get update \
         ca-certificates \
         curl \
         iptables \
+        libcairo2 \
+        libcurl4t64 \
+        libicu74 \
+        libmariadb3 \
+        liblz4-1 \
+        libodbc2 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libpq5 \
+        libsqlite3-0 \
+        libssl3t64 \
+        libxml2 \
+        libzstd1 \
+    && case "${TARGETARCH}" in \
+        arm64) RIG_ASSET="rig-linux-arm64-${RIG_VERSION}.tar.gz" ;; \
+        amd64) RIG_ASSET="rig-linux-${RIG_VERSION}.tar.gz" ;; \
+        *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+       esac \
+    && curl -fsSL "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}" \
+        | tar xz -C /usr/local \
+    && rig add release \
+    && ln -sf /usr/local/bin/R /usr/bin/R \
+    && ln -sf /usr/local/bin/Rscript /usr/bin/Rscript \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /blockyard /usr/local/bin/blockyard
@@ -73,8 +103,14 @@ COPY blockyard.toml /etc/blockyard/blockyard.toml
 COPY --from=seccomp-compiler /blockyard-bwrap-seccomp.bpf /etc/blockyard/seccomp.bpf
 COPY internal/seccomp/blockyard-outer.json /etc/blockyard/seccomp.json
 
+# Extras hook. See server-process.Dockerfile for the full comment
+# and docs/content/docs/guides/process-backend-container.md for
+# the operator-facing contract.
+COPY docker/extras.sh /etc/blockyard/extras.sh
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+
 ENV BLOCKYARD_PROCESS_SECCOMP_PROFILE=/etc/blockyard/seccomp.bpf
 
 EXPOSE 8080
 
-ENTRYPOINT ["blockyard", "--config", "/etc/blockyard/blockyard.toml"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh", "blockyard", "--config", "/etc/blockyard/blockyard.toml"]

--- a/docker/server-everything.Dockerfile
+++ b/docker/server-everything.Dockerfile
@@ -5,11 +5,12 @@
 # image under phase 3-8; operators who want slim Docker-only pull
 # `-docker` instead.
 #
-# Base: ubuntu:24.04 + rig + r-release (issue #185). Shares the
-# rationale and runtime-lib list with server-process.Dockerfile;
-# the only additions here are iptables (for the Docker backend's
-# native egress firewall path) and the broader set of build tags
-# on the Go compile step above.
+# Base: ubuntu:24.04 + rig (issue #185). Shares the rationale and
+# runtime-lib list with server-process.Dockerfile; the only
+# additions here are iptables (for the Docker backend's native
+# egress firewall path) and the broader set of build tags on the
+# Go compile step above. R_VERSION build ARG controls which R
+# version is baked in (default: "release").
 
 FROM hugomods/hugo:exts-0.147.4 AS docs
 WORKDIR /docs
@@ -63,6 +64,7 @@ RUN CGO_ENABLED=0 go build ${COVER:+-cover} -o /by-builder ./cmd/by-builder
 FROM ubuntu:24.04
 
 ARG RIG_VERSION=0.7.1
+ARG R_VERSION=release
 ARG TARGETARCH=amd64
 
 RUN apt-get update \
@@ -92,7 +94,7 @@ RUN apt-get update \
        esac \
     && curl -fsSL "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}" \
         | tar xz -C /usr/local \
-    && rig add release \
+    && rig add "${R_VERSION}" \
     && ln -sf /usr/local/bin/R /usr/bin/R \
     && ln -sf /usr/local/bin/Rscript /usr/bin/Rscript \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/server-process.Dockerfile
+++ b/docker/server-process.Dockerfile
@@ -1,11 +1,17 @@
 # Process-backend variant image. Ships the blockyard binary built
 # with `-tags 'minimal,process_backend'` — no Docker SDK in the
-# dependency graph, no socket expectation — plus R, bubblewrap, and
-# the compiled BPF seccomp profile at /etc/blockyard/seccomp.bpf.
+# dependency graph, no socket expectation — plus R (via rig),
+# bubblewrap, and the compiled BPF seccomp profile at
+# /etc/blockyard/seccomp.bpf.
 #
-# Based on rocker/r-ver so the R toolchain and library paths match
-# what the process backend's preflight and worker spawn expect. See
-# docs/design/v3/phase-3-8.md (step 4) for the base-image rationale.
+# Base: ubuntu:24.04 + rig + r-release (issue #185). Rocker's full
+# R toolchain ships binutils, g++, gfortran, and -dev headers that
+# bloat the attack surface for a runtime that executes untrusted R
+# code. This image ships only runtime shared libraries; operators
+# who need source builds or extra packages install them via the
+# extras.sh hook (see the bottom of this file). R itself is managed
+# by rig (r-lib/rig), so operators can swap versions without
+# rebuilding the image — `rig add 4.5` in an extras.sh override.
 
 FROM hugomods/hugo:exts-0.147.4 AS docs
 WORKDIR /docs
@@ -58,25 +64,57 @@ RUN CGO_ENABLED=0 go build ${COVER:+-cover} \
     -o /blockyard ./cmd/blockyard
 RUN CGO_ENABLED=0 go build ${COVER:+-cover} -o /by-builder ./cmd/by-builder
 
-# Final stage: rocker/r-ver is the R-on-Debian base used by phase
-# 3-7's CI matrix and the default blockyard.toml worker image. The
-# GHCR mirror avoids Docker Hub anonymous-pull rate limits.
-FROM ghcr.io/rocker-org/r-ver:4.4.3
+# Final stage: ubuntu:24.04 + rig + R release. See the header
+# comment for the rationale and issue #185 for the full discussion.
+FROM ubuntu:24.04
 
-# bubblewrap for the sandbox, ca-certificates for TLS, curl for
-# bootstrap and health probes. No iptables — the process-backend
-# variant relies on the operator's host iptables rules (or the
-# outer container's) for worker egress isolation; shipping the
-# tool would suggest blockyard itself installs the rules.
+# rig version pin. rig is the R installation manager from r-lib;
+# it downloads official R binaries and manages multiple installed
+# R versions via shims under /usr/local/bin. Operators can swap R
+# versions at runtime via the extras.sh hook without rebuilding
+# this image.
+ARG RIG_VERSION=0.7.1
+# Docker buildx sets TARGETARCH automatically for multi-platform
+# builds. Default to amd64 for local single-arch `docker build`
+# invocations so rig downloads the correct tarball.
+ARG TARGETARCH=amd64
+
+# Runtime libraries only — no -dev headers, no compiler toolchain.
+# r-base-core-style runtime deps + common DB connectors + xml + ssl
+# + compression. Packages with compiled code requiring libraries
+# not listed here are installed via the extras.sh hook.
 #
-# `apt-get upgrade` pulls in Ubuntu security patches that the
-# rocker/r-ver base may have missed since its last rebuild.
+# `apt-get upgrade` picks up Ubuntu security patches landed since
+# the base image's last rebuild.
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         bubblewrap \
         ca-certificates \
         curl \
+        libcairo2 \
+        libcurl4t64 \
+        libicu74 \
+        libmariadb3 \
+        liblz4-1 \
+        libodbc2 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libpq5 \
+        libsqlite3-0 \
+        libssl3t64 \
+        libxml2 \
+        libzstd1 \
+    && case "${TARGETARCH}" in \
+        arm64) RIG_ASSET="rig-linux-arm64-${RIG_VERSION}.tar.gz" ;; \
+        amd64) RIG_ASSET="rig-linux-${RIG_VERSION}.tar.gz" ;; \
+        *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+       esac \
+    && curl -fsSL "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}" \
+        | tar xz -C /usr/local \
+    && rig add release \
+    && ln -sf /usr/local/bin/R /usr/bin/R \
+    && ln -sf /usr/local/bin/Rscript /usr/bin/Rscript \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /blockyard /usr/local/bin/blockyard
@@ -90,6 +128,18 @@ COPY --from=seccomp-compiler /blockyard-bwrap-seccomp.bpf /etc/blockyard/seccomp
 # a copy.
 COPY internal/seccomp/blockyard-outer.json /etc/blockyard/seccomp.json
 
+# Extras hook. The default is a no-op; operators override by
+# bind-mounting their own script to /etc/blockyard/extras.sh to
+# install additional system libraries, pin a specific R version
+# via rig, or drop credential files. Runs as root before the
+# blockyard server starts; failures propagate (set -e in the
+# entrypoint) and abort startup with a clear error.
+#
+# See docs/content/docs/guides/process-backend-container.md for
+# the full contract and mount patterns.
+COPY docker/extras.sh /etc/blockyard/extras.sh
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+
 # Default the process backend's bwrap seccomp profile path to the
 # shipped blob so operators don't need to set process.seccomp_profile
 # in TOML.
@@ -97,4 +147,8 @@ ENV BLOCKYARD_PROCESS_SECCOMP_PROFILE=/etc/blockyard/seccomp.bpf
 
 EXPOSE 8080
 
-ENTRYPOINT ["blockyard", "--config", "/etc/blockyard/blockyard.toml"]
+# ENTRYPOINT carries the full command; no CMD. docker run args are
+# appended to the entrypoint, so `docker run image --log-level debug`
+# still works. `docker run --entrypoint cat image /path` still
+# replaces the entire entrypoint chain for the seccomp extract flow.
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh", "blockyard", "--config", "/etc/blockyard/blockyard.toml"]

--- a/docker/server-process.Dockerfile
+++ b/docker/server-process.Dockerfile
@@ -4,14 +4,15 @@
 # bubblewrap, and the compiled BPF seccomp profile at
 # /etc/blockyard/seccomp.bpf.
 #
-# Base: ubuntu:24.04 + rig + r-release (issue #185). Rocker's full
-# R toolchain ships binutils, g++, gfortran, and -dev headers that
-# bloat the attack surface for a runtime that executes untrusted R
-# code. This image ships only runtime shared libraries; operators
-# who need source builds or extra packages install them via the
-# extras.sh hook (see the bottom of this file). R itself is managed
-# by rig (r-lib/rig), so operators can swap versions without
-# rebuilding the image — `rig add 4.5` in an extras.sh override.
+# Base: ubuntu:24.04 + rig (issue #185). Rocker's full R toolchain
+# ships binutils, g++, gfortran, and -dev headers that bloat the
+# attack surface for a runtime that executes untrusted R code. This
+# image ships only runtime shared libraries; operators who need
+# source builds or extra packages install them via the extras.sh
+# hook (see the bottom of this file). R itself is managed by rig
+# (r-lib/rig); the R_VERSION build ARG controls which version is
+# baked in (default: "release"). Operators can also swap versions
+# at runtime via `rig add 4.5` in an extras.sh override.
 
 FROM hugomods/hugo:exts-0.147.4 AS docs
 WORKDIR /docs
@@ -74,6 +75,10 @@ FROM ubuntu:24.04
 # versions at runtime via the extras.sh hook without rebuilding
 # this image.
 ARG RIG_VERSION=0.7.1
+# R version to install via rig. Defaults to "release" (latest
+# stable); pin to a specific version (e.g. "4.4.3") for
+# reproducible builds.
+ARG R_VERSION=release
 # Docker buildx sets TARGETARCH automatically for multi-platform
 # builds. Default to amd64 for local single-arch `docker build`
 # invocations so rig downloads the correct tarball.
@@ -112,7 +117,7 @@ RUN apt-get update \
        esac \
     && curl -fsSL "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}" \
         | tar xz -C /usr/local \
-    && rig add release \
+    && rig add "${R_VERSION}" \
     && ln -sf /usr/local/bin/R /usr/bin/R \
     && ln -sf /usr/local/bin/Rscript /usr/bin/Rscript \
     && rm -rf /var/lib/apt/lists/*

--- a/docs/content/docs/guides/process-backend-container.md
+++ b/docs/content/docs/guides/process-backend-container.md
@@ -22,11 +22,132 @@ For the native (bare-metal) variant, see
 binary compiled with `-tags 'minimal,process_backend'` (no Docker SDK
 in the dep graph), plus:
 
-- R 4.4.3 from `rocker/r-ver`
+- `ubuntu:24.04` base
+- R (the current release at image build time), installed via
+  [`rig`](https://github.com/r-lib/rig) so operators can swap R
+  versions at deploy time via the extras hook — see below
+- Runtime shared libraries commonly needed by R packages
+  (libcurl, libssl, libxml2, libcairo, libpango, libpq, libmariadb,
+  libsqlite3, unixodbc, libzstd, …). No compiler toolchain and no
+  `-dev` headers; extra libraries are added via the extras hook.
 - `bubblewrap`
 - The compiled bwrap seccomp profile at `/etc/blockyard/seccomp.bpf`
 - The outer-container seccomp profile at `/etc/blockyard/seccomp.json`
   (for extraction to the host)
+
+## Extending the image — the extras hook
+
+The image runs `/etc/blockyard/extras.sh` as root before starting
+the blockyard server. A no-op default is baked in; operators
+override it by bind-mounting their own script.
+
+Use the hook to:
+
+- install additional system libraries for R packages your bundles
+  need (libgdal for `sf`/`terra`, libpoppler for `pdftools`, …)
+- pin or add R versions via `rig` (e.g. `rig add 4.4.3`)
+- add custom apt sources and GPG keys
+- drop `.netrc` or credentials files into `/root`
+
+Example:
+
+```sh
+#!/bin/sh
+# extras.sh
+set -e
+
+# Pin a specific R version instead of the baked-in release
+rig add 4.4.3
+rig default 4.4.3
+
+# Spatial libraries for sf / terra
+apt-get update
+apt-get install -y --no-install-recommends \
+    libgdal34t64 libgeos-c1t64 libproj25 libudunits2-0
+rm -rf /var/lib/apt/lists/*
+```
+
+See `docker/extras.example.sh` in the blockyard repository for a
+fuller example with commented blocks for common R ecosystem
+extras.
+
+### Mount patterns
+
+**Docker / docker-compose:**
+
+```yaml
+services:
+  blockyard:
+    image: ghcr.io/cynkra/blockyard-process:1.2.3
+    volumes:
+      - ./extras.sh:/etc/blockyard/extras.sh:ro
+```
+
+**Kubernetes:** create a ConfigMap from the script and mount a
+single `items` entry at the target path:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blockyard-extras
+data:
+  extras.sh: |
+    #!/bin/sh
+    set -e
+    apt-get update
+    apt-get install -y --no-install-recommends libgdal34t64
+    rm -rf /var/lib/apt/lists/*
+---
+# in the Deployment's pod spec:
+        volumeMounts:
+        - name: extras
+          mountPath: /etc/blockyard/extras.sh
+          subPath: extras.sh
+          readOnly: true
+      volumes:
+      - name: extras
+        configMap:
+          name: blockyard-extras
+          defaultMode: 0755
+```
+
+### Failure semantics
+
+The entrypoint shim runs `set -e` before executing the extras
+script. A non-zero exit aborts container startup with a clear
+error visible in `docker logs` / `kubectl logs`. Typos and missing
+packages surface immediately instead of turning into mysterious
+`dyn.load()` failures at first user session.
+
+### Scan drift caveat
+
+The Trivy scan in the blockyard CI publishes findings for the
+built image. Any packages or R versions added at startup via the
+extras hook are **not** covered by that scan — the operator owns
+the CVE picture of whatever they layer on. Operators who need the
+scan to reflect reality should bake their own image instead:
+
+```dockerfile
+FROM ghcr.io/cynkra/blockyard-process:1.2.3
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libgdal34t64 \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+Baked-in packages are scanned by whatever image-scanning pipeline
+the operator runs on their own registry.
+
+### Airgapped and network-restricted deploys
+
+The default extras hook is a no-op, so the out-of-the-box image
+starts with no network access required. But any extras script
+that calls `apt-get update`, `rig add`, or downloads anything
+over HTTP needs outbound connectivity at container start. For
+airgapped deploys, bake what you need into a derived image
+instead of using the runtime hook — the `FROM
+ghcr.io/cynkra/blockyard-process:<v>` pattern above is the
+airgap-friendly path.
 
 ## Why the outer seccomp profile is needed
 


### PR DESCRIPTION
## Summary

- Swap `ghcr.io/rocker-org/r-ver:4.4.3` base for `ubuntu:24.04` in both `server-process.Dockerfile` and `server-everything.Dockerfile`, dropping the compiler toolchain and `-dev` headers
- Install R via rig (`rig add release`) so operators can swap versions at deploy time without rebuilding
- Add `docker/entrypoint.sh` + `docker/extras.sh` extension hook: operators bind-mount a script at `/etc/blockyard/extras.sh` to install additional system libs, pin a specific R version, or add apt sources
- Drop the `linux-libc-dev` Rego suppression in `.trivyignore.rego` — the toolchain it covered is gone
- Document the extras hook contract, mount patterns, and scan-drift caveat in the containerized process-backend guide

Closes #185.