### PR TITLE
fix(orchestrator): rolling update watchdog and signal handling bugs

### DIFF
--- a/cmd/blockyard/main.go
+++ b/cmd/blockyard/main.go
@@ -620,19 +620,32 @@ func main() {
 	}
 
 	// Wait for signal or update-complete notification.
-	select {
-	case sig := <-sigCh:
-		forceExitOnSecondSignal()
-		switch sig {
-		case syscall.SIGUSR1:
-			drainer.Drain()
+	for {
+		select {
+		case sig := <-sigCh:
+			// SIGUSR1 during an active orchestrator operation must be
+			// ignored — the orchestrator owns the drain/exit lifecycle
+			// and Finish() would shut down the HTTP server it's using
+			// to communicate with the new instance.
+			if sig == syscall.SIGUSR1 && orch != nil && orch.State() != "idle" {
+				slog.Warn("SIGUSR1 ignored: orchestrator operation in progress",
+					"state", orch.State())
+				continue
+			}
+			forceExitOnSecondSignal()
+			switch sig {
+			case syscall.SIGUSR1:
+				drainer.Drain()
+				drainer.Finish(cfg.Server.DrainTimeout.Duration)
+			default:
+				// SIGTERM, SIGINT → full shutdown.
+				drainer.Shutdown(cfg.Server.ShutdownTimeout.Duration)
+			}
+			return
+		case <-doneCh:
 			drainer.Finish(cfg.Server.DrainTimeout.Duration)
-		default:
-			// SIGTERM, SIGINT → full shutdown.
-			drainer.Shutdown(cfg.Server.ShutdownTimeout.Duration)
+			return
 		}
-	case <-doneCh:
-		drainer.Finish(cfg.Server.DrainTimeout.Duration)
 	}
 }
 

--- a/internal/orchestrator/export_test.go
+++ b/internal/orchestrator/export_test.go
@@ -46,3 +46,12 @@ func ActiveInstanceForTest(o *Orchestrator) TestServerInstance {
 	}
 	return o.activeInstance
 }
+
+// SetWatchdogFailureThresholdForTest overrides the consecutive failure
+// count for tests and returns a cleanup function that restores the
+// original value.
+func SetWatchdogFailureThresholdForTest(n int) func() {
+	old := watchdogFailureThreshold
+	watchdogFailureThreshold = n
+	return func() { watchdogFailureThreshold = old }
+}

--- a/internal/orchestrator/helpers.go
+++ b/internal/orchestrator/helpers.go
@@ -45,7 +45,8 @@ func (o *Orchestrator) activate(ctx context.Context, addr string) error {
 		req.Header.Set("Authorization", "Bearer "+o.activationToken)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("POST activate: %w", err)
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -426,6 +426,10 @@ func TestWatchdogHealthy(t *testing.T) {
 }
 
 func TestWatchdogUnhealthy(t *testing.T) {
+	// Use threshold=1 so the test doesn't need to wait for 3 ticks.
+	cleanup := SetWatchdogFailureThresholdForTest(1)
+	defer cleanup()
+
 	calls := 0
 	readyzServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls++
@@ -457,6 +461,32 @@ func TestWatchdogUnhealthy(t *testing.T) {
 	}
 	if !killed.Load() {
 		t.Error("instance should be killed on watchdog failure")
+	}
+}
+
+func TestWatchdogTransientFailureRecovers(t *testing.T) {
+	var calls atomic.Int32
+	readyzServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		// Fail on the 2nd call only; all others succeed.
+		if n == 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer readyzServer.Close()
+
+	o, tracker := newTestOrchestrator(t, &fakeServerFactory{}, &mockChecker{})
+	sender := newSender(t)
+	o.activeInstance = &fakeInstance{id: "new-id", addr: readyzServer.Listener.Addr().String()}
+
+	err := o.Watchdog(context.Background(), 100*time.Millisecond, sender)
+	if err != nil {
+		t.Fatalf("single transient failure should not trigger rollback: %v", err)
+	}
+	if tracker.undrained.Load() != 0 {
+		t.Error("undrain should not be called for a transient failure")
 	}
 }
 

--- a/internal/orchestrator/watchdog.go
+++ b/internal/orchestrator/watchdog.go
@@ -8,13 +8,20 @@ import (
 	"github.com/cynkra/blockyard/internal/task"
 )
 
+// watchdogFailureThreshold is the number of consecutive /readyz
+// failures required before the watchdog triggers a rollback. A single
+// transient failure (GC pause, brief DB pool exhaustion, slow IdP
+// response) should not undo a successful deployment.
+var watchdogFailureThreshold = 3
+
 // Watchdog monitors the new server after a successful update. It
 // reads the target instance from o.activeInstance (set by Update) so
 // the admin handler doesn't thread an opaque handle through the API
 // layer.
 //
-// If the new server becomes unhealthy within the watch period, the
-// watchdog kills the new instance, un-drains, and resumes serving.
+// If the new server becomes unhealthy (3 consecutive failures) within
+// the watch period, the watchdog kills the new instance, un-drains,
+// and resumes serving.
 //
 // If the new server stays healthy for the full period, the old
 // server exits (returns nil, caller signals main goroutine).
@@ -39,22 +46,32 @@ func (o *Orchestrator) Watchdog(
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 
+	consecutiveFailures := 0
+
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			if err := o.checkReady(ctx, addr); err != nil {
-				sender.Write(fmt.Sprintf(
-					"New server unhealthy: %v. Rolling back.", err))
-				inst.Kill(ctx)
-				o.undrainFn()
-				sender.Write("Rolled back. Old server resumed.")
-				return fmt.Errorf("watchdog: new server failed: %w", err)
-			}
 			if time.Now().After(deadline) {
 				sender.Write("Watch period elapsed. New server healthy. Exiting.")
 				return nil // caller exits the process
+			}
+			if err := o.checkReady(ctx, addr); err != nil {
+				consecutiveFailures++
+				sender.Write(fmt.Sprintf(
+					"New server unhealthy (%d/%d): %v",
+					consecutiveFailures, watchdogFailureThreshold, err))
+				if consecutiveFailures >= watchdogFailureThreshold {
+					sender.Write("Failure threshold reached. Rolling back.")
+					inst.Kill(ctx)
+					o.undrainFn()
+					sender.Write("Rolled back. Old server resumed.")
+					return fmt.Errorf("watchdog: new server failed after %d consecutive checks: %w",
+						consecutiveFailures, err)
+				}
+			} else {
+				consecutiveFailures = 0
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Fix watchdog deadline check ordering to match spec — deadline before health check, preventing false rollbacks after watch period elapses
- Require 3 consecutive health check failures before triggering watchdog rollback instead of rolling back on a single transient failure
- Add 30s timeout to the `activate()` HTTP call which was using `http.DefaultClient` with no timeout
- Guard SIGUSR1 during active orchestrator operations to prevent `Finish()` from shutting down the HTTP server the orchestrator uses to talk to the new instance