### PR TITLE
Fix r-versions.sh crash on /opt/R/current symlink

### DIFF
--- a/docker/r-versions.sh
+++ b/docker/r-versions.sh
@@ -24,7 +24,7 @@ set -eu
 rig add release
 
 # Derive the current minor version from what rig installed.
-LATEST=$(ls /opt/R | sort -V | tail -1)
+LATEST=$(ls /opt/R | grep '^[0-9]' | sort -V | tail -1)
 MAJOR=${LATEST%%.*}
 MINOR=${LATEST#*.}; MINOR=${MINOR%%.*}
 
@@ -35,7 +35,7 @@ for i in 1 2 3 4; do
 done
 
 # Default to the previous minor for stability.
-PREV=$(ls /opt/R | sort -V | tail -2 | head -1)
+PREV=$(ls /opt/R | grep '^[0-9]' | sort -V | tail -2 | head -1)
 if [ -n "$PREV" ]; then
   rig default "$PREV"
 fi


### PR DESCRIPTION
## Summary
- `rig add release` creates a `current` symlink in `/opt/R` alongside versioned directories
- `ls /opt/R | sort -V | tail -1` picks `current` (sorts after digits), so `MINOR` becomes the string `current` and shell arithmetic fails with "Illegal number: current"
- Filter `ls` output through `grep '^[0-9]'` to only consider versioned directories