### PR TITLE
fix: inject shiny host per backend so bundles don't need to

### DIFF
--- a/examples/hello-pocketbase/app/app.R
+++ b/examples/hello-pocketbase/app/app.R
@@ -1,4 +1,1 @@
-options(shiny.port = as.integer(Sys.getenv("SHINY_PORT", "3838")))
-options(shiny.host = "0.0.0.0")
-
 blockr::run_app()

--- a/examples/hello-postgrest/app/app.R
+++ b/examples/hello-postgrest/app/app.R
@@ -1,4 +1,1 @@
-options(shiny.port = as.integer(Sys.getenv("SHINY_PORT", "3838")))
-options(shiny.host = "0.0.0.0")
-
 blockr::run_app()

--- a/examples/hello-shiny/app/app.R
+++ b/examples/hello-shiny/app/app.R
@@ -21,7 +21,4 @@ server <- function(input, output) {
   })
 }
 
-shinyApp(ui = ui, server = server, options = list(
-  port = as.integer(Sys.getenv("SHINY_PORT", "3838")),
-  host = "0.0.0.0"
-))
+shinyApp(ui = ui, server = server)

--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -20,9 +19,7 @@ import (
 	"github.com/cynkra/blockyard/internal/auth"
 	"github.com/cynkra/blockyard/internal/authz"
 	"github.com/cynkra/blockyard/internal/backend"
-	"github.com/cynkra/blockyard/internal/bundle"
 	"github.com/cynkra/blockyard/internal/db"
-	"github.com/cynkra/blockyard/internal/manifest"
 	"github.com/cynkra/blockyard/internal/mount"
 	"github.com/cynkra/blockyard/internal/ops"
 	"github.com/cynkra/blockyard/internal/server"
@@ -885,40 +882,9 @@ func StartApp(srv *server.Server) http.HandlerFunc {
 
 		// Build WorkerSpec
 		workerID := uuid.New().String()
-		hostPaths := bundle.NewBundlePaths(
-			srv.Config.Storage.BundleServerPath, app.ID, *app.ActiveBundle,
-		)
-
-		labels := map[string]string{
-			"dev.blockyard/managed":   "true",
-			"dev.blockyard/app-id":    app.ID,
-			"dev.blockyard/worker-id": workerID,
-			"dev.blockyard/role":      "worker",
-		}
-
-		var rVersion string
-		if m, err := manifest.Read(filepath.Join(hostPaths.Unpacked, "manifest.json")); err == nil {
-			rVersion = m.RVersion
-		}
-
-		spec := backend.WorkerSpec{
-			AppID:       app.ID,
-			WorkerID:    workerID,
-			Image:       server.AppImage(app, srv.Config.Docker.Image),
-			Cmd: []string{"R", "-e",
-				fmt.Sprintf("shiny::runApp('%s', port = as.integer(Sys.getenv('SHINY_PORT')), host = Sys.getenv('SHINY_HOST', unset = '0.0.0.0'))",
-					srv.Config.Storage.BundleWorkerPath)},
-			BundlePath:  hostPaths.Unpacked,
-			LibraryPath: hostPaths.Library,
-			WorkerMount: srv.Config.Storage.BundleWorkerPath,
-			ShinyPort:   srv.Config.Docker.ShinyPort,
-			RVersion:    rVersion,
-			MemoryLimit: stringOrEmpty(app.MemoryLimit),
-			CPULimit:    floatOrZero(app.CPULimit),
-			Labels:      labels,
-			Env:         server.WorkerEnv(srv),
-			Runtime:     server.AppRuntime(app, srv.Config.Docker),
-		}
+		spec := server.BaseWorkerSpec(srv, app, workerID, *app.ActiveBundle)
+		spec.MemoryLimit = stringOrEmpty(app.MemoryLimit)
+		spec.CPULimit = floatOrZero(app.CPULimit)
 
 		// Resolve per-app data mounts.
 		appMounts, _ := srv.DB.ListAppDataMounts(app.ID)

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -97,9 +97,10 @@ type WorkerSpec struct {
 	MemoryLimit string            // e.g. "512m", "" if unset
 	CPULimit    float64           // fractional vCPUs, 0 if unset
 	Labels      map[string]string
-	Env         map[string]string // additional env vars (e.g. VAULT_ADDR)
-	DataMounts  []MountEntry      // data mounts from app config; resolved host paths
-	Runtime     string            // OCI runtime override; empty = default
+	Env          map[string]string // additional env vars (e.g. VAULT_ADDR)
+	RProfilePath string            // server-side path to blockyard R profile; mounted ro by backends
+	DataMounts   []MountEntry      // data mounts from app config; resolved host paths
+	Runtime      string            // OCI runtime override; empty = default
 }
 
 type BuildSpec struct {

--- a/internal/backend/docker/docker.go
+++ b/internal/backend/docker/docker.go
@@ -405,6 +405,17 @@ func (d *DockerBackend) createWorkerContainer(
 		binds = append(binds, dm.Source+":"+dm.Target+flag)
 	}
 
+	// R profile — mount the blockyard R profile so R picks up
+	// SHINY_HOST / SHINY_PORT as options before the user's script runs.
+	const rProfileTarget = "/etc/blockyard/rprofile.R"
+	if spec.RProfilePath != "" {
+		pb, pm := d.mountCfg.TranslateMount(backend.MountEntry{
+			Source: spec.RProfilePath, Target: rProfileTarget, ReadOnly: true,
+		})
+		binds = append(binds, pb...)
+		mounts = append(mounts, pm...)
+	}
+
 	// R_LIBS: use /blockyard-lib-store when store-assembled library is
 	// available, else legacy /blockyard-lib. Must not use /lib as that
 	// shadows the system shared library directory on Linux.
@@ -415,6 +426,9 @@ func (d *DockerBackend) createWorkerContainer(
 	env := []string{
 		fmt.Sprintf("SHINY_PORT=%d", spec.ShinyPort),
 		"R_LIBS=" + rLibs,
+	}
+	if spec.RProfilePath != "" {
+		env = append(env, "R_PROFILE_USER="+rProfileTarget)
 	}
 	for k, v := range spec.Env {
 		env = append(env, k+"="+v)

--- a/internal/backend/docker/mounts_test.go
+++ b/internal/backend/docker/mounts_test.go
@@ -335,6 +335,60 @@ func TestMountConfig_WorkerMounts_LibDirOverridesLibraryPath(t *testing.T) {
 	}
 }
 
+func TestTranslateMount_RProfile_NativeMode(t *testing.T) {
+	mc := MountConfig{Mode: MountModeNative}
+	binds, mounts := mc.TranslateMount(backend.MountEntry{
+		Source: "/data/bundles/.blockyard-rprofile.R", Target: "/etc/blockyard/rprofile.R", ReadOnly: true,
+	})
+	if len(mounts) != 0 {
+		t.Fatalf("expected no volume mounts in native mode, got %d", len(mounts))
+	}
+	if len(binds) != 1 {
+		t.Fatalf("expected 1 bind, got %d", len(binds))
+	}
+	if binds[0] != "/data/bundles/.blockyard-rprofile.R:/etc/blockyard/rprofile.R:ro" {
+		t.Errorf("bind = %q", binds[0])
+	}
+}
+
+func TestTranslateMount_RProfile_BindMode(t *testing.T) {
+	mc := MountConfig{
+		Mode:       MountModeBind,
+		HostSource: "/host/data",
+		MountDest:  "/data",
+	}
+	binds, mounts := mc.TranslateMount(backend.MountEntry{
+		Source: "/data/bundles/.blockyard-rprofile.R", Target: "/etc/blockyard/rprofile.R", ReadOnly: true,
+	})
+	if len(mounts) != 0 {
+		t.Fatalf("expected no volume mounts in bind mode, got %d", len(mounts))
+	}
+	if len(binds) != 1 {
+		t.Fatalf("expected 1 bind, got %d", len(binds))
+	}
+	if binds[0] != "/host/data/bundles/.blockyard-rprofile.R:/etc/blockyard/rprofile.R:ro" {
+		t.Errorf("bind = %q, expected host-translated path", binds[0])
+	}
+}
+
+func TestTranslateMount_RProfile_VolumeMode(t *testing.T) {
+	mc := MountConfig{
+		Mode:       MountModeVolume,
+		VolumeName: "blockyard-data",
+		MountDest:  "/data",
+	}
+	binds, mounts := mc.TranslateMount(backend.MountEntry{
+		Source: "/data/bundles/.blockyard-rprofile.R", Target: "/etc/blockyard/rprofile.R", ReadOnly: true,
+	})
+	if len(binds) != 0 {
+		t.Fatalf("expected no binds in volume mode, got %d", len(binds))
+	}
+	if len(mounts) != 1 {
+		t.Fatalf("expected 1 volume mount, got %d", len(mounts))
+	}
+	assertVolumeMount(t, mounts[0], "blockyard-data", "/etc/blockyard/rprofile.R", true, "bundles/.blockyard-rprofile.R")
+}
+
 func assertVolumeMount(t *testing.T, m mount.Mount, source, target string, readOnly bool, subpath string) {
 	t.Helper()
 	if m.Type != mount.TypeVolume {

--- a/internal/backend/process/bwrap.go
+++ b/internal/backend/process/bwrap.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 
 	"github.com/cynkra/blockyard/internal/backend"
@@ -22,7 +23,7 @@ import (
 // For the host UID/GID to actually take effect (so iptables owner
 // match works), blockyard must run as root or bwrap must be setuid.
 // Verified at startup by checkBwrapHostUIDMapping.
-func bwrapArgs(cfg *config.ProcessConfig, spec backend.WorkerSpec, port, uid, gid int) []string {
+func bwrapArgs(_ *config.ProcessConfig, spec backend.WorkerSpec, port, uid, gid int) []string {
 	args := []string{
 		// Namespace isolation
 		"--unshare-pid",
@@ -106,9 +107,7 @@ func bwrapArgs(cfg *config.ProcessConfig, spec backend.WorkerSpec, port, uid, gi
 		args = append(args, spec.Cmd...)
 	} else {
 		args = append(args,
-			cfg.RPath, "-e",
-			fmt.Sprintf("shiny::runApp('%s', port=%d, host='127.0.0.1')",
-				spec.WorkerMount, port),
+			"Rscript", filepath.Join(spec.WorkerMount, "app.R"),
 		)
 	}
 

--- a/internal/backend/process/bwrap_test.go
+++ b/internal/backend/process/bwrap_test.go
@@ -101,24 +101,16 @@ func TestBwrapArgs(t *testing.T) {
 	assertBindMount(t, args, "--ro-bind", "/", "/")
 	assertBindMount(t, args, "--ro-bind", spec.BundlePath, spec.WorkerMount)
 
-	// Verify the R command is after the -- separator.
+	// Verify the Rscript command is after the -- separator.
 	sepIdx := indexOf(args, "--")
 	if sepIdx < 0 {
 		t.Fatal("missing -- separator")
 	}
-	if args[sepIdx+1] != cfg.RPath {
-		t.Errorf("expected R path %q after --, got %q", cfg.RPath, args[sepIdx+1])
+	if args[sepIdx+1] != "Rscript" {
+		t.Errorf("expected Rscript after --, got %q", args[sepIdx+1])
 	}
-
-	// Workers share the host network stack (no --unshare-net), so
-	// Shiny must bind loopback — 0.0.0.0 would expose the app on the
-	// host's external interface, bypassing the proxy auth layer.
-	rest := strings.Join(args[sepIdx+1:], " ")
-	if !strings.Contains(rest, "port=10000") {
-		t.Errorf("default cmd should reference port=10000: %s", rest)
-	}
-	if !strings.Contains(rest, "host='127.0.0.1'") {
-		t.Errorf("default cmd must bind loopback, got: %s", rest)
+	if args[sepIdx+2] != spec.WorkerMount+"/app.R" {
+		t.Errorf("expected %s/app.R, got %q", spec.WorkerMount, args[sepIdx+2])
 	}
 }
 
@@ -193,6 +185,28 @@ func TestBwrapArgsCustomCmd(t *testing.T) {
 	cmd := args[sepIdx+1:]
 	if len(cmd) != 3 || cmd[0] != "/usr/bin/R" {
 		t.Errorf("expected custom command after --, got %v", cmd)
+	}
+}
+
+// TestBwrapArgsCmdPassthrough verifies that a non-nil spec.Cmd is passed
+// through to bwrap unchanged (no fallback to the default Rscript command).
+func TestBwrapArgsCmdPassthrough(t *testing.T) {
+	cfg := &config.ProcessConfig{
+		BwrapPath: "/usr/bin/bwrap",
+		RPath:     "/usr/bin/R",
+	}
+	spec := backend.WorkerSpec{
+		WorkerID:    "w-1",
+		BundlePath:  "/data/bundles/app1/v1",
+		WorkerMount: "/app",
+		Cmd:         []string{"Rscript", "/app/app.R"},
+	}
+
+	args := bwrapArgs(cfg, spec, 10002, 60002, 65534)
+	sepIdx := indexOf(args, "--")
+	cmd := args[sepIdx+1:]
+	if len(cmd) != 2 || cmd[0] != "Rscript" || cmd[1] != "/app/app.R" {
+		t.Errorf("expected [Rscript /app/app.R] after --, got %v", cmd)
 	}
 }
 

--- a/internal/backend/process/process.go
+++ b/internal/backend/process/process.go
@@ -316,6 +316,9 @@ func (b *ProcessBackend) Spawn(_ context.Context, spec backend.WorkerSpec) error
 		"LANG=C.UTF-8",
 		"R_LIBS=" + rLibs,
 	}
+	if spec.RProfilePath != "" {
+		cmd.Env = append(cmd.Env, "R_PROFILE_USER="+spec.RProfilePath)
+	}
 	for k, v := range spec.Env {
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}

--- a/internal/bundle/buildmode.go
+++ b/internal/bundle/buildmode.go
@@ -22,7 +22,7 @@ func resolveManifest(unpackedPath string) (*manifest.Manifest, error) {
 
 	meta := manifest.Metadata{
 		AppMode:    detectAppMode(unpackedPath),
-		Entrypoint: detectEntrypoint(unpackedPath),
+		Entrypoint: DetectEntrypoint(unpackedPath),
 	}
 	files := computeFileChecksums(unpackedPath)
 
@@ -52,15 +52,10 @@ func detectAppMode(unpackedPath string) string {
 	return "shiny" // default
 }
 
-// detectEntrypoint returns the primary entrypoint file name.
-func detectEntrypoint(unpackedPath string) string {
-	if fileExists(filepath.Join(unpackedPath, "app.R")) {
-		return "app.R"
-	}
-	if fileExists(filepath.Join(unpackedPath, "server.R")) {
-		return "server.R"
-	}
-	return "app.R" // default
+// DetectEntrypoint returns the entrypoint file name. Bundles must
+// contain app.R — this is the only supported entrypoint.
+func DetectEntrypoint(unpackedPath string) string {
+	return "app.R"
 }
 
 // computeFileChecksums walks the unpacked dir and computes SHA-256

--- a/internal/bundle/buildmode_test.go
+++ b/internal/bundle/buildmode_test.go
@@ -141,22 +141,8 @@ func TestResolveManifest_Priority(t *testing.T) {
 
 func TestDetectEntrypoint(t *testing.T) {
 	dir := t.TempDir()
-
-	// No files → default app.R
-	if got := detectEntrypoint(dir); got != "app.R" {
-		t.Errorf("default = %q", got)
-	}
-
-	// server.R present
-	os.WriteFile(filepath.Join(dir, "server.R"), []byte("# server"), 0o644)
-	if got := detectEntrypoint(dir); got != "server.R" {
-		t.Errorf("with server.R = %q", got)
-	}
-
-	// app.R wins
-	os.WriteFile(filepath.Join(dir, "app.R"), []byte("# app"), 0o644)
-	if got := detectEntrypoint(dir); got != "app.R" {
-		t.Errorf("with both = %q", got)
+	if got := DetectEntrypoint(dir); got != "app.R" {
+		t.Errorf("got %q, want app.R", got)
 	}
 }
 

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -149,15 +149,13 @@ func UnpackArchive(paths Paths) error {
 	return nil
 }
 
-// ValidateEntrypoint checks that the unpacked bundle contains an app.R
-// or server.R file at the top level.
+// ValidateEntrypoint checks that the unpacked bundle contains app.R
+// at the top level.
 func ValidateEntrypoint(paths Paths) error {
-	for _, name := range []string{"app.R", "server.R"} {
-		if _, err := os.Stat(filepath.Join(paths.Unpacked, name)); err == nil {
-			return nil
-		}
+	if _, err := os.Stat(filepath.Join(paths.Unpacked, "app.R")); err == nil {
+		return nil
 	}
-	return fmt.Errorf("missing entrypoint: app.R or server.R")
+	return fmt.Errorf("missing entrypoint: app.R")
 }
 
 // CreateLibraryDir creates the output directory for dependency restoration.

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -162,16 +162,16 @@ func TestValidateEntrypoint_Valid(t *testing.T) {
 	}
 }
 
-func TestValidateEntrypoint_ServerR(t *testing.T) {
+func TestValidateEntrypoint_ServerR_Rejected(t *testing.T) {
 	tmp := t.TempDir()
 	paths := NewBundlePaths(tmp, "app-1", "bundle-1")
 
-	// Create unpacked dir with server.R only.
+	// server.R alone is not a valid entrypoint — must be app.R.
 	os.MkdirAll(paths.Unpacked, 0o755)
 	os.WriteFile(filepath.Join(paths.Unpacked, "server.R"), []byte("# server"), 0o644)
 
-	if err := ValidateEntrypoint(paths); err != nil {
-		t.Fatalf("expected valid entrypoint with server.R, got: %v", err)
+	if err := ValidateEntrypoint(paths); err == nil {
+		t.Fatal("expected error for server.R without app.R")
 	}
 }
 

--- a/internal/proxy/coldstart.go
+++ b/internal/proxy/coldstart.go
@@ -12,10 +12,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/cynkra/blockyard/internal/backend"
 	"github.com/cynkra/blockyard/internal/bundle"
 	"github.com/cynkra/blockyard/internal/db"
-	"github.com/cynkra/blockyard/internal/manifest"
 	"github.com/cynkra/blockyard/internal/mount"
 	"github.com/cynkra/blockyard/internal/ops"
 	"github.com/cynkra/blockyard/internal/pkgstore"
@@ -246,33 +244,14 @@ func spawnWorker(ctx context.Context, srv *server.Server, app *db.AppRow) (strin
 		}
 	}
 
-	// Read R version from bundle manifest for version dispatch.
-	var rVersion string
-	if m, err := manifest.Read(filepath.Join(hostPaths.Unpacked, "manifest.json")); err == nil {
-		rVersion = m.RVersion
-	}
-
-	spec := backend.WorkerSpec{
-		AppID:       app.ID,
-		WorkerID:    wid,
-		Image:       server.AppImage(app, srv.Config.Docker.Image),
-		Cmd: []string{"R", "-e",
-			fmt.Sprintf("shiny::runApp('%s', port = as.integer(Sys.getenv('SHINY_PORT')), host = Sys.getenv('SHINY_HOST', unset = '0.0.0.0'))",
-				srv.Config.Storage.BundleWorkerPath)},
-		BundlePath:  hostPaths.Unpacked,
-		LibraryPath: hostPaths.Library,
-		LibDir:      libDir,
-		TransferDir: transferDir,
-		TokenDir:    tokDir,
-		WorkerMount: srv.Config.Storage.BundleWorkerPath,
-		ShinyPort:   srv.Config.Docker.ShinyPort,
-		RVersion:    rVersion,
-		MemoryLimit: ptrOr(app.MemoryLimit, ""),
-		CPULimit:    ptrOr(app.CPULimit, 0.0),
-		Labels:      labels,
-		Env:         extraEnv,
-		Runtime:     server.AppRuntime(app, srv.Config.Docker),
-	}
+	spec := server.BaseWorkerSpec(srv, app, wid, *app.ActiveBundle)
+	spec.LibDir = libDir
+	spec.TransferDir = transferDir
+	spec.TokenDir = tokDir
+	spec.MemoryLimit = ptrOr(app.MemoryLimit, "")
+	spec.CPULimit = ptrOr(app.CPULimit, 0.0)
+	spec.Labels = labels
+	spec.Env = extraEnv
 
 	// Resolve per-app data mounts.
 	appMounts, err := srv.DB.ListAppDataMounts(app.ID)

--- a/internal/server/rprofile.go
+++ b/internal/server/rprofile.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+const rProfileContent = `local({
+  host <- Sys.getenv("SHINY_HOST", "127.0.0.1")
+  port <- Sys.getenv("SHINY_PORT", "3838")
+  options(shiny.host = host, shiny.port = as.integer(port))
+})
+`
+
+var (
+	rProfileOnce sync.Once
+	rProfilePath string
+	rProfileErr  error
+)
+
+// EnsureRProfile writes the blockyard R profile to dir and returns
+// the path. The file bridges SHINY_HOST and SHINY_PORT env vars to
+// the corresponding R options so bundles don't have to.
+// Safe to call from multiple goroutines; the file is written once.
+func EnsureRProfile(dir string) (string, error) {
+	rProfileOnce.Do(func() {
+		rProfilePath = filepath.Join(dir, ".blockyard-rprofile.R")
+		rProfileErr = os.WriteFile(rProfilePath, []byte(rProfileContent), 0o644) //nolint:gosec // G306: must be world-readable; workers run as different UIDs
+	})
+	return rProfilePath, rProfileErr
+}

--- a/internal/server/rprofile_test.go
+++ b/internal/server/rprofile_test.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestEnsureRProfile(t *testing.T) {
+	// Reset the sync.Once so this test is self-contained.
+	rProfileOnce = sync.Once{}
+	rProfilePath = ""
+	rProfileErr = nil
+
+	dir := t.TempDir()
+	path, err := EnsureRProfile(dir)
+	if err != nil {
+		t.Fatalf("EnsureRProfile: %v", err)
+	}
+
+	if filepath.Dir(path) != dir {
+		t.Errorf("profile written to %q, expected dir %q", path, dir)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read profile: %v", err)
+	}
+	content := string(data)
+
+	// Must bridge SHINY_HOST and SHINY_PORT to R options.
+	if !strings.Contains(content, "SHINY_HOST") {
+		t.Error("profile does not reference SHINY_HOST")
+	}
+	if !strings.Contains(content, "SHINY_PORT") {
+		t.Error("profile does not reference SHINY_PORT")
+	}
+	if !strings.Contains(content, "shiny.host") {
+		t.Error("profile does not set shiny.host option")
+	}
+	if !strings.Contains(content, "shiny.port") {
+		t.Error("profile does not set shiny.port option")
+	}
+}
+
+func TestEnsureRProfile_Idempotent(t *testing.T) {
+	rProfileOnce = sync.Once{}
+	rProfilePath = ""
+	rProfileErr = nil
+
+	dir := t.TempDir()
+	p1, err1 := EnsureRProfile(dir)
+	if err1 != nil {
+		t.Fatal(err1)
+	}
+
+	// Second call returns the same path without error.
+	p2, err2 := EnsureRProfile(dir)
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+	if p1 != p2 {
+		t.Errorf("second call returned %q, want %q", p2, p1)
+	}
+}

--- a/internal/server/state_test.go
+++ b/internal/server/state_test.go
@@ -525,6 +525,42 @@ func TestWorkerEnv_BoardStorageEmptyURL(t *testing.T) {
 	}
 }
 
+func TestWorkerEnv_ShinyHostDocker(t *testing.T) {
+	srv := &Server{
+		Config: &config.Config{
+			Server: config.ServerConfig{Bind: ":8080", Backend: "docker"},
+		},
+	}
+	env := WorkerEnv(srv)
+	if env["SHINY_HOST"] != "0.0.0.0" {
+		t.Errorf("docker backend: SHINY_HOST = %q, want 0.0.0.0", env["SHINY_HOST"])
+	}
+}
+
+func TestWorkerEnv_ShinyHostProcess(t *testing.T) {
+	srv := &Server{
+		Config: &config.Config{
+			Server: config.ServerConfig{Bind: ":8080", Backend: "process"},
+		},
+	}
+	env := WorkerEnv(srv)
+	if env["SHINY_HOST"] != "127.0.0.1" {
+		t.Errorf("process backend: SHINY_HOST = %q, want 127.0.0.1", env["SHINY_HOST"])
+	}
+}
+
+func TestWorkerEnv_ShinyHostDefault(t *testing.T) {
+	srv := &Server{
+		Config: &config.Config{
+			Server: config.ServerConfig{Bind: ":8080"},
+		},
+	}
+	env := WorkerEnv(srv)
+	if env["SHINY_HOST"] != "0.0.0.0" {
+		t.Errorf("default backend: SHINY_HOST = %q, want 0.0.0.0", env["SHINY_HOST"])
+	}
+}
+
 func TestMarkDraining(t *testing.T) {
 	m := NewMemoryWorkerMap()
 	m.Set("w1", ActiveWorker{AppID: "app-a"})

--- a/internal/server/transfer.go
+++ b/internal/server/transfer.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/cynkra/blockyard/internal/backend"
 	"github.com/cynkra/blockyard/internal/db"
-	"github.com/cynkra/blockyard/internal/manifest"
 	"github.com/cynkra/blockyard/internal/mount"
 	"github.com/cynkra/blockyard/internal/pkgstore"
 )
@@ -235,38 +234,12 @@ func (srv *Server) buildTransferWorkerSpec(
 func (srv *Server) defaultWorkerSpec(
 	app *db.AppRow, workerID, libDir, bundleID string,
 ) backend.WorkerSpec {
-	hostPaths := srv.BundlePaths(app.ID, bundleID)
 	transferDir := filepath.Join(srv.Config.Storage.BundleServerPath, ".transfers", workerID)
 	_ = os.MkdirAll(transferDir, 0o755) //nolint:gosec // G301: transfer dir, not secrets
 
-	var rVersion string
-	if m, err := manifest.Read(filepath.Join(hostPaths.Unpacked, "manifest.json")); err == nil {
-		rVersion = m.RVersion
-	}
-
-	spec := backend.WorkerSpec{
-		AppID:    app.ID,
-		WorkerID: workerID,
-		Image:    AppImage(app, srv.Config.Docker.Image),
-		Cmd: []string{"R", "-e",
-			fmt.Sprintf("shiny::runApp('%s', port = as.integer(Sys.getenv('SHINY_PORT')), host = Sys.getenv('SHINY_HOST', unset = '0.0.0.0'))",
-				srv.Config.Storage.BundleWorkerPath)},
-		BundlePath:  hostPaths.Unpacked,
-		LibraryPath: hostPaths.Library,
-		LibDir:      libDir,
-		TransferDir: transferDir,
-		WorkerMount: srv.Config.Storage.BundleWorkerPath,
-		ShinyPort:   srv.Config.Docker.ShinyPort,
-		RVersion:    rVersion,
-		Labels: map[string]string{
-			"dev.blockyard/managed":   "true",
-			"dev.blockyard/app-id":    app.ID,
-			"dev.blockyard/worker-id": workerID,
-			"dev.blockyard/role":      "worker",
-		},
-		Env:     WorkerEnv(srv),
-		Runtime: AppRuntime(app, srv.Config.Docker),
-	}
+	spec := BaseWorkerSpec(srv, app, workerID, bundleID)
+	spec.LibDir = libDir
+	spec.TransferDir = transferDir
 
 	// Resolve per-app data mounts.
 	if srv.DB != nil {

--- a/internal/server/workerenv.go
+++ b/internal/server/workerenv.go
@@ -2,14 +2,26 @@ package server
 
 import (
 	"encoding/json"
+	"path/filepath"
+
+	"github.com/cynkra/blockyard/internal/backend"
+	"github.com/cynkra/blockyard/internal/db"
+	"github.com/cynkra/blockyard/internal/manifest"
 )
 
 // WorkerEnv builds the environment variable map for worker containers.
 // Always sets BLOCKYARD_API_URL (needed for runtime package installs).
 // Includes Vault/OpenBao integration vars when configured.
+// Sets SHINY_HOST per backend so bundles don't have to.
 func WorkerEnv(srv *Server) map[string]string {
+	shinyHost := "0.0.0.0"
+	if srv.Config.Server.Backend == "process" {
+		shinyHost = "127.0.0.1"
+	}
+
 	env := map[string]string{
 		"BLOCKYARD_API_URL": srv.InternalAPIURL(),
+		"SHINY_HOST":        shinyHost,
 	}
 
 	if srv.Config.Openbao != nil {
@@ -30,4 +42,39 @@ func WorkerEnv(srv *Server) map[string]string {
 	}
 
 	return env
+}
+
+// BaseWorkerSpec returns a WorkerSpec with all fields that are common
+// across spawn sites (coldstart, transfer, API scale-up). Callers
+// fill in site-specific fields like LibDir, TransferDir, TokenDir,
+// MemoryLimit, and CPULimit.
+func BaseWorkerSpec(srv *Server, app *db.AppRow, workerID, bundleID string) backend.WorkerSpec {
+	hostPaths := srv.BundlePaths(app.ID, bundleID)
+	rProfile, _ := EnsureRProfile(srv.Config.Storage.BundleServerPath)
+
+	var rVersion string
+	if m, err := manifest.Read(filepath.Join(hostPaths.Unpacked, "manifest.json")); err == nil {
+		rVersion = m.RVersion
+	}
+
+	return backend.WorkerSpec{
+		AppID:        app.ID,
+		WorkerID:     workerID,
+		Image:        AppImage(app, srv.Config.Docker.Image),
+		Cmd:          []string{"Rscript", filepath.Join(srv.Config.Storage.BundleWorkerPath, "app.R")},
+		BundlePath:   hostPaths.Unpacked,
+		LibraryPath:  hostPaths.Library,
+		WorkerMount:  srv.Config.Storage.BundleWorkerPath,
+		ShinyPort:    srv.Config.Docker.ShinyPort,
+		RVersion:     rVersion,
+		RProfilePath: rProfile,
+		Labels: map[string]string{
+			"dev.blockyard/managed":   "true",
+			"dev.blockyard/app-id":    app.ID,
+			"dev.blockyard/worker-id": workerID,
+			"dev.blockyard/role":      "worker",
+		},
+		Env:     WorkerEnv(srv),
+		Runtime: AppRuntime(app, srv.Config.Docker),
+	}
 }

--- a/internal/ui/upload.go
+++ b/internal/ui/upload.go
@@ -277,7 +277,7 @@ func (ui *UI) createApp(srv *server.Server) http.HandlerFunc {
 
 		if err := bundle.ValidateEntrypoint(paths); err != nil {
 			cleanup()
-			renderUploadError(w, "Missing entrypoint: the upload must contain app.R or server.R.")
+			renderUploadError(w, "Missing entrypoint: the upload must contain app.R.")
 			return
 		}
 

--- a/internal/ui/upload_test.go
+++ b/internal/ui/upload_test.go
@@ -270,7 +270,7 @@ func TestCreateAppUploadMissingEntrypoint(t *testing.T) {
 	defer resp.Body.Close()
 
 	respBody := readBody(t, resp)
-	if !strings.Contains(respBody, "app.R or server.R") {
+	if !strings.Contains(respBody, "app.R") {
 		t.Errorf("expected entrypoint error, got: %s", respBody)
 	}
 


### PR DESCRIPTION
Closes #187

## Summary
- Replace `R -e "shiny::runApp(...)"` with `Rscript app.R` — bundles are self-contained scripts, blockyard just runs them
- Inject `shiny.host` and `shiny.port` via `R_PROFILE_USER` that bridges `SHINY_HOST`/`SHINY_PORT` env vars to R options, so bundles don't carry deployment wiring
- Set `SHINY_HOST` per backend: `0.0.0.0` for Docker (bridge network), `127.0.0.1` for process (shared host namespace)
- Drop `server.R` support — `app.R` is the only entrypoint
- Clean up example bundles (remove `host`/`port` workarounds)