### PR TITLE
Restore Trivy linux-libc-dev suppression

### DIFF
--- a/.trivyignore.rego
+++ b/.trivyignore.rego
@@ -1,16 +1,5 @@
 # Trivy ignore policy for blockyard container images.
 #
-# Currently empty — issue #185 replaced the rocker/r-ver base for
-# the server-process and server-everything images with a minimal
-# ubuntu:24.04 + rig build, which drops the compiler toolchain and
-# its transitive dependencies (binutils, libctf*, libgprofng*,
-# linux-libc-dev). That eliminated the kernel-header and binutils
-# CVE noise that previously required per-package suppressions
-# here.
-#
-# If new no-upstream-fix CVEs reappear against runtime libraries
-# we still ship (libpixman-1-0, libexpat1, tar, …), add narrow
-# per-package rules below, each with a one-line rationale.
 # Rule-by-package, not by CVE ID, so future CVEs in the same
 # package silence automatically on every base rebuild.
 
@@ -19,3 +8,9 @@ package trivy
 import rego.v1
 
 default ignore := false
+
+# linux-libc-dev ships kernel header files pulled in transitively
+# by rig's R installation. The CVEs describe running-kernel
+# vulnerabilities — containers use the host kernel, not a kernel
+# built from these headers, so they are not container-exploitable.
+ignore if input.PkgName == "linux-libc-dev"


### PR DESCRIPTION
## Summary
- The rocker-to-rig migration (f507066) dropped the `linux-libc-dev` Trivy filter assuming the package would no longer be present in the image
- rig's R installation pulls `linux-libc-dev` back in as a transitive dependency, causing ~1,150 kernel-header CVE alerts across the two server images
- Restores the per-package suppression rule — kernel CVEs are not container-exploitable