### PR TITLE
Support multiple R versions per server via rig

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,11 +1,15 @@
 #!/bin/sh
 # Entrypoint shim for the blockyard server-process and
-# server-everything images. Runs the operator's extras hook
-# (default /etc/blockyard/extras.sh is a no-op baked into the
-# image; override by bind-mounting) and then execs the command
-# passed in by the Dockerfile's ENTRYPOINT array.
+# server-everything images. Runs the R version policy script
+# and the operator's extras hook, then execs the server.
 #
-# `set -e` propagates extras failures as container startup errors
+# Hook order:
+#   1. r-versions.sh — R version installation and default
+#      (baked-in policy; override by bind-mounting)
+#   2. extras.sh     — system libraries, credentials, etc.
+#      (no-op by default; override by bind-mounting)
+#
+# `set -e` propagates hook failures as container startup errors
 # — a typo in an apt package name or a missing rig version aborts
 # the start cleanly instead of silently producing a running server
 # that fails at first dyn.load or first bwrap spawn.
@@ -16,6 +20,7 @@
 # continues to work unchanged.
 set -eu
 
+/etc/blockyard/r-versions.sh
 /etc/blockyard/extras.sh
 
 exec "$@"

--- a/docker/extras.sh
+++ b/docker/extras.sh
@@ -6,9 +6,11 @@
 # as root before the blockyard server starts and can:
 #
 #   - install additional system libraries via apt-get
-#   - pin or add R versions via rig (e.g. `rig add 4.4.3`)
 #   - add custom apt sources and GPG keys
 #   - drop .netrc / credentials files into /root
+#
+# To change the set of installed R versions, override
+# /etc/blockyard/r-versions.sh instead of this file.
 #
 # Failures propagate via `set -e` in the entrypoint shim, so a
 # non-zero exit here aborts container startup with a clear error

