### PR TITLE
fix: copy r-versions.sh in server-everything Dockerfile

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -114,7 +114,7 @@ jobs:
         run: docker compose -f examples/hello-shiny/docker-compose.yml pull --ignore-pull-failures
       - name: Build blockyard image from source
         if: github.event_name != 'pull_request' && github.event_name != 'push'
-        run: docker build -t ghcr.io/cynkra/blockyard:latest --build-arg COVER=1 -f docker/server.Dockerfile .
+        run: docker build -t ghcr.io/cynkra/blockyard:latest -t ghcr.io/cynkra/blockyard:main --build-arg COVER=1 -f docker/server.Dockerfile .
       - name: Block cloud metadata endpoint
         if: github.event_name != 'pull_request' && github.event_name != 'push'
         run: sudo iptables -I DOCKER-USER -d 169.254.169.254/32 -j DROP 2>/dev/null || true

--- a/docker/server-everything.Dockerfile
+++ b/docker/server-everything.Dockerfile
@@ -9,8 +9,8 @@
 # runtime-lib list with server-process.Dockerfile; the only
 # additions here are iptables (for the Docker backend's native
 # egress firewall path) and the broader set of build tags on the
-# Go compile step above. R_VERSION build ARG controls which R
-# version is baked in (default: "release").
+# Go compile step above. R versions are managed by r-versions.sh
+# (same policy as server-process.Dockerfile).
 
 FROM hugomods/hugo:exts-0.147.4 AS docs
 WORKDIR /docs
@@ -57,14 +57,13 @@ RUN CGO_ENABLED=0 go build ${COVER:+-cover} \
     -o /blockyard ./cmd/blockyard
 RUN CGO_ENABLED=0 go build ${COVER:+-cover} -o /by-builder ./cmd/by-builder
 
-# Final stage: ubuntu:24.04 + rig + R release. See the header
-# comment and issue #185 for the rationale. iptables is the only
-# addition over the process-variant image — the Docker backend
-# uses it for worker egress in native mode.
+# Final stage: ubuntu:24.04 + rig + R. See the header comment
+# and issue #185 for the rationale. iptables is the only addition
+# over the process-variant image — the Docker backend uses it for
+# worker egress in native mode.
 FROM ubuntu:24.04
 
 ARG RIG_VERSION=0.7.1
-ARG R_VERSION=release
 ARG TARGETARCH
 
 RUN apt-get update \
@@ -94,10 +93,12 @@ RUN apt-get update \
        esac \
     && curl -fsSL "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}" \
         | tar xz -C /usr/local \
-    && rig add "${R_VERSION}" \
-    && ln -sf /usr/local/bin/R /usr/bin/R \
-    && ln -sf /usr/local/bin/Rscript /usr/bin/Rscript \
     && rm -rf /var/lib/apt/lists/*
+
+COPY docker/r-versions.sh /etc/blockyard/r-versions.sh
+RUN /etc/blockyard/r-versions.sh \
+    && ln -sf /usr/local/bin/R /usr/bin/R \
+    && ln -sf /usr/local/bin/Rscript /usr/bin/Rscript
 
 COPY --from=builder /blockyard /usr/local/bin/blockyard
 COPY --from=builder /by-builder /usr/local/lib/blockyard/by-builder


### PR DESCRIPTION
## Summary
- The `server-everything.Dockerfile` entrypoint calls `/etc/blockyard/r-versions.sh` but the file was never copied into the image, crashing the container on startup
- Replace the inline `rig add "${R_VERSION}"` with the shared `r-versions.sh` policy script, matching `server-process.Dockerfile`
- Remove the unused `R_VERSION` build arg