### PR TITLE
fix: honour process.r_path when spawning workers and builds

### DIFF
--- a/internal/backend/process/process.go
+++ b/internal/backend/process/process.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -215,22 +216,28 @@ func (b *ProcessBackend) Spawn(_ context.Context, spec backend.WorkerSpec) error
 	// the value is set — emitting it here would fire on every spawn
 	// for every app for the lifetime of the deployment.
 
-	// Resolve R version from the bundle manifest. Deploy-time
-	// validation (CheckRVersion) ensures the version is installed,
-	// so a miss here means the operator removed it after deploy.
-	if spec.RVersion != "" && len(spec.Cmd) > 0 && spec.Cmd[0] == "R" {
+	// Resolve R binary path from cfg.RPath (and optionally the bundle
+	// manifest's R version). This ensures operators' process.r_path
+	// setting is honoured — without it, bwrap would resolve a bare
+	// "Rscript" via its limited PATH, failing when R lives at a
+	// non-standard location.
+	if len(spec.Cmd) > 0 && (spec.Cmd[0] == "R" || spec.Cmd[0] == "Rscript") {
 		rPath, fell := ResolveRBinary(spec.RVersion, b.cfg.RPath)
 		if fell {
 			return fmt.Errorf(
 				"r %s was available at deploy time but is no longer installed",
 				spec.RVersion)
 		}
-		slog.Info("resolved R version",
+		resolved := rPath
+		if spec.Cmd[0] == "Rscript" {
+			resolved = filepath.Join(filepath.Dir(rPath), "Rscript")
+		}
+		slog.Info("resolved R binary",
 			"worker_id", spec.WorkerID, "version", spec.RVersion,
-			"path", rPath)
+			"path", resolved)
 		cmd := make([]string, len(spec.Cmd))
 		copy(cmd, spec.Cmd)
-		cmd[0] = rPath
+		cmd[0] = resolved
 		spec.Cmd = cmd
 	}
 
@@ -515,8 +522,8 @@ func (b *ProcessBackend) Addr(_ context.Context, id string) (string, error) {
 }
 
 func (b *ProcessBackend) Build(ctx context.Context, spec backend.BuildSpec) (backend.BuildResult, error) {
-	// Resolve R version so the build uses the same R the worker will.
-	if spec.RVersion != "" && len(spec.Cmd) > 0 && spec.Cmd[0] == "R" {
+	// Resolve R binary path so the build uses the operator-configured R.
+	if len(spec.Cmd) > 0 && (spec.Cmd[0] == "R" || spec.Cmd[0] == "Rscript") {
 		rPath, fell := ResolveRBinary(spec.RVersion, b.cfg.RPath)
 		if fell {
 			return backend.BuildResult{
@@ -527,9 +534,13 @@ func (b *ProcessBackend) Build(ctx context.Context, spec backend.BuildSpec) (bac
 					spec.RVersion),
 			}, nil
 		}
+		resolved := rPath
+		if spec.Cmd[0] == "Rscript" {
+			resolved = filepath.Join(filepath.Dir(rPath), "Rscript")
+		}
 		cmd := make([]string, len(spec.Cmd))
 		copy(cmd, spec.Cmd)
-		cmd[0] = rPath
+		cmd[0] = resolved
 		spec.Cmd = cmd
 	}
 

--- a/internal/backend/process/process_unit_test.go
+++ b/internal/backend/process/process_unit_test.go
@@ -359,6 +359,65 @@ func TestSpawnErrorPathsReleaseSlots(t *testing.T) {
 	}
 }
 
+// TestSpawnResolvesRscriptCmd verifies that Spawn rewrites a bare
+// "Rscript" Cmd[0] using cfg.RPath — the bug that prompted #202.
+func TestSpawnResolvesRscriptCmd(t *testing.T) {
+	dir := setupRigFixture(t, "4.5.0")
+	orig := rigBase
+	defer func() { setRigBase(orig) }()
+	setRigBase(dir)
+
+	b := newFakeBackend(t)
+	// Point RPath at the fixture's default R binary.
+	b.cfg.RPath = "/usr/bin/R"
+
+	// Version that falls through to fallback → Spawn must error.
+	err := b.Spawn(context.Background(), backend.WorkerSpec{
+		WorkerID:    "w-rscript",
+		Cmd:         []string{"Rscript", "/app/app.R"},
+		RVersion:    "3.6.0", // not in fixture
+		BundlePath:  t.TempDir(),
+		WorkerMount: "/tmp/app",
+	})
+	if err == nil || !strings.Contains(err.Error(), "no longer installed") {
+		t.Errorf("expected 'no longer installed' error for missing version, got: %v", err)
+	}
+
+	// Version that resolves → Spawn proceeds past resolution (will
+	// fail later at bwrap, which is fine — the point is it no longer
+	// silently skips the rewrite).
+	err = b.Spawn(context.Background(), backend.WorkerSpec{
+		WorkerID:    "w-rscript-ok",
+		Cmd:         []string{"Rscript", "/app/app.R"},
+		RVersion:    "4.5.0",
+		BundlePath:  t.TempDir(),
+		WorkerMount: "/tmp/app",
+	})
+	// Should fail downstream (bwrap not found), not at R resolution.
+	if err != nil && strings.Contains(err.Error(), "no longer installed") {
+		t.Errorf("unexpected resolution failure for installed version: %v", err)
+	}
+}
+
+// TestSpawnResolvesRscriptWithoutVersion verifies that Spawn rewrites
+// Cmd[0] using cfg.RPath even when no R version is specified.
+func TestSpawnResolvesRscriptWithoutVersion(t *testing.T) {
+	b := newFakeBackend(t)
+	b.cfg.RPath = "/opt/R/4.5/bin/R"
+
+	// No RVersion → should use cfg.RPath as fallback, then fail
+	// downstream (not at resolution).
+	err := b.Spawn(context.Background(), backend.WorkerSpec{
+		WorkerID:    "w-no-version",
+		Cmd:         []string{"Rscript", "/app/app.R"},
+		BundlePath:  t.TempDir(),
+		WorkerMount: "/tmp/app",
+	})
+	if err != nil && strings.Contains(err.Error(), "no longer installed") {
+		t.Errorf("empty RVersion should not trigger fallback error: %v", err)
+	}
+}
+
 // TestSpawnRefusesDuplicateLiveWorker verifies that calling Spawn
 // with a worker ID that's already running returns an error rather
 // than clobbering the live entry.


### PR DESCRIPTION
## Summary
- `BaseWorkerSpec` sets `Cmd[0]` to `"Rscript"`, but `Spawn()` and `Build()` only resolved `cfg.RPath` when `Cmd[0] == "R"` — a condition that never matched
- Workers fell back to bare PATH resolution inside the bwrap sandbox, failing when R lives at a non-standard location (e.g. `/opt/R/4.5/bin/R`)
- Widen the check to match both `"R"` and `"Rscript"`, derive the correct binary name from the resolved R path

Closes #202

## Test plan
- [ ] Tests pass locally
- [ ] CI green