### PR TITLE
fix(test): prevent pak test DB race and increase restore timeout

### DIFF
--- a/internal/backend/docker/pak_integration_test.go
+++ b/internal/backend/docker/pak_integration_test.go
@@ -152,10 +152,10 @@ func TestFullPipeline_RestoreAndSpawnWorker(t *testing.T) {
 	taskID := uuid.New().String()
 	sender := tasks.Create(taskID, app.ID)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	bundle.SpawnRestore(bundle.RestoreParams{
+	restoreDone := bundle.SpawnRestore(bundle.RestoreParams{
 		Ctx:          ctx,
 		Backend:      be,
 		DB:           database,
@@ -170,6 +170,7 @@ func TestFullPipeline_RestoreAndSpawnWorker(t *testing.T) {
 		Retention:    5,
 		BasePath:     basePath,
 	})
+	defer func() { <-restoreDone }() // wait for goroutine before database.Close()
 
 	// Wait for restore to complete.
 	_, _, done, ok := tasks.Subscribe(taskID)

--- a/internal/bundle/restore.go
+++ b/internal/bundle/restore.go
@@ -299,6 +299,9 @@ func runRestore(p RestoreParams) error {
 		slog.Error("build container failed",
 			"app_id", p.AppID, "bundle_id", p.BundleID,
 			"exit_code", result.ExitCode, "logs", result.Logs)
+		if result.ExitCode == -1 && ctx.Err() != nil {
+			return fmt.Errorf("dependency restore timed out: %w", ctx.Err())
+		}
 		return fmt.Errorf("dependency restore failed (exit %d)", result.ExitCode)
 	}
 

--- a/internal/server/refresh_docker_test.go
+++ b/internal/server/refresh_docker_test.go
@@ -132,10 +132,10 @@ func deployUnpinnedBundle(t *testing.T, srv *server.Server) (*db.AppRow, string)
 	taskID := uuid.New().String()
 	sender := srv.Tasks.Create(taskID, app.ID)
 
-	restoreCtx, restoreCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	restoreCtx, restoreCancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer restoreCancel()
 
-	bundle.SpawnRestore(bundle.RestoreParams{
+	restoreDone := bundle.SpawnRestore(bundle.RestoreParams{
 		Ctx:          restoreCtx,
 		Backend:      srv.Backend,
 		DB:           srv.DB,
@@ -150,6 +150,7 @@ func deployUnpinnedBundle(t *testing.T, srv *server.Server) (*db.AppRow, string)
 		Retention:    5,
 		BasePath:     srv.Config.Storage.BundleServerPath,
 	})
+	t.Cleanup(func() { <-restoreDone }) // wait for goroutine before database.Close()
 
 	_, _, done, ok := srv.Tasks.Subscribe(taskID)
 	if !ok {
@@ -158,7 +159,7 @@ func deployUnpinnedBundle(t *testing.T, srv *server.Server) (*db.AppRow, string)
 	select {
 	case <-done:
 	case <-restoreCtx.Done():
-		t.Fatal("restore timed out after 5 minutes")
+		t.Fatal("restore timed out after 10 minutes")
 	}
 
 	status, _ := srv.Tasks.Status(taskID)


### PR DESCRIPTION
## Summary
- Wait for `SpawnRestore` goroutine to finish before closing the test database, preventing `sql: database is closed` errors during teardown
- Increase restore context timeout from 5 to 10 minutes to absorb CI network/resource variance
- Return `dependency restore timed out: context deadline exceeded` instead of the opaque `dependency restore failed (exit -1)` when the build container is killed by context cancellation

Closes #197