### PR TITLE
Fix arm64 server image builds downloading x86_64 rig binary

### DIFF
--- a/docker/server-everything.Dockerfile
+++ b/docker/server-everything.Dockerfile
@@ -65,7 +65,7 @@ FROM ubuntu:24.04
 
 ARG RIG_VERSION=0.7.1
 ARG R_VERSION=release
-ARG TARGETARCH=amd64
+ARG TARGETARCH
 
 RUN apt-get update \
     && apt-get upgrade -y \

--- a/docker/server-process.Dockerfile
+++ b/docker/server-process.Dockerfile
@@ -75,10 +75,7 @@ FROM ubuntu:24.04
 # R versions via shims under /usr/local/bin. Operators can add or
 # remove versions at runtime via the extras.sh hook.
 ARG RIG_VERSION=0.7.1
-# Docker buildx sets TARGETARCH automatically for multi-platform
-# builds. Default to amd64 for local single-arch `docker build`
-# invocations so rig downloads the correct tarball.
-ARG TARGETARCH=amd64
+ARG TARGETARCH
 
 # Runtime libraries only — no -dev headers, no compiler toolchain.
 # r-base-core-style runtime deps + common DB connectors + xml + ssl


### PR DESCRIPTION
## Summary
- `ARG TARGETARCH=amd64` in server-everything and server-process Dockerfiles shadows BuildKit's automatic platform ARG, causing arm64 builds to download the x86_64 rig binary and fail with "Exec format error"
- Remove the `=amd64` default so BuildKit's value flows through correctly