### PR TITLE
ci: stop running CI and Merge on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
   merge_group:
   workflow_call:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,8 +1,6 @@
 name: Merge
 
 on:
-  push:
-    branches: [main]
   pull_request:
   merge_group:
   workflow_call:


### PR DESCRIPTION
## Summary
- Remove `push: branches: [main]` trigger from CI and Merge workflows
- The merge queue already runs both via `merge_group`, so post-merge runs are redundant
- Remaining triggers (`pull_request`, `merge_group`, `workflow_call`, `workflow_dispatch`) cover all use cases