### PR TITLE
feat: configurable default role for new OIDC users

### DIFF
--- a/docs/content/docs/guides/authorization.md
+++ b/docs/content/docs/guides/authorization.md
@@ -13,6 +13,9 @@ play no role in blockyard's permission model.
 
 Every user has one system-wide role, assigned by a blockyard admin.
 New users get **viewer** by default when they first log in via OIDC.
+Operators who treat the IdP itself as the access gate can change that
+default to **publisher** via `oidc.default_role`; see
+[Default role for new users](#default-role-for-new-users).
 
 | Role | What you can do |
 |---|---|
@@ -35,6 +38,29 @@ When this user logs in for the first time, they receive the `admin`
 role instead of `viewer`. Once an admin exists, they can promote other
 users via the API or admin UI. The `initial_admin` field is only checked
 on first login — changing it later has no effect on existing users.
+
+### Default role for new users
+
+When a new user logs in via OIDC for the first time, they receive the
+role configured by `oidc.default_role` (default: `viewer`). Existing
+users keep whatever role an admin has set; the default is consulted
+only on the INSERT path.
+
+```toml
+[oidc]
+default_role = "publisher"
+```
+
+Use `publisher` when access to the IdP is itself the gate — i.e. only
+trusted team members can authenticate at all, so manually promoting
+each new user to publisher adds friction without adding safety. Use
+`viewer` (the default) for deployments where authenticated users are a
+broader audience and the ability to deploy apps should be granted
+explicitly.
+
+`admin` is rejected at config validation: bootstrapping admins belongs
+to `initial_admin`, and an `admin` default would silently grant full
+control to anyone the IdP admits.
 
 ### Managing Users
 

--- a/docs/content/docs/reference/config.md
+++ b/docs/content/docs/reference/config.md
@@ -275,6 +275,7 @@ client_id            = "blockyard"
 client_secret        = "oidc-client-secret"
 cookie_max_age       = "24h"
 initial_admin        = "google-oauth2|abc123"
+default_role         = "viewer"
 ```
 
 | Field | Type | Default | Required | Description |
@@ -285,6 +286,7 @@ initial_admin        = "google-oauth2|abc123"
 | `client_secret` | `string` | — | **Yes** | OIDC client secret. Supports [vault references](#vault-references). |
 | `cookie_max_age` | `duration` | `24h` | No | Maximum lifetime of session cookies |
 | `initial_admin` | `string` | — | No | OIDC `sub` of the first admin user. Checked only on first login. See [First Admin Setup](/docs/guides/authorization/#first-admin-setup). |
+| `default_role` | `string` | `viewer` | No | Role assigned to new users on first OIDC login. Must be `viewer` or `publisher`. Set to `publisher` when the IdP itself is the access gate and every authenticated user should be trusted to deploy. `admin` is rejected — bootstrap admins via `initial_admin`. |
 
 > [!WARNING]
 > When OIDC is configured, the proxy routes (`/app/{name}/`) enforce

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -994,6 +994,134 @@ func TestCallbackDeactivatedUser(t *testing.T) {
 	}
 }
 
+// runLoginCallback runs one /login + /callback exchange against the
+// given router and returns the response from /callback.
+func runLoginCallback(t *testing.T, router http.Handler, idp *testutil.MockIdP) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/login", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	stateCookie := findCookie(w.Result(), "blockyard_oidc_state")
+	if stateCookie == nil {
+		t.Fatal("login: missing state cookie")
+	}
+	location := w.Header().Get("Location")
+	csrfToken := extractStateParam(location)
+	idp.Nonce = extractNonceParam(location)
+
+	req = httptest.NewRequest("GET", "/callback?code=test-code&state="+csrfToken, nil)
+	req.AddCookie(stateCookie)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func TestCallbackUsesConfiguredDefaultRole(t *testing.T) {
+	idp := testutil.NewMockIdP()
+	defer idp.Close()
+
+	deps := buildTestDeps(t, idp)
+	deps.Config.OIDC.DefaultRole = "publisher"
+
+	database, err := db.Open(config.DatabaseConfig{Driver: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	deps.DB = database
+
+	router := buildTestRouter(deps)
+
+	w := runLoginCallback(t, router, idp)
+	if w.Code != http.StatusFound {
+		t.Fatalf("callback: expected 302, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	user, err := database.GetUser("test-sub")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if user == nil {
+		t.Fatal("expected user to be created on first login")
+	}
+	if user.Role != "publisher" {
+		t.Errorf("first-login role = %q, want publisher (from oidc.default_role)", user.Role)
+	}
+}
+
+func TestCallbackPreservesExistingRoleOnSubsequentLogin(t *testing.T) {
+	idp := testutil.NewMockIdP()
+	defer idp.Close()
+
+	deps := buildTestDeps(t, idp)
+	deps.Config.OIDC.DefaultRole = "publisher"
+
+	database, err := db.Open(config.DatabaseConfig{Driver: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	deps.DB = database
+
+	// Pre-existing user with viewer role (e.g. demoted by an admin).
+	if _, err := database.UpsertUserWithRole("test-sub", "test@example.com", "Test User", "viewer"); err != nil {
+		t.Fatal(err)
+	}
+
+	router := buildTestRouter(deps)
+
+	w := runLoginCallback(t, router, idp)
+	if w.Code != http.StatusFound {
+		t.Fatalf("callback: expected 302, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	user, err := database.GetUser("test-sub")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if user == nil {
+		t.Fatal("user disappeared")
+	}
+	if user.Role != "viewer" {
+		t.Errorf("subsequent-login role = %q, want preserved viewer", user.Role)
+	}
+}
+
+func TestCallbackInitialAdminOverridesDefaultRole(t *testing.T) {
+	idp := testutil.NewMockIdP()
+	defer idp.Close()
+
+	deps := buildTestDeps(t, idp)
+	deps.Config.OIDC.DefaultRole = "publisher"
+	deps.Config.OIDC.InitialAdmin = "test-sub"
+
+	database, err := db.Open(config.DatabaseConfig{Driver: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	deps.DB = database
+
+	router := buildTestRouter(deps)
+
+	w := runLoginCallback(t, router, idp)
+	if w.Code != http.StatusFound {
+		t.Fatalf("callback: expected 302, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	user, err := database.GetUser("test-sub")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if user == nil {
+		t.Fatal("expected user to be created on first login")
+	}
+	if user.Role != "admin" {
+		t.Errorf("initial_admin role = %q, want admin (must override default_role)", user.Role)
+	}
+}
+
 // TestFullLoginCallbackMiddlewareFlow verifies the complete chain:
 // GET /login → callback with state cookie → session cookie set →
 // middleware recognises session cookie → user is authenticated.

--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -42,6 +42,17 @@ type Deps struct {
 	DB           *db.DB
 }
 
+// defaultUserRole returns the role to assign to a brand-new OIDC user.
+// Falls back to "viewer" when oidc is nil or default_role is unset; in
+// production both are populated by [config.Load], so the fallback only
+// matters for tests that build OidcConfig by hand.
+func defaultUserRole(c *config.OidcConfig) string {
+	if c == nil || c.DefaultRole == "" {
+		return "viewer"
+	}
+	return c.DefaultRole
+}
+
 // secureFlag returns "; Secure" if external_url is HTTPS, empty
 // string otherwise.
 func secureFlag(cfg *config.Config) string {
@@ -235,26 +246,16 @@ func CallbackHandler(deps *Deps) http.HandlerFunc {
 			}
 		}
 
-		// 5. Upsert user in database.
+		// 5. Upsert user in database. The role is only used on INSERT;
+		// existing users keep whatever role an admin assigned them
+		// (UpsertUserWithRole's ON CONFLICT clause does not touch role).
 		if deps.DB != nil {
-			// Check if this is the initial_admin on first login.
+			role := defaultUserRole(deps.Config.OIDC)
 			if deps.Config.OIDC != nil && deps.Config.OIDC.InitialAdmin == subClaim {
-				existing, _ := deps.DB.GetUser(subClaim)
-				if existing == nil {
-					// First login — create as admin.
-					if _, err := deps.DB.UpsertUserWithRole(subClaim, emailClaim, nameClaim, "admin"); err != nil {
-						slog.Error("failed to upsert initial admin", "sub", subClaim, "error", err)
-					}
-				} else {
-					// Already exists — just update login info.
-					if _, err := deps.DB.UpsertUser(subClaim, emailClaim, nameClaim); err != nil {
-						slog.Error("failed to upsert user", "sub", subClaim, "error", err)
-					}
-				}
-			} else {
-				if _, err := deps.DB.UpsertUser(subClaim, emailClaim, nameClaim); err != nil {
-					slog.Error("failed to upsert user", "sub", subClaim, "error", err)
-				}
+				role = "admin"
+			}
+			if _, err := deps.DB.UpsertUserWithRole(subClaim, emailClaim, nameClaim, role); err != nil {
+				slog.Error("failed to upsert user", "sub", subClaim, "error", err)
 			}
 
 			// Check if user is active.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -168,6 +168,7 @@ type OidcConfig struct {
 	ClientSecret      Secret   `toml:"client_secret"`
 	CookieMaxAge      Duration `toml:"cookie_max_age"`
 	InitialAdmin      string   `toml:"initial_admin"`
+	DefaultRole       string   `toml:"default_role"` // role assigned on first login: "viewer" (default) or "publisher"
 }
 
 type OpenbaoConfig struct {
@@ -358,6 +359,9 @@ func redisDefaults(c *RedisConfig) {
 func oidcDefaults(c *OidcConfig) {
 	if c.CookieMaxAge.Duration == 0 {
 		c.CookieMaxAge.Duration = 24 * time.Hour
+	}
+	if c.DefaultRole == "" {
+		c.DefaultRole = "viewer"
 	}
 }
 
@@ -666,6 +670,11 @@ func validate(cfg *Config) error {
 			if cfg.Server.SessionSecret == nil || cfg.Server.SessionSecret.IsEmpty() {
 				return fmt.Errorf("config: server.session_secret is required when [oidc] is configured without [openbao]")
 			}
+		}
+		switch cfg.OIDC.DefaultRole {
+		case "viewer", "publisher":
+		default:
+			return fmt.Errorf(`config: oidc.default_role must be "viewer" or "publisher", got %q`, cfg.OIDC.DefaultRole)
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -507,6 +507,51 @@ func TestParseOidcConfig(t *testing.T) {
 	if cfg.OIDC.CookieMaxAge.Duration != 24*time.Hour {
 		t.Errorf("expected default cookie_max_age 24h, got %v", cfg.OIDC.CookieMaxAge.Duration)
 	}
+	if cfg.OIDC.DefaultRole != "viewer" {
+		t.Errorf("expected default_role viewer, got %q", cfg.OIDC.DefaultRole)
+	}
+}
+
+func TestOidcDefaultRolePublisher(t *testing.T) {
+	toml := oidcTOML(t) + "default_role = \"publisher\"\n"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "blockyard.toml")
+	if err := os.WriteFile(path, []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("expected publisher to be accepted, got: %v", err)
+	}
+	if cfg.OIDC.DefaultRole != "publisher" {
+		t.Errorf("default_role = %q, want publisher", cfg.OIDC.DefaultRole)
+	}
+}
+
+func TestOidcDefaultRoleRejectsAdmin(t *testing.T) {
+	toml := oidcTOML(t) + "default_role = \"admin\"\n"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "blockyard.toml")
+	if err := os.WriteFile(path, []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(path)
+	if err == nil || !strings.Contains(err.Error(), "oidc.default_role") {
+		t.Errorf("expected oidc.default_role error, got: %v", err)
+	}
+}
+
+func TestOidcDefaultRoleRejectsUnknown(t *testing.T) {
+	toml := oidcTOML(t) + "default_role = \"editor\"\n"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "blockyard.toml")
+	if err := os.WriteFile(path, []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(path)
+	if err == nil || !strings.Contains(err.Error(), "oidc.default_role") {
+		t.Errorf("expected oidc.default_role error, got: %v", err)
+	}
 }
 
 func TestParseConfigWithoutOidc(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `oidc.default_role` (default `viewer`); validates to `viewer` or `publisher` and rejects `admin`
- `CallbackHandler` threads the configured role through `UpsertUserWithRole` on first login; existing users' roles are still preserved by the `ON CONFLICT` clause
- `initial_admin` still wins over `default_role`

Closes #218