### PR TITLE
fix: consistent search field layout across views

### DIFF
--- a/internal/ui/templates/deployments.html
+++ b/internal/ui/templates/deployments.html
@@ -4,14 +4,14 @@
 
 {{define "content"}}
 <div class="page-header">
-    <h1>Deployment History</h1>
+    <h1 class="mb-4">Deployment History</h1>
+    <form method="GET" action="/deployments" class="flex gap-2">
+        <input type="search" name="search" placeholder="Search by app name..."
+               class="input input-sm flex-1 text-sm" value="{{.Search}}"
+               oninput="filterDeployments(this.value)">
+        <button type="submit" class="btn btn-soft btn-sm">Search</button>
+    </form>
 </div>
-<form method="GET" action="/deployments" class="flex gap-2 mb-6">
-    <input type="search" name="search" placeholder="Search by app name..."
-           class="input input-sm flex-1 text-sm" value="{{.Search}}"
-           oninput="filterDeployments(this.value)">
-    <button type="submit" class="btn btn-soft btn-sm">Search</button>
-</form>
 {{if .Deployments}}
 <table class="table table-sm w-full">
     <thead>


### PR DESCRIPTION
## Summary
- Move search form inside `page-header` in deployments template to match apps template structure
- Eliminates vertical position jump when switching between Apps and History views
- Both views now use the same `page-header > h1 + form` layout pattern