### PR TITLE
fix(process): data mounts, loopback binding, chained transfers

### DIFF
--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -899,7 +899,7 @@ func StartApp(srv *server.Server) http.HandlerFunc {
 			WorkerID:    workerID,
 			Image:       server.AppImage(app, srv.Config.Docker.Image),
 			Cmd: []string{"R", "-e",
-				fmt.Sprintf("shiny::runApp('%s', port = as.integer(Sys.getenv('SHINY_PORT')))",
+				fmt.Sprintf("shiny::runApp('%s', port = as.integer(Sys.getenv('SHINY_PORT')), host = Sys.getenv('SHINY_HOST', unset = '0.0.0.0'))",
 					srv.Config.Storage.BundleWorkerPath)},
 			BundlePath:  hostPaths.Unpacked,
 			LibraryPath: hostPaths.Library,

--- a/internal/backend/process/bwrap.go
+++ b/internal/backend/process/bwrap.go
@@ -87,6 +87,15 @@ func bwrapArgs(cfg *config.ProcessConfig, spec backend.WorkerSpec, port, uid, gi
 		args = append(args, "--bind", spec.TransferDir, "/transfer")
 	}
 
+	// Per-app data mounts (resolved host paths from app config).
+	for _, dm := range spec.DataMounts {
+		if dm.ReadOnly {
+			args = append(args, "--ro-bind", dm.Source, dm.Target)
+		} else {
+			args = append(args, "--bind", dm.Source, dm.Target)
+		}
+	}
+
 	// Capability dropping — bwrap drops all by default with --unshare-user,
 	// but we explicitly drop to be defensive in case of flag changes.
 	args = append(args, "--cap-drop", "ALL")

--- a/internal/backend/process/bwrap_test.go
+++ b/internal/backend/process/bwrap_test.go
@@ -214,6 +214,26 @@ func TestBwrapArgsTokenAndTransfer(t *testing.T) {
 	assertBindMount(t, args, "--bind", spec.TransferDir, "/transfer")
 }
 
+func TestBwrapArgsDataMounts(t *testing.T) {
+	cfg := &config.ProcessConfig{
+		BwrapPath: "/usr/bin/bwrap",
+		RPath:     "/usr/bin/R",
+	}
+	spec := backend.WorkerSpec{
+		WorkerID:    "w-1",
+		BundlePath:  "/data/bundles/app1/v1",
+		WorkerMount: "/app",
+		DataMounts: []backend.MountEntry{
+			{Source: "/data/models", Target: "/data/models", ReadOnly: true},
+			{Source: "/data/uploads", Target: "/data/uploads", ReadOnly: false},
+		},
+	}
+
+	args := bwrapArgs(cfg, spec, 10004, 60004, 65534)
+	assertBindMount(t, args, "--ro-bind", "/data/models", "/data/models")
+	assertBindMount(t, args, "--bind", "/data/uploads", "/data/uploads")
+}
+
 func TestBwrapBuildArgs(t *testing.T) {
 	cfg := &config.ProcessConfig{
 		BwrapPath: "/usr/bin/bwrap",

--- a/internal/backend/process/process.go
+++ b/internal/backend/process/process.go
@@ -274,6 +274,12 @@ func (b *ProcessBackend) Spawn(_ context.Context, spec backend.WorkerSpec) error
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}
 	cmd.Env = append(cmd.Env, fmt.Sprintf("SHINY_PORT=%d", port))
+	// Process backend shares the host network (no --unshare-net), so
+	// workers must bind to loopback to avoid exposing the Shiny port
+	// on all interfaces, which would let clients bypass the proxy.
+	// Docker workers don't set this, defaulting to 0.0.0.0, which is
+	// fine because each container has its own network namespace.
+	cmd.Env = append(cmd.Env, "SHINY_HOST=127.0.0.1")
 
 	// Log capture
 	logs := newLogBuffer(10000)

--- a/internal/proxy/coldstart.go
+++ b/internal/proxy/coldstart.go
@@ -250,7 +250,7 @@ func spawnWorker(ctx context.Context, srv *server.Server, app *db.AppRow) (strin
 		WorkerID:    wid,
 		Image:       server.AppImage(app, srv.Config.Docker.Image),
 		Cmd: []string{"R", "-e",
-			fmt.Sprintf("shiny::runApp('%s', port = as.integer(Sys.getenv('SHINY_PORT')))",
+			fmt.Sprintf("shiny::runApp('%s', port = as.integer(Sys.getenv('SHINY_PORT')), host = Sys.getenv('SHINY_HOST', unset = '0.0.0.0'))",
 				srv.Config.Storage.BundleWorkerPath)},
 		BundlePath:  hostPaths.Unpacked,
 		LibraryPath: hostPaths.Library,

--- a/internal/server/transfer.go
+++ b/internal/server/transfer.go
@@ -135,9 +135,14 @@ func (srv *Server) completeTransfer(
 		return
 	}
 
-	// Spawn new worker with updated library and old worker's
-	// transfer dir (containing board.json).
-	spec := srv.buildTransferWorkerSpec(app, newWorkerID, newLibDir, transferDir, oldWorker.BundleID)
+	// Spawn new worker with updated library. board.json is copied
+	// into the new worker's own transfer dir so future transfers on
+	// this worker use the correct path.
+	spec, err := srv.buildTransferWorkerSpec(app, newWorkerID, newLibDir, transferDir, oldWorker.BundleID)
+	if err != nil {
+		slog.Error("transfer: build worker spec", "error", err)
+		return
+	}
 	if err := srv.Backend.Spawn(ctx, spec); err != nil {
 		slog.Error("transfer: spawn worker", "error", err)
 		return
@@ -184,8 +189,9 @@ func (srv *Server) completeTransfer(
 	// Reroute sessions from old worker to new worker.
 	srv.Sessions.RerouteWorker(oldWorkerID, newWorkerID)
 
-	// Evict old worker.
+	// Evict old worker and clean up its transfer directory.
 	srv.EvictWorkerFn(ctx, srv, oldWorkerID)
+	os.RemoveAll(transferDir) //nolint:errcheck
 
 	slog.Info("transfer complete",
 		"app_id", appID,
@@ -193,22 +199,34 @@ func (srv *Server) completeTransfer(
 		"new_worker", newWorkerID)
 }
 
-// buildTransferWorkerSpec creates a WorkerSpec for a transfer target worker.
-// The old worker's transfer directory is mounted read-only (contains board.json).
+// buildTransferWorkerSpec creates a WorkerSpec for a transfer target
+// worker. The new worker keeps its own transfer directory (created by
+// defaultWorkerSpec) so that future transfers on this worker write to
+// and watch the correct path. The old worker's board.json is copied
+// into the new dir so the R session can resume state.
 func (srv *Server) buildTransferWorkerSpec(
 	app *db.AppRow, workerID, libDir, oldTransferDir, bundleID string,
-) backend.WorkerSpec {
+) (backend.WorkerSpec, error) {
 	spec := srv.defaultWorkerSpec(app, workerID, libDir, bundleID)
 
 	if oldTransferDir != "" {
-		spec.TransferDir = oldTransferDir
+		// Copy board.json from the old worker's transfer dir into the
+		// new worker's own dir. This lets the R session pick up the
+		// saved board state while keeping /transfer pointed at a dir
+		// the server will watch for subsequent transfers.
+		src := filepath.Join(oldTransferDir, "board.json")
+		dst := filepath.Join(spec.TransferDir, "board.json")
+		if err := copyFile(src, dst); err != nil {
+			return backend.WorkerSpec{}, fmt.Errorf(
+				"copy board.json to new transfer dir: %w", err)
+		}
 		if spec.Env == nil {
 			spec.Env = make(map[string]string)
 		}
 		spec.Env["BLOCKYARD_TRANSFER_PATH"] = "/transfer/board.json"
 	}
 
-	return spec
+	return spec, nil
 }
 
 // defaultWorkerSpec builds a WorkerSpec with standard settings.
@@ -225,7 +243,7 @@ func (srv *Server) defaultWorkerSpec(
 		WorkerID: workerID,
 		Image:    AppImage(app, srv.Config.Docker.Image),
 		Cmd: []string{"R", "-e",
-			fmt.Sprintf("shiny::runApp('%s', port = as.integer(Sys.getenv('SHINY_PORT')))",
+			fmt.Sprintf("shiny::runApp('%s', port = as.integer(Sys.getenv('SHINY_PORT')), host = Sys.getenv('SHINY_HOST', unset = '0.0.0.0'))",
 				srv.Config.Storage.BundleWorkerPath)},
 		BundlePath:  hostPaths.Unpacked,
 		LibraryPath: hostPaths.Library,

--- a/internal/server/transfer_test.go
+++ b/internal/server/transfer_test.go
@@ -164,10 +164,25 @@ func TestDefaultWorkerSpec(t *testing.T) {
 func TestBuildTransferWorkerSpec(t *testing.T) {
 	srv, _ := testServerWithMock(t)
 
+	// Create the old transfer dir with a board.json that will be
+	// copied into the new worker's own transfer dir.
+	oldTransferDir := filepath.Join(t.TempDir(), "old-transfer")
+	os.MkdirAll(oldTransferDir, 0o755)
+	os.WriteFile(filepath.Join(oldTransferDir, "board.json"), []byte(`{}`), 0o644)
+
 	app := &db.AppRow{ID: "app-1", Name: "test-app"}
-	spec := srv.buildTransferWorkerSpec(app, "w-2", "/lib/w-2", "/transfer/w-1", "bundle-abc")
-	if spec.TransferDir != "/transfer/w-1" {
-		t.Errorf("TransferDir = %q, want %q", spec.TransferDir, "/transfer/w-1")
+	spec, err := srv.buildTransferWorkerSpec(app, "w-2", "/lib/w-2", oldTransferDir, "bundle-abc")
+	if err != nil {
+		t.Fatalf("buildTransferWorkerSpec: %v", err)
+	}
+	// The new worker must keep its own transfer dir (not the old one)
+	// so that future transfers write to the path the server watches.
+	if spec.TransferDir == oldTransferDir {
+		t.Errorf("TransferDir must not be the old worker's dir; got %q", spec.TransferDir)
+	}
+	// board.json should have been copied into the new dir.
+	if !fileExists(filepath.Join(spec.TransferDir, "board.json")) {
+		t.Error("board.json not found in new worker's transfer dir")
 	}
 	if spec.Env["BLOCKYARD_TRANSFER_PATH"] != "/transfer/board.json" {
 		t.Errorf("BLOCKYARD_TRANSFER_PATH = %q, want %q",
@@ -179,7 +194,10 @@ func TestBuildTransferWorkerSpec_EmptyTransferDir(t *testing.T) {
 	srv, _ := testServerWithMock(t)
 
 	app := &db.AppRow{ID: "app-1", Name: "test-app"}
-	spec := srv.buildTransferWorkerSpec(app, "w-2", "/lib/w-2", "", "bundle-abc")
+	spec, err := srv.buildTransferWorkerSpec(app, "w-2", "/lib/w-2", "", "bundle-abc")
+	if err != nil {
+		t.Fatalf("buildTransferWorkerSpec: %v", err)
+	}
 	if _, ok := spec.Env["BLOCKYARD_TRANSFER_PATH"]; ok {
 		t.Error("expected no BLOCKYARD_TRANSFER_PATH when transfer dir is empty")
 	}


### PR DESCRIPTION
## Summary
- **Data mounts**: `bwrapArgs` now handles `spec.DataMounts` — previously silently dropped, leaving apps without their data directories
- **Loopback binding**: all `shiny::runApp` Cmd sites read `SHINY_HOST` env (default `0.0.0.0` for Docker); process backend sets `127.0.0.1` to prevent workers from being directly reachable on the host network
- **Chained transfers**: `buildTransferWorkerSpec` copies `board.json` into the new worker's own transfer dir instead of hijacking the old dir, fixing timeout on second transfer; old dir cleaned up after completion