--- a/docker/r-versions.sh
+++ b/docker/r-versions.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Default R version policy for the blockyard process backend.
+#
+# Installs the latest patch of the current and previous 4 minor
+# releases via rig. The default is set to the previous minor (not
+# the bleeding-edge release) for stability — most bundles target
+# the prior release.
+#
+# This script runs at both image build time and container start.
+# rig skips versions that are already installed, so the startup
+# run is effectively a no-op for the default image. Operators
+# override the entire policy by bind-mounting their own script to
+# /etc/blockyard/r-versions.sh.
+#
+# Example operator override (pin to a single version):
+#
+#   #!/bin/sh
+#   rig add 4.4.3
+#   rig default 4.4.3
+#
+set -eu
+
+# Install the current release.
+rig add release
+
+# Derive the current minor version from what rig installed.
+LATEST=$(ls /opt/R | sort -V | tail -1)
+MAJOR=${LATEST%%.*}
+MINOR=${LATEST#*.}; MINOR=${MINOR%%.*}
+
+# Install previous 4 minor releases.
+for i in 1 2 3 4; do
+  m=$((MINOR - i))
+  [ "$m" -ge 0 ] && rig add "${MAJOR}.${m}" || true
+done
+
+# Default to the previous minor for stability.
+PREV=$(ls /opt/R | sort -V | tail -2 | head -1)
+if [ -n "$PREV" ]; then
+  rig default "$PREV"
+fi

--- a/docker/server-process.Dockerfile
+++ b/docker/server-process.Dockerfile
@@ -10,9 +10,9 @@
 # image ships only runtime shared libraries; operators who need
 # source builds or extra packages install them via the extras.sh
 # hook (see the bottom of this file). R itself is managed by rig
-# (r-lib/rig); the R_VERSION build ARG controls which version is
-# baked in (default: "release"). Operators can also swap versions
-# at runtime via `rig add 4.5` in an extras.sh override.
+# (r-lib/rig); the R_VERSIONS build ARG controls which versions
+# are baked in (default: "release"). Operators can also add
+# versions at runtime via `rig add 4.5` in an extras.sh override.
 
 FROM hugomods/hugo:exts-0.147.4 AS docs
 WORKDIR /docs
@@ -65,8 +65,8 @@ RUN CGO_ENABLED=0 go build ${COVER:+-cover} \
     -o /blockyard ./cmd/blockyard
 RUN CGO_ENABLED=0 go build ${COVER:+-cover} -o /by-builder ./cmd/by-builder
 
-# Final stage: ubuntu:24.04 + rig + R release. See the header
-# comment for the rationale and issue #185 for the full discussion.
+# Final stage: ubuntu:24.04 + rig + R. See the header comment for
+# the rationale and issue #185 for the full discussion.
 FROM ubuntu:24.04
 
 # rig version pin. rig is the R installation manager from r-lib;
@@ -75,10 +75,11 @@ FROM ubuntu:24.04
 # versions at runtime via the extras.sh hook without rebuilding
 # this image.
 ARG RIG_VERSION=0.7.1
-# R version to install via rig. Defaults to "release" (latest
-# stable); pin to a specific version (e.g. "4.4.3") for
-# reproducible builds.
-ARG R_VERSION=release
+# Space-separated list of R versions to install via rig. The first
+# entry becomes the default. Use full version pins (e.g. "4.5.0")
+# for reproducible builds, or "release" for the latest stable.
+# Example: R_VERSIONS="4.5.0 4.4.3 4.3.2"
+ARG R_VERSIONS="release"
 # Docker buildx sets TARGETARCH automatically for multi-platform
 # builds. Default to amd64 for local single-arch `docker build`
 # invocations so rig downloads the correct tarball.
@@ -117,7 +118,7 @@ RUN apt-get update \
        esac \
     && curl -fsSL "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}" \
         | tar xz -C /usr/local \
-    && rig add "${R_VERSION}" \
+    && for v in ${R_VERSIONS}; do rig add "$v"; done \
     && ln -sf /usr/local/bin/R /usr/bin/R \
     && ln -sf /usr/local/bin/Rscript /usr/bin/Rscript \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/server-process.Dockerfile
+++ b/docker/server-process.Dockerfile
@@ -113,17 +113,17 @@ RUN apt-get update \
        esac \
     && curl -fsSL "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}" \
         | tar xz -C /usr/local \
-    && rig add release \
-    && LATEST=$(ls /opt/R | sort -V | tail -1) \
-    && MAJOR=${LATEST%%.*} \
-    && MINOR=${LATEST#*.} && MINOR=${MINOR%%.*} \
-    && for i in 1 2 3 4; do \
-         m=$((MINOR - i)); \
-         [ "$m" -ge 0 ] && rig add "${MAJOR}.${m}" || true; \
-       done \
-    && ln -sf /usr/local/bin/R /usr/bin/R \
-    && ln -sf /usr/local/bin/Rscript /usr/bin/Rscript \
     && rm -rf /var/lib/apt/lists/*
+
+# R version policy script. Installs the default set of R versions
+# and sets the rig default. Runs at both build time (to bake
+# versions into the image) and container start (so an operator-
+# provided override takes effect). Override by bind-mounting to
+# /etc/blockyard/r-versions.sh.
+COPY docker/r-versions.sh /etc/blockyard/r-versions.sh
+RUN /etc/blockyard/r-versions.sh \
+    && ln -sf /usr/local/bin/R /usr/bin/R \
+    && ln -sf /usr/local/bin/Rscript /usr/bin/Rscript
 
 COPY --from=builder /blockyard /usr/local/bin/blockyard
 COPY --from=builder /by-builder /usr/local/lib/blockyard/by-builder
@@ -138,13 +138,11 @@ COPY internal/seccomp/blockyard-outer.json /etc/blockyard/seccomp.json
 
 # Extras hook. The default is a no-op; operators override by
 # bind-mounting their own script to /etc/blockyard/extras.sh to
-# install additional system libraries, pin a specific R version
-# via rig, or drop credential files. Runs as root before the
-# blockyard server starts; failures propagate (set -e in the
-# entrypoint) and abort startup with a clear error.
+# install additional system libraries or drop credential files.
+# Runs as root before the blockyard server starts; failures
+# propagate (set -e in the entrypoint) and abort startup.
 #
-# See docs/content/docs/guides/process-backend-container.md for
-# the full contract and mount patterns.
+# For R version policy, override r-versions.sh instead.
 COPY docker/extras.sh /etc/blockyard/extras.sh
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 

--- a/docker/server-process.Dockerfile
+++ b/docker/server-process.Dockerfile
@@ -10,9 +10,10 @@
 # image ships only runtime shared libraries; operators who need
 # source builds or extra packages install them via the extras.sh
 # hook (see the bottom of this file). R itself is managed by rig
-# (r-lib/rig); the R_VERSIONS build ARG controls which versions
-# are baked in (default: "release"). Operators can also add
-# versions at runtime via `rig add 4.5` in an extras.sh override.
+# (r-lib/rig); the image ships the latest patch of the current and
+# previous 4 minor releases (e.g. 4.5.x through 4.1.x). Weekly
+# rebuilds via the Publish workflow keep the set current. Operators
+# can add or remove versions at runtime via the extras.sh hook.
 
 FROM hugomods/hugo:exts-0.147.4 AS docs
 WORKDIR /docs
@@ -71,15 +72,9 @@ FROM ubuntu:24.04
 
 # rig version pin. rig is the R installation manager from r-lib;
 # it downloads official R binaries and manages multiple installed
-# R versions via shims under /usr/local/bin. Operators can swap R
-# versions at runtime via the extras.sh hook without rebuilding
-# this image.
+# R versions via shims under /usr/local/bin. Operators can add or
+# remove versions at runtime via the extras.sh hook.
 ARG RIG_VERSION=0.7.1
-# Space-separated list of R versions to install via rig. The first
-# entry becomes the default. Use full version pins (e.g. "4.5.0")
-# for reproducible builds, or "release" for the latest stable.
-# Example: R_VERSIONS="4.5.0 4.4.3 4.3.2"
-ARG R_VERSIONS="release"
 # Docker buildx sets TARGETARCH automatically for multi-platform
 # builds. Default to amd64 for local single-arch `docker build`
 # invocations so rig downloads the correct tarball.
@@ -118,7 +113,14 @@ RUN apt-get update \
        esac \
     && curl -fsSL "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}" \
         | tar xz -C /usr/local \
-    && for v in ${R_VERSIONS}; do rig add "$v"; done \
+    && rig add release \
+    && LATEST=$(ls /opt/R | sort -V | tail -1) \
+    && MAJOR=${LATEST%%.*} \
+    && MINOR=${LATEST#*.} && MINOR=${MINOR%%.*} \
+    && for i in 1 2 3 4; do \
+         m=$((MINOR - i)); \
+         [ "$m" -ge 0 ] && rig add "${MAJOR}.${m}" || true; \
+       done \
     && ln -sf /usr/local/bin/R /usr/bin/R \
     && ln -sf /usr/local/bin/Rscript /usr/bin/Rscript \
     && rm -rf /var/lib/apt/lists/*

--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -21,6 +22,7 @@ import (
 	"github.com/cynkra/blockyard/internal/backend"
 	"github.com/cynkra/blockyard/internal/bundle"
 	"github.com/cynkra/blockyard/internal/db"
+	"github.com/cynkra/blockyard/internal/manifest"
 	"github.com/cynkra/blockyard/internal/mount"
 	"github.com/cynkra/blockyard/internal/ops"
 	"github.com/cynkra/blockyard/internal/server"
@@ -894,6 +896,11 @@ func StartApp(srv *server.Server) http.HandlerFunc {
 			"dev.blockyard/role":      "worker",
 		}
 
+		var rVersion string
+		if m, err := manifest.Read(filepath.Join(hostPaths.Unpacked, "manifest.json")); err == nil {
+			rVersion = m.RVersion
+		}
+
 		spec := backend.WorkerSpec{
 			AppID:       app.ID,
 			WorkerID:    workerID,
@@ -905,6 +912,7 @@ func StartApp(srv *server.Server) http.HandlerFunc {
 			LibraryPath: hostPaths.Library,
 			WorkerMount: srv.Config.Storage.BundleWorkerPath,
 			ShinyPort:   srv.Config.Docker.ShinyPort,
+			RVersion:    rVersion,
 			MemoryLimit: stringOrEmpty(app.MemoryLimit),
 			CPULimit:    floatOrZero(app.CPULimit),
 			Labels:      labels,

--- a/internal/api/bundles.go
+++ b/internal/api/bundles.go
@@ -89,12 +89,28 @@ func UploadBundle(srv *server.Server) http.HandlerFunc {
 			return
 		}
 
-		// Insert bundle row (status = pending)
-		// Determine if bundle has pinned dependencies by checking the manifest.
+		// Determine if bundle has pinned dependencies and extract the
+		// pinned R version for validation.
 		bundlePinned := false
+		var rVersion string
 		manifestPath := filepath.Join(paths.Unpacked, "manifest.json")
 		if m, mErr := manifest.Read(manifestPath); mErr == nil {
 			bundlePinned = m.IsPinned()
+			rVersion = m.RVersion
+		} else {
+			// No manifest.json yet — check renv.lock directly.
+			rVersion = manifest.RVersionFromRenvLock(
+				filepath.Join(paths.Unpacked, "renv.lock"))
+		}
+
+		// Reject early if the bundle pins an R version this backend
+		// cannot serve.
+		if rVersion != "" {
+			if err := srv.Backend.CheckRVersion(rVersion); err != nil {
+				bundle.DeleteFiles(paths)
+				badRequest(w, err.Error())
+				return
+			}
 		}
 		deployedBy := ""
 		if caller != nil {

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -85,6 +85,7 @@ type WorkerSpec struct {
 	TokenDir    string            // server-side path to worker token dir; mounted ro at /var/run/blockyard
 	WorkerMount string            // in-container mount point (BundleWorkerPath)
 	ShinyPort   int
+	RVersion    string            // pinned R version from bundle manifest (e.g. "4.5.0"); empty = default
 	MemoryLimit string            // e.g. "512m", "" if unset
 	CPULimit    float64           // fractional vCPUs, 0 if unset
 	Labels      map[string]string
@@ -102,6 +103,7 @@ type BuildSpec struct {
 	Cmd      []string        // container command (e.g. R script invocation)
 	Mounts   []MountEntry    // bind/volume mounts for the build container
 	Env      []string        // environment variables (KEY=VALUE)
+	RVersion string          // pinned R version from bundle manifest; empty = default
 }
 
 // MountEntry describes a single bind/volume mount for a build container.

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -58,6 +58,14 @@ type Backend interface {
 	// main.go calls this through the interface so it does not have to
 	// branch on the backend type.
 	Preflight(ctx context.Context) (*preflight.Report, error)
+
+	// CheckRVersion validates that the given R version can be served
+	// by this backend. The process backend checks rig-managed
+	// installations; the Docker backend returns nil (the image tag
+	// determines the R version). Returns a user-facing error message
+	// listing available versions when the requested version is not
+	// installed.
+	CheckRVersion(version string) error
 }
 
 // ErrNotSupported is returned by backend methods that are not

--- a/internal/backend/docker/pak_integration_test.go
+++ b/internal/backend/docker/pak_integration_test.go
@@ -133,7 +133,7 @@ func TestFullPipeline_RestoreAndSpawnWorker(t *testing.T) {
 
 	// Write a minimal manifest with P3M repos for binary packages, and
 	// overwrite the DESCRIPTION to only import 'mime' (pure R, no compilation).
-	manifestData := `{"version":1,"platform":"4.4.3","metadata":{"appmode":"shiny","entrypoint":"app.R"},"repositories":[{"Name":"CRAN","URL":"https://p3m.dev/cran/latest"}],"description":{"Imports":"mime"},"files":{"app.R":{"checksum":"abc"}}}`
+	manifestData := `{"version":1,"r_version":"4.4.3","metadata":{"appmode":"shiny","entrypoint":"app.R"},"repositories":[{"Name":"CRAN","URL":"https://p3m.dev/cran/latest"}],"description":{"Imports":"mime"},"files":{"app.R":{"checksum":"abc"}}}`
 	if err := os.WriteFile(filepath.Join(paths.Unpacked, "manifest.json"), []byte(manifestData), 0o644); err != nil {
 		t.Fatalf("write manifest.json: %v", err)
 	}

--- a/internal/backend/docker/preflight.go
+++ b/internal/backend/docker/preflight.go
@@ -31,14 +31,13 @@ type PreflightDeps struct {
 	Version    string
 }
 
+// CheckRVersion returns nil — the Docker backend selects R via image tag.
+func (d *DockerBackend) CheckRVersion(_ string) error { return nil }
+
 // Preflight implements backend.Backend. It runs all docker-specific
 // preflight checks and returns a populated *preflight.Report. The full
 // list of checks lives in this file as runDockerChecks; this method is
 // the entry point that main.go calls through the Backend interface.
-// CheckRVersion always returns nil for the Docker backend — the
-// image tag determines the R version.
-func (d *DockerBackend) CheckRVersion(_ string) error { return nil }
-
 func (d *DockerBackend) Preflight(ctx context.Context) (*preflight.Report, error) {
 	storePath := filepath.Join(d.bundleServerPath, ".pkg-store")
 	builderBin, builderErr := buildercache.EnsureCached(

--- a/internal/backend/docker/preflight.go
+++ b/internal/backend/docker/preflight.go
@@ -35,8 +35,8 @@ type PreflightDeps struct {
 // preflight checks and returns a populated *preflight.Report. The full
 // list of checks lives in this file as runDockerChecks; this method is
 // the entry point that main.go calls through the Backend interface.
-// CheckRVersion is a no-op for the Docker backend — the image tag
-// determines the R version.
+// CheckRVersion always returns nil for the Docker backend — the
+// image tag determines the R version.
 func (d *DockerBackend) CheckRVersion(_ string) error { return nil }
 
 func (d *DockerBackend) Preflight(ctx context.Context) (*preflight.Report, error) {

--- a/internal/backend/docker/preflight.go
+++ b/internal/backend/docker/preflight.go
@@ -35,6 +35,10 @@ type PreflightDeps struct {
 // preflight checks and returns a populated *preflight.Report. The full
 // list of checks lives in this file as runDockerChecks; this method is
 // the entry point that main.go calls through the Backend interface.
+// CheckRVersion is a no-op for the Docker backend — the image tag
+// determines the R version.
+func (d *DockerBackend) CheckRVersion(_ string) error { return nil }
+
 func (d *DockerBackend) Preflight(ctx context.Context) (*preflight.Report, error) {
 	storePath := filepath.Join(d.bundleServerPath, ".pkg-store")
 	builderBin, builderErr := buildercache.EnsureCached(

--- a/internal/backend/mock/mock.go
+++ b/internal/backend/mock/mock.go
@@ -214,6 +214,8 @@ func (b *MockBackend) Preflight(_ context.Context) (*preflight.Report, error) {
 	return &preflight.Report{RanAt: time.Now().UTC()}, nil
 }
 
+func (b *MockBackend) CheckRVersion(_ string) error { return nil }
+
 func (b *MockBackend) UpdateResources(_ context.Context, id string, mem int64, nanoCPUs int64) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/backend/process/preflight.go
+++ b/internal/backend/process/preflight.go
@@ -28,6 +28,7 @@ func RunPreflight(cfg *config.ProcessConfig, fullCfg *config.Config) *preflight.
 	r := &preflight.Report{RanAt: time.Now().UTC()}
 	r.Add(checkBwrap(cfg))
 	r.Add(checkRBinary(cfg))
+	r.Add(checkRigVersions())
 	r.Add(checkUserNamespaces())
 	r.Add(checkPortRange(cfg))
 	r.Add(checkResourceLimits(&fullCfg.Server))
@@ -134,6 +135,24 @@ func checkRBinary(cfg *config.ProcessConfig) preflight.Result {
 		Name:     "r_binary",
 		Severity: preflight.SeverityOK,
 		Message:  "R binary found",
+		Category: "process",
+	}
+}
+
+func checkRigVersions() preflight.Result {
+	versions := InstalledRVersions()
+	if len(versions) == 0 {
+		return preflight.Result{
+			Name:     "rig_versions",
+			Severity: preflight.SeverityInfo,
+			Message:  "no rig-managed R versions found in /opt/R",
+			Category: "process",
+		}
+	}
+	return preflight.Result{
+		Name:     "rig_versions",
+		Severity: preflight.SeverityOK,
+		Message:  fmt.Sprintf("rig-managed R versions: %s", strings.Join(versions, ", ")),
 		Category: "process",
 	}
 }

--- a/internal/backend/process/process.go
+++ b/internal/backend/process/process.go
@@ -159,6 +159,25 @@ func (b *ProcessBackend) Preflight(_ context.Context) (*preflight.Report, error)
 	return RunPreflight(b.cfg, b.fullCfg), nil
 }
 
+func (b *ProcessBackend) CheckRVersion(version string) error {
+	if version == "" {
+		return nil
+	}
+	_, fell := ResolveRBinary(version, "")
+	if !fell {
+		return nil
+	}
+	installed := InstalledRVersions()
+	if len(installed) == 0 {
+		return fmt.Errorf(
+			"bundle requires R %s but no rig-managed R versions are installed",
+			version)
+	}
+	return fmt.Errorf(
+		"bundle requires R %s which is not installed; available versions: %s",
+		version, strings.Join(installed, ", "))
+}
+
 // CleanupOrphanResources implements backend.Backend. Workers from a
 // previous run are already dead (Pdeathsig killed them with the
 // server), so the in-memory variants have nothing to clean up. The
@@ -188,21 +207,19 @@ func (b *ProcessBackend) Spawn(_ context.Context, spec backend.WorkerSpec) error
 	// the value is set — emitting it here would fire on every spawn
 	// for every app for the lifetime of the deployment.
 
-	// Resolve R version from the bundle manifest. When a specific
-	// version is requested and installed via rig, the worker runs
-	// against that binary. Otherwise fall back to the configured
-	// default (cfg.RPath / the rig shim).
+	// Resolve R version from the bundle manifest. Deploy-time
+	// validation (CheckRVersion) ensures the version is installed,
+	// so a miss here means the operator removed it after deploy.
 	if spec.RVersion != "" && len(spec.Cmd) > 0 && spec.Cmd[0] == "R" {
 		rPath, fell := ResolveRBinary(spec.RVersion, b.cfg.RPath)
 		if fell {
-			slog.Warn("requested R version not installed, using default",
-				"worker_id", spec.WorkerID, "requested", spec.RVersion,
-				"fallback", rPath)
-		} else {
-			slog.Info("resolved R version",
-				"worker_id", spec.WorkerID, "version", spec.RVersion,
-				"path", rPath)
+			return fmt.Errorf(
+				"R %s was available at deploy time but is no longer installed",
+				spec.RVersion)
 		}
+		slog.Info("resolved R version",
+			"worker_id", spec.WorkerID, "version", spec.RVersion,
+			"path", rPath)
 		cmd := make([]string, len(spec.Cmd))
 		copy(cmd, spec.Cmd)
 		cmd[0] = rPath
@@ -491,9 +508,13 @@ func (b *ProcessBackend) Build(ctx context.Context, spec backend.BuildSpec) (bac
 	if spec.RVersion != "" && len(spec.Cmd) > 0 && spec.Cmd[0] == "R" {
 		rPath, fell := ResolveRBinary(spec.RVersion, b.cfg.RPath)
 		if fell {
-			slog.Warn("requested R version not installed for build, using default",
-				"app_id", spec.AppID, "bundle_id", spec.BundleID,
-				"requested", spec.RVersion, "fallback", rPath)
+			return backend.BuildResult{
+				Success:  false,
+				ExitCode: 1,
+				Logs: fmt.Sprintf(
+					"R %s was available at deploy time but is no longer installed",
+					spec.RVersion),
+			}, nil
 		}
 		cmd := make([]string, len(spec.Cmd))
 		copy(cmd, spec.Cmd)

--- a/internal/backend/process/process.go
+++ b/internal/backend/process/process.go
@@ -188,6 +188,27 @@ func (b *ProcessBackend) Spawn(_ context.Context, spec backend.WorkerSpec) error
 	// the value is set — emitting it here would fire on every spawn
 	// for every app for the lifetime of the deployment.
 
+	// Resolve R version from the bundle manifest. When a specific
+	// version is requested and installed via rig, the worker runs
+	// against that binary. Otherwise fall back to the configured
+	// default (cfg.RPath / the rig shim).
+	if spec.RVersion != "" && len(spec.Cmd) > 0 && spec.Cmd[0] == "R" {
+		rPath, fell := ResolveRBinary(spec.RVersion, b.cfg.RPath)
+		if fell {
+			slog.Warn("requested R version not installed, using default",
+				"worker_id", spec.WorkerID, "requested", spec.RVersion,
+				"fallback", rPath)
+		} else {
+			slog.Info("resolved R version",
+				"worker_id", spec.WorkerID, "version", spec.RVersion,
+				"path", rPath)
+		}
+		cmd := make([]string, len(spec.Cmd))
+		copy(cmd, spec.Cmd)
+		cmd[0] = rPath
+		spec.Cmd = cmd
+	}
+
 	// If an entry for this worker ID already exists, refuse to spawn
 	// over a live one. An entry that has already exited (its done
 	// channel is closed and slots have been released) is cleared so
@@ -466,6 +487,20 @@ func (b *ProcessBackend) Addr(_ context.Context, id string) (string, error) {
 }
 
 func (b *ProcessBackend) Build(ctx context.Context, spec backend.BuildSpec) (backend.BuildResult, error) {
+	// Resolve R version so the build uses the same R the worker will.
+	if spec.RVersion != "" && len(spec.Cmd) > 0 && spec.Cmd[0] == "R" {
+		rPath, fell := ResolveRBinary(spec.RVersion, b.cfg.RPath)
+		if fell {
+			slog.Warn("requested R version not installed for build, using default",
+				"app_id", spec.AppID, "bundle_id", spec.BundleID,
+				"requested", spec.RVersion, "fallback", rPath)
+		}
+		cmd := make([]string, len(spec.Cmd))
+		copy(cmd, spec.Cmd)
+		cmd[0] = rPath
+		spec.Cmd = cmd
+	}
+
 	// Builds run under the same UID pool as workers — they're sandboxed
 	// R processes that share the worker firewall rules.
 	uid, err := b.uids.Alloc()

--- a/internal/backend/process/process.go
+++ b/internal/backend/process/process.go
@@ -214,7 +214,7 @@ func (b *ProcessBackend) Spawn(_ context.Context, spec backend.WorkerSpec) error
 		rPath, fell := ResolveRBinary(spec.RVersion, b.cfg.RPath)
 		if fell {
 			return fmt.Errorf(
-				"R %s was available at deploy time but is no longer installed",
+				"r %s was available at deploy time but is no longer installed",
 				spec.RVersion)
 		}
 		slog.Info("resolved R version",

--- a/internal/backend/process/process.go
+++ b/internal/backend/process/process.go
@@ -163,19 +163,27 @@ func (b *ProcessBackend) CheckRVersion(version string) error {
 	if version == "" {
 		return nil
 	}
+	// ResolveRBinary accepts any patch within the same minor (e.g.
+	// bundle pins 4.4.2 but 4.4.3 is installed → OK). A miss means
+	// no matching major.minor is available at all.
 	_, fell := ResolveRBinary(version, "")
 	if !fell {
 		return nil
 	}
+	parts := strings.SplitN(version, ".", 3)
+	minor := version
+	if len(parts) >= 2 {
+		minor = parts[0] + "." + parts[1]
+	}
 	installed := InstalledRVersions()
 	if len(installed) == 0 {
 		return fmt.Errorf(
-			"bundle requires R %s but no rig-managed R versions are installed",
-			version)
+			"bundle requires R %s but no R versions are installed",
+			minor)
 	}
 	return fmt.Errorf(
-		"bundle requires R %s which is not installed; available versions: %s",
-		version, strings.Join(installed, ", "))
+		"bundle requires R %s which is not installed; available: %s",
+		minor, strings.Join(installed, ", "))
 }
 
 // CleanupOrphanResources implements backend.Backend. Workers from a

--- a/internal/backend/process/rversion.go
+++ b/internal/backend/process/rversion.go
@@ -1,0 +1,75 @@
+package process
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// rigBase is the directory where rig installs R versions.
+// Tests override this via setRigBase.
+var rigBase = "/opt/R" //nolint:gochecknoglobals // test seam
+
+func setRigBase(path string) { rigBase = path }
+
+// ResolveRBinary maps a requested R version (e.g. "4.5.0") to the
+// full path of a rig-managed R binary. Resolution order:
+//
+//  1. Exact match: /opt/R/<version>/bin/R
+//  2. Minor match: highest /opt/R/<major>.<minor>.*/bin/R
+//  3. Fallback: the configured default R path
+//
+// Returns the resolved path and whether the fallback was used. When
+// version is empty the fallback is returned directly (not considered
+// a miss).
+func ResolveRBinary(version, fallback string) (string, bool) {
+	if version == "" {
+		return fallback, false
+	}
+
+	// 1. Exact match.
+	path := filepath.Join(rigBase, version, "bin", "R")
+	if _, err := os.Stat(path); err == nil {
+		return path, false
+	}
+
+	// 2. Minor match — if version is X.Y.Z, glob X.Y.* and pick
+	// the highest patch release.
+	parts := strings.SplitN(version, ".", 3)
+	if len(parts) >= 2 {
+		prefix := parts[0] + "." + parts[1]
+
+		pattern := filepath.Join(rigBase, prefix+".*", "bin", "R")
+		if matches, _ := filepath.Glob(pattern); len(matches) > 0 {
+			sort.Strings(matches)
+			return matches[len(matches)-1], false
+		}
+
+		// Try bare major.minor (e.g. /opt/R/4.5/bin/R).
+		path = filepath.Join(rigBase, prefix, "bin", "R")
+		if _, err := os.Stat(path); err == nil {
+			return path, false
+		}
+	}
+
+	// 3. Fallback.
+	return fallback, true
+}
+
+// InstalledRVersions returns the R versions installed under rigBase.
+// Each entry is the directory name (e.g. "4.5.0", "4.4.3").
+func InstalledRVersions() []string {
+	matches, err := filepath.Glob(filepath.Join(rigBase, "*", "bin", "R"))
+	if err != nil || len(matches) == 0 {
+		return nil
+	}
+	versions := make([]string, 0, len(matches))
+	for _, m := range matches {
+		// /opt/R/<version>/bin/R → extract <version>
+		dir := filepath.Dir(filepath.Dir(m))
+		versions = append(versions, filepath.Base(dir))
+	}
+	sort.Strings(versions)
+	return versions
+}

--- a/internal/backend/process/rversion_test.go
+++ b/internal/backend/process/rversion_test.go
@@ -1,0 +1,131 @@
+package process
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// setupRigFixture creates a fake /opt/R/<version>/bin/R tree under
+// dir and temporarily overrides rigBase so ResolveRBinary and
+// InstalledRVersions operate against the fixture.
+func setupRigFixture(t *testing.T, versions ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, v := range versions {
+		binDir := filepath.Join(dir, v, "bin")
+		if err := os.MkdirAll(binDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(binDir, "R"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestResolveRBinary_ExactMatch(t *testing.T) {
+	dir := setupRigFixture(t, "4.5.0", "4.4.3")
+	// Patch rigBase for this test.
+	orig := rigBase
+	defer func() { setRigBase(orig) }()
+	setRigBase(dir)
+
+	path, fell := ResolveRBinary("4.5.0", "/usr/bin/R")
+	if fell {
+		t.Error("expected exact match, got fallback")
+	}
+	want := filepath.Join(dir, "4.5.0", "bin", "R")
+	if path != want {
+		t.Errorf("path = %q, want %q", path, want)
+	}
+}
+
+func TestResolveRBinary_MinorMatch(t *testing.T) {
+	dir := setupRigFixture(t, "4.5.1")
+	orig := rigBase
+	defer func() { setRigBase(orig) }()
+	setRigBase(dir)
+
+	// Request 4.5.0 but only 4.5.1 is installed → minor match.
+	path, fell := ResolveRBinary("4.5.0", "/usr/bin/R")
+	if fell {
+		t.Error("expected minor match, got fallback")
+	}
+	want := filepath.Join(dir, "4.5.1", "bin", "R")
+	if path != want {
+		t.Errorf("path = %q, want %q", path, want)
+	}
+}
+
+func TestResolveRBinary_MinorMatchPicksHighest(t *testing.T) {
+	dir := setupRigFixture(t, "4.5.0", "4.5.1", "4.5.2")
+	orig := rigBase
+	defer func() { setRigBase(orig) }()
+	setRigBase(dir)
+
+	// Request 4.5.0 with multiple 4.5.x available → highest patch.
+	path, fell := ResolveRBinary("4.5.0", "/usr/bin/R")
+	if fell {
+		t.Error("expected minor match, got fallback")
+	}
+	// Exact match takes priority over minor match.
+	want := filepath.Join(dir, "4.5.0", "bin", "R")
+	if path != want {
+		t.Errorf("path = %q, want %q", path, want)
+	}
+}
+
+func TestResolveRBinary_Fallback(t *testing.T) {
+	dir := setupRigFixture(t, "4.4.3")
+	orig := rigBase
+	defer func() { setRigBase(orig) }()
+	setRigBase(dir)
+
+	// Request 4.5.0 but nothing in 4.5.x installed.
+	path, fell := ResolveRBinary("4.5.0", "/usr/bin/R")
+	if !fell {
+		t.Error("expected fallback")
+	}
+	if path != "/usr/bin/R" {
+		t.Errorf("path = %q, want fallback", path)
+	}
+}
+
+func TestResolveRBinary_EmptyVersion(t *testing.T) {
+	path, fell := ResolveRBinary("", "/usr/bin/R")
+	if fell {
+		t.Error("empty version should not be a fallback")
+	}
+	if path != "/usr/bin/R" {
+		t.Errorf("path = %q, want /usr/bin/R", path)
+	}
+}
+
+func TestInstalledRVersions(t *testing.T) {
+	dir := setupRigFixture(t, "4.3.2", "4.5.0", "4.4.3")
+	orig := rigBase
+	defer func() { setRigBase(orig) }()
+	setRigBase(dir)
+
+	versions := InstalledRVersions()
+	if len(versions) != 3 {
+		t.Fatalf("expected 3 versions, got %v", versions)
+	}
+	// Should be sorted.
+	if versions[0] != "4.3.2" || versions[1] != "4.4.3" || versions[2] != "4.5.0" {
+		t.Errorf("versions = %v", versions)
+	}
+}
+
+func TestInstalledRVersions_Empty(t *testing.T) {
+	dir := t.TempDir() // empty
+	orig := rigBase
+	defer func() { setRigBase(orig) }()
+	setRigBase(dir)
+
+	versions := InstalledRVersions()
+	if len(versions) != 0 {
+		t.Errorf("expected empty, got %v", versions)
+	}
+}

--- a/internal/bundle/buildmode_test.go
+++ b/internal/bundle/buildmode_test.go
@@ -21,7 +21,7 @@ func TestResolveManifest_ManifestExists(t *testing.T) {
 
 	m := manifest.Manifest{
 		Version:  1,
-		Platform: "4.4.2",
+		RVersion: "4.4.2",
 		Metadata: manifest.Metadata{AppMode: "shiny", Entrypoint: "app.R"},
 		Packages: map[string]manifest.Package{
 			"shiny": {Package: "shiny", Version: "1.9.1", Source: "Repository"},

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -337,7 +337,7 @@ func writeBundleWithManifest(t *testing.T, paths Paths) {
 
 	m := manifest.Manifest{
 		Version:  1,
-		Platform: "4.4.2",
+		RVersion: "4.4.2",
 		Metadata: manifest.Metadata{AppMode: "shiny", Entrypoint: "app.R"},
 		Description: map[string]string{
 			"Imports": "shiny",

--- a/internal/bundle/preprocess_test.go
+++ b/internal/bundle/preprocess_test.go
@@ -41,6 +41,7 @@ func (b *ppBackend) CleanupOrphanResources(context.Context) error { return nil }
 func (b *ppBackend) Preflight(context.Context) (*preflight.Report, error) {
 	return &preflight.Report{}, nil
 }
+func (b *ppBackend) CheckRVersion(string) error { return nil }
 
 // --- preProcess tests ---
 

--- a/internal/bundle/restore.go
+++ b/internal/bundle/restore.go
@@ -250,6 +250,13 @@ func runRestore(p RestoreParams) error {
 	// 7. Generate build UUID for the build library path.
 	buildUUID := uuid.New().String()
 
+	// R version from the manifest for version dispatch in the process
+	// backend. Empty for bare-script bundles (no renv.lock).
+	var rVersion string
+	if m != nil {
+		rVersion = m.RVersion
+	}
+
 	// 8. Run build container.
 	var spec backend.BuildSpec
 	if p.Store != nil {
@@ -268,6 +275,7 @@ func runRestore(p RestoreParams) error {
 				"dev.blockyard/bundle-id": p.BundleID,
 			},
 			LogWriter: func(line string) { p.Sender.Write(line) },
+			RVersion:  rVersion,
 		}
 	} else {
 		// Legacy build (no store): phase 2-5 flow.
@@ -284,6 +292,7 @@ func runRestore(p RestoreParams) error {
 				"dev.blockyard/bundle-id": p.BundleID,
 			},
 			LogWriter: func(line string) { p.Sender.Write(line) },
+			RVersion:  rVersion,
 		}
 	}
 

--- a/internal/bundle/restore_test.go
+++ b/internal/bundle/restore_test.go
@@ -41,7 +41,7 @@ func setupRestoreTest(t *testing.T, buildSuccess bool) (RestoreParams, *task.Sto
 
 	m := manifest.Manifest{
 		Version:  1,
-		Platform: "4.4.2",
+		RVersion: "4.4.2",
 		Metadata: manifest.Metadata{AppMode: "shiny", Entrypoint: "app.R"},
 		Description: map[string]string{
 			"Imports": "shiny",

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -11,10 +11,10 @@ const currentVersion = 1
 
 // Manifest is the canonical interface between CLI and server. It has two
 // shapes: pinned (with Packages) and unpinned (with Description). Both share
-// an envelope (Version, Platform, Metadata, Repositories, Files).
+// an envelope (Version, RVersion, Metadata, Repositories, Files).
 type Manifest struct {
 	Version      int                 `json:"version"`
-	Platform     string              `json:"platform"`
+	RVersion     string              `json:"r_version"`
 	Metadata     Metadata            `json:"metadata"`
 	Repositories []Repository        `json:"repositories"`
 	Packages     map[string]Package  `json:"packages,omitempty"`

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -114,7 +114,7 @@ func TestManifestReadWrite(t *testing.T) {
 
 	m := &Manifest{
 		Version:  1,
-		Platform: "4.4.2",
+		RVersion: "4.4.2",
 		Metadata: Metadata{AppMode: "shiny", Entrypoint: "app.R"},
 		Repositories: []Repository{
 			{Name: "CRAN", URL: "https://p3m.dev/cran/latest"},
@@ -132,8 +132,8 @@ func TestManifestReadWrite(t *testing.T) {
 		t.Fatalf("Read: %v", err)
 	}
 
-	if got.Platform != "4.4.2" {
-		t.Errorf("Platform = %q, want %q", got.Platform, "4.4.2")
+	if got.RVersion != "4.4.2" {
+		t.Errorf("RVersion = %q, want %q", got.RVersion, "4.4.2")
 	}
 	if got.Metadata.AppMode != "shiny" {
 		t.Errorf("AppMode = %q, want %q", got.Metadata.AppMode, "shiny")
@@ -262,8 +262,8 @@ func TestFromRenvLock_BasicCRAN(t *testing.T) {
 		t.Fatalf("FromRenvLock: %v", err)
 	}
 
-	if m.Platform != "4.4.2" {
-		t.Errorf("Platform = %q", m.Platform)
+	if m.RVersion != "4.4.2" {
+		t.Errorf("RVersion = %q", m.RVersion)
 	}
 	if !m.IsPinned() {
 		t.Error("expected pinned manifest")

--- a/internal/manifest/renvlock.go
+++ b/internal/manifest/renvlock.go
@@ -38,7 +38,7 @@ func FromRenvLock(
 
 	m := &Manifest{
 		Version:      currentVersion,
-		Platform:     lock.R.Version,
+		RVersion:     lock.R.Version,
 		Metadata:     meta,
 		Repositories: lock.R.Repositories,
 		Packages:     lock.Packages,

--- a/internal/manifest/renvlock.go
+++ b/internal/manifest/renvlock.go
@@ -18,6 +18,24 @@ type renvLock struct {
 	Packages map[string]Package `json:"Packages"`
 }
 
+// RVersionFromRenvLock reads only the R.Version field from an
+// renv.lock file. Returns "" if the file is missing or unparseable.
+func RVersionFromRenvLock(lockPath string) string {
+	data, err := os.ReadFile(lockPath) //nolint:gosec // G304: reads renv.lock from managed path
+	if err != nil {
+		return ""
+	}
+	var partial struct {
+		R struct {
+			Version string `json:"Version"`
+		} `json:"R"`
+	}
+	if json.Unmarshal(data, &partial) != nil {
+		return ""
+	}
+	return partial.R.Version
+}
+
 // FromRenvLock converts an renv.lock file to a pinned manifest.
 // Package identity and source fields are preserved unchanged.
 // Extra DESCRIPTION fields from v2 lockfiles are not carried.

--- a/internal/pakcache/pakcache_test.go
+++ b/internal/pakcache/pakcache_test.go
@@ -42,6 +42,7 @@ func (b *stubBackend) CleanupOrphanResources(context.Context) error { return nil
 func (b *stubBackend) Preflight(context.Context) (*preflight.Report, error) {
 	return &preflight.Report{}, nil
 }
+func (b *stubBackend) CheckRVersion(string) error { return nil }
 
 // --- EnsureInstalled tests ---
 

--- a/internal/proxy/coldstart.go
+++ b/internal/proxy/coldstart.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cynkra/blockyard/internal/backend"
 	"github.com/cynkra/blockyard/internal/bundle"
 	"github.com/cynkra/blockyard/internal/db"
+	"github.com/cynkra/blockyard/internal/manifest"
 	"github.com/cynkra/blockyard/internal/mount"
 	"github.com/cynkra/blockyard/internal/ops"
 	"github.com/cynkra/blockyard/internal/pkgstore"
@@ -245,6 +246,12 @@ func spawnWorker(ctx context.Context, srv *server.Server, app *db.AppRow) (strin
 		}
 	}
 
+	// Read R version from bundle manifest for version dispatch.
+	var rVersion string
+	if m, err := manifest.Read(filepath.Join(hostPaths.Unpacked, "manifest.json")); err == nil {
+		rVersion = m.RVersion
+	}
+
 	spec := backend.WorkerSpec{
 		AppID:       app.ID,
 		WorkerID:    wid,
@@ -259,6 +266,7 @@ func spawnWorker(ctx context.Context, srv *server.Server, app *db.AppRow) (strin
 		TokenDir:    tokDir,
 		WorkerMount: srv.Config.Storage.BundleWorkerPath,
 		ShinyPort:   srv.Config.Docker.ShinyPort,
+		RVersion:    rVersion,
 		MemoryLimit: ptrOr(app.MemoryLimit, ""),
 		CPULimit:    ptrOr(app.CPULimit, 0.0),
 		Labels:      labels,

--- a/internal/server/refresh_docker_test.go
+++ b/internal/server/refresh_docker_test.go
@@ -123,7 +123,7 @@ func deployUnpinnedBundle(t *testing.T, srv *server.Server) (*db.AppRow, string)
 	}
 
 	// Write an unpinned manifest (DESCRIPTION-based, no pinned packages).
-	manifestJSON := `{"version":1,"platform":"4.4.3","metadata":{"appmode":"shiny","entrypoint":"app.R"},"repositories":[{"Name":"CRAN","URL":"https://p3m.dev/cran/latest"}],"description":{"Imports":"mime"},"files":{"app.R":{"checksum":"abc"}}}`
+	manifestJSON := `{"version":1,"r_version":"4.4.3","metadata":{"appmode":"shiny","entrypoint":"app.R"},"repositories":[{"Name":"CRAN","URL":"https://p3m.dev/cran/latest"}],"description":{"Imports":"mime"},"files":{"app.R":{"checksum":"abc"}}}`
 	os.WriteFile(filepath.Join(paths.Unpacked, "manifest.json"), []byte(manifestJSON), 0o644)
 	os.WriteFile(filepath.Join(paths.Unpacked, "DESCRIPTION"),
 		[]byte("Package: testapp\nVersion: 0.1.0\nImports:\n    mime\n"), 0o644)
@@ -380,7 +380,7 @@ func TestRefreshAndRollback_Docker(t *testing.T) {
 		os.WriteFile(filepath.Join(badPaths.Unpacked, "DESCRIPTION"),
 			[]byte("Package: badapp\nVersion: 0.1.0\nImports:\n    this.package.does.not.exist.12345\n"), 0o644)
 		os.WriteFile(filepath.Join(badPaths.Unpacked, "manifest.json"),
-			[]byte(`{"version":1,"platform":"4.4.3","metadata":{"appmode":"shiny","entrypoint":"app.R"},"repositories":[{"Name":"CRAN","URL":"https://p3m.dev/cran/latest"}],"description":{"Imports":"this.package.does.not.exist.12345"},"files":{"app.R":{"checksum":"abc"}}}`),
+			[]byte(`{"version":1,"r_version":"4.4.3","metadata":{"appmode":"shiny","entrypoint":"app.R"},"repositories":[{"Name":"CRAN","URL":"https://p3m.dev/cran/latest"}],"description":{"Imports":"this.package.does.not.exist.12345"},"files":{"app.R":{"checksum":"abc"}}}`),
 			0o644)
 
 		badApp := &db.AppRow{

--- a/internal/server/transfer.go
+++ b/internal/server/transfer.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cynkra/blockyard/internal/backend"
 	"github.com/cynkra/blockyard/internal/db"
+	"github.com/cynkra/blockyard/internal/manifest"
 	"github.com/cynkra/blockyard/internal/mount"
 	"github.com/cynkra/blockyard/internal/pkgstore"
 )
@@ -238,6 +239,11 @@ func (srv *Server) defaultWorkerSpec(
 	transferDir := filepath.Join(srv.Config.Storage.BundleServerPath, ".transfers", workerID)
 	_ = os.MkdirAll(transferDir, 0o755) //nolint:gosec // G301: transfer dir, not secrets
 
+	var rVersion string
+	if m, err := manifest.Read(filepath.Join(hostPaths.Unpacked, "manifest.json")); err == nil {
+		rVersion = m.RVersion
+	}
+
 	spec := backend.WorkerSpec{
 		AppID:    app.ID,
 		WorkerID: workerID,
@@ -251,6 +257,7 @@ func (srv *Server) defaultWorkerSpec(
 		TransferDir: transferDir,
 		WorkerMount: srv.Config.Storage.BundleWorkerPath,
 		ShinyPort:   srv.Config.Docker.ShinyPort,
+		RVersion:    rVersion,
 		Labels: map[string]string{
 			"dev.blockyard/managed":   "true",
 			"dev.blockyard/app-id":    app.ID,


### PR DESCRIPTION
## Summary
- Add R version dispatch to the process backend: resolve the bundle's pinned R version (from `renv.lock` → `manifest.RVersion`) to a rig-managed binary at `/opt/R/<version>/bin/R` at worker spawn and build time, falling back to the configured default
- Rename `manifest.Platform` → `manifest.RVersion` (JSON key `"platform"` → `"r_version"`) since the field carries the R version, not an OS platform triple
- Change the process-backend Dockerfile from `R_VERSION` (single) to `R_VERSIONS` (space-separated list) to pre-install multiple R versions in one image
- Add preflight check that enumerates installed rig-managed R versions at startup

Closes #189