### PR TITLE
Label proxy, health, and worker metrics for ops dashboards

### DIFF
--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cynkra/blockyard/internal/ops"
 	"github.com/cynkra/blockyard/internal/server"
 	"github.com/cynkra/blockyard/internal/task"
+	"github.com/cynkra/blockyard/internal/telemetry"
 	"github.com/cynkra/blockyard/internal/units"
 )
 
@@ -1017,7 +1018,7 @@ func drainWorkers(srv *server.Server, appID string, workerIDs []string, sender t
 	}
 
 	for _, wid := range workerIDs {
-		ops.EvictWorker(context.Background(), srv, wid)
+		ops.EvictWorker(context.Background(), srv, wid, telemetry.ReasonGraceful)
 		sender.Write(fmt.Sprintf("stopped worker %s", wid))
 	}
 	sender.Write(fmt.Sprintf("stopped %d workers", len(workerIDs)))

--- a/internal/api/runtime.go
+++ b/internal/api/runtime.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cynkra/blockyard/internal/db"
 	"github.com/cynkra/blockyard/internal/ops"
 	"github.com/cynkra/blockyard/internal/server"
+	"github.com/cynkra/blockyard/internal/telemetry"
 )
 
 // runtimeWorker is the JSON shape for a worker in the runtime response.
@@ -499,7 +500,7 @@ func DisableApp(srv *server.Server) http.HandlerFunc {
 					time.Sleep(time.Second)
 				}
 				for _, wid := range workerIDs {
-					ops.EvictWorker(context.Background(), srv, wid)
+					ops.EvictWorker(context.Background(), srv, wid, telemetry.ReasonGraceful)
 				}
 			}()
 		}

--- a/internal/backend/process/preflight.go
+++ b/internal/backend/process/preflight.go
@@ -254,10 +254,13 @@ func checkBwrapHostUIDMapping(cfg *config.ProcessConfig) preflight.Result {
 	// the bwrap pid is sufficient.
 	//
 	// The first successful read may catch bwrap before it has written
-	// the uid_map (the real UID still shows the caller's UID). Keep
-	// polling while the observed UID matches the caller — namespace
-	// setup is still in progress.
+	// uid_map/gid_map (the real UID still shows the caller's UID).
+	// bwrap writes uid_map and gid_map as two separate syscalls, so
+	// there is also a window where UID has been remapped but GID has
+	// not. Keep polling while EITHER UID or GID still reads as the
+	// caller's — namespace setup is still in progress. Fixes #233.
 	callerUID := os.Getuid()
+	callerGID := os.Getgid()
 	var uidLine, gidLine string
 	deadline := time.Now().Add(1 * time.Second)
 	for time.Now().Before(deadline) {
@@ -274,12 +277,13 @@ func checkBwrapHostUIDMapping(cfg *config.ProcessConfig) preflight.Result {
 			}
 			if curUID != "" && curGID != "" {
 				hostUID, _ := parseStatusUID(curUID)
-				if hostUID != callerUID {
+				hostGID, _ := parseStatusUID(curGID)
+				if hostUID != callerUID && hostGID != callerGID {
 					uidLine = curUID
 					gidLine = curGID
 					break
 				}
-				// Still showing caller's UID — namespace
+				// Still showing caller's UID or GID — namespace
 				// setup in progress, keep polling.
 				uidLine = curUID
 				gidLine = curGID

--- a/internal/ops/ops.go
+++ b/internal/ops/ops.go
@@ -10,22 +10,26 @@ import (
 	"time"
 
 	"github.com/cynkra/blockyard/internal/server"
+	"github.com/cynkra/blockyard/internal/telemetry"
 )
 
 // EvictWorker is the single codepath for decommissioning a worker.
 // Idempotent — safe to call concurrently from multiple goroutines.
-func EvictWorker(ctx context.Context, srv *server.Server, workerID string) {
+// reason is recorded in the blockyard_workers_stopped_total metric
+// and must be one of the telemetry.Reason* constants.
+func EvictWorker(ctx context.Context, srv *server.Server, workerID, reason string) {
 	w, found := srv.Workers.Get(workerID)
 	srv.Workers.Delete(workerID)
 	if found {
 		// Cancel the token refresher goroutine.
 		srv.CancelTokenRefresher(workerID)
-		slog.Info("evicting worker", "worker_id", workerID, "app_id", w.AppID)
+		slog.Info("evicting worker",
+			"worker_id", workerID, "app_id", w.AppID, "reason", reason)
 		if err := srv.Backend.Stop(ctx, workerID); err != nil {
 			slog.Warn("evict: failed to stop worker",
 				"worker_id", workerID, "error", err)
 		}
-		srv.Metrics.WorkersStopped.Inc()
+		srv.Metrics.WorkersStopped.WithLabelValues(reason).Inc()
 		srv.Metrics.WorkersActive.Dec()
 	}
 	sessionCount := srv.Sessions.CountForWorkers([]string{workerID})
@@ -163,6 +167,22 @@ func StartupCleanup(ctx context.Context, srv *server.Server, passive bool) error
 
 const maxMisses = 2
 
+// appLabelForWorker returns the app name for the given worker, or
+// telemetry.AppUnknown if the worker/app cannot be resolved. Used for
+// labelling per-worker metrics (health-check failures) with a human
+// readable app name rather than an opaque ID.
+func appLabelForWorker(srv *server.Server, workerID string) string {
+	w, ok := srv.Workers.Get(workerID)
+	if !ok {
+		return telemetry.AppUnknown
+	}
+	app, err := srv.DB.GetApp(w.AppID)
+	if err != nil || app == nil {
+		return telemetry.AppUnknown
+	}
+	return app.Name
+}
+
 // evictDrainedWorkers checks draining workers and evicts those with
 // zero active sessions. Called from the health poller tick.
 func evictDrainedWorkers(ctx context.Context, srv *server.Server) {
@@ -174,7 +194,7 @@ func evictDrainedWorkers(ctx context.Context, srv *server.Server) {
 		if srv.Sessions.CountForWorker(wid) == 0 {
 			slog.Info("evicting drained worker with zero sessions",
 				"worker_id", wid, "app_id", w.AppID)
-			EvictWorker(ctx, srv, wid)
+			EvictWorker(ctx, srv, wid, telemetry.ReasonGraceful)
 		}
 	}
 }
@@ -223,13 +243,13 @@ func pollOnce(ctx context.Context, srv *server.Server, misses map[string]int) {
 			slog.Warn("health poller: evicting unhealthy worker",
 				"worker_id", r.workerID,
 				"consecutive_misses", misses[r.workerID])
-			srv.Metrics.HealthChecksFailed.Inc()
+			srv.Metrics.HealthChecksFailed.WithLabelValues(appLabelForWorker(srv, r.workerID)).Inc()
 			// Mark sessions as crashed before eviction (which marks them as ended).
 			if err := srv.DB.CrashWorkerSessions(r.workerID); err != nil {
 				slog.Warn("health poller: failed to crash worker sessions",
 					"worker_id", r.workerID, "error", err)
 			}
-			EvictWorker(ctx, srv, r.workerID)
+			EvictWorker(ctx, srv, r.workerID, telemetry.ReasonCrashed)
 			delete(misses, r.workerID)
 		}
 	}
@@ -327,7 +347,7 @@ func drainAndEvictAll(ctx context.Context, srv *server.Server, workerIDs []strin
 			defer wg.Done()
 			evictCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 			defer cancel()
-			EvictWorker(evictCtx, srv, id)
+			EvictWorker(evictCtx, srv, id, telemetry.ReasonGraceful)
 		}(wid)
 	}
 	wg.Wait()
@@ -378,7 +398,7 @@ func StopAppSync(srv *server.Server, appID string) {
 	}
 
 	for _, wid := range workerIDs {
-		EvictWorker(context.Background(), srv, wid)
+		EvictWorker(context.Background(), srv, wid, telemetry.ReasonGraceful)
 	}
 }
 

--- a/internal/ops/ops_test.go
+++ b/internal/ops/ops_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cynkra/blockyard/internal/pkgstore"
 	"github.com/cynkra/blockyard/internal/server"
 	"github.com/cynkra/blockyard/internal/session"
+	"github.com/cynkra/blockyard/internal/telemetry"
 )
 
 func testServer(t *testing.T) (*server.Server, *mock.MockBackend) {
@@ -61,7 +62,7 @@ func TestEvictWorker(t *testing.T) {
 	srv.Sessions.Set("sess1", session.Entry{WorkerID: "w1"})
 	srv.LogStore.Create("w1", "app1")
 
-	EvictWorker(context.Background(), srv, "w1")
+	EvictWorker(context.Background(), srv, "w1", telemetry.ReasonGraceful)
 
 	if _, ok := srv.Workers.Get("w1"); ok {
 		t.Error("worker should be removed from WorkerMap")
@@ -84,8 +85,8 @@ func TestEvictWorkerIdempotent(t *testing.T) {
 	srv, be := testServer(t)
 	spawnWorker(t, srv, be, "w1", "app1")
 
-	EvictWorker(context.Background(), srv, "w1")
-	EvictWorker(context.Background(), srv, "w1") // must not panic
+	EvictWorker(context.Background(), srv, "w1", telemetry.ReasonGraceful)
+	EvictWorker(context.Background(), srv, "w1", telemetry.ReasonCrashed) // must not panic
 }
 
 func TestEvictWorkerCleansUpPkgStore(t *testing.T) {
@@ -101,7 +102,7 @@ func TestEvictWorkerCleansUpPkgStore(t *testing.T) {
 	os.MkdirAll(workerLib, 0o755)
 	os.WriteFile(filepath.Join(workerLib, "marker"), []byte("x"), 0o644)
 
-	EvictWorker(context.Background(), srv, "w1")
+	EvictWorker(context.Background(), srv, "w1", telemetry.ReasonGraceful)
 
 	// Worker library should be removed.
 	if _, err := os.Stat(workerLib); !os.IsNotExist(err) {
@@ -249,7 +250,7 @@ func TestEvictWorkerCleansUpTransferAndToken(t *testing.T) {
 	os.MkdirAll(tokenDir, 0o755)
 	os.WriteFile(filepath.Join(tokenDir, "token"), []byte("tok"), 0o644)
 
-	EvictWorker(context.Background(), srv, "w1")
+	EvictWorker(context.Background(), srv, "w1", telemetry.ReasonGraceful)
 
 	if _, err := os.Stat(transferDir); !os.IsNotExist(err) {
 		t.Error("transfer dir should be removed after eviction")

--- a/internal/proxy/autoscaler.go
+++ b/internal/proxy/autoscaler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cynkra/blockyard/internal/db"
 	"github.com/cynkra/blockyard/internal/ops"
 	"github.com/cynkra/blockyard/internal/server"
+	"github.com/cynkra/blockyard/internal/telemetry"
 )
 
 // RunAutoscaler runs as a background goroutine alongside health polling.
@@ -66,7 +67,7 @@ func autoscaleTick(ctx context.Context, srv *server.Server) {
 	for _, wid := range idle {
 		slog.Info("autoscaler: evicting idle worker",
 			"worker_id", wid, "idle_for", idleWorkerTimeout)
-		ops.EvictWorker(ctx, srv, wid)
+		ops.EvictWorker(ctx, srv, wid, telemetry.ReasonIdleTimeout)
 	}
 
 	appIDs := srv.Workers.AppIDs()
@@ -111,6 +112,36 @@ func autoscaleTick(ctx context.Context, srv *server.Server) {
 	if err := srv.DB.CleanupExpiredRedirects(); err != nil {
 		slog.Error("autoscaler: redirect cleanup failed", "error", err)
 	}
+
+	// Refresh the workers-by-state gauge from the (now reconciled)
+	// worker map. Doing this last ensures the snapshot reflects
+	// evictions and idle marks applied earlier in the tick.
+	reconcileWorkersByState(srv)
+}
+
+// reconcileWorkersByState sets blockyard_workers{state=…} to the
+// current count of workers in each state. Called from the autoscaler
+// tick; derives state from ActiveWorker.Draining and per-worker
+// session counts rather than tracking explicit transitions.
+func reconcileWorkersByState(srv *server.Server) {
+	var busy, idle, draining float64
+	for _, wid := range srv.Workers.All() {
+		w, ok := srv.Workers.Get(wid)
+		if !ok {
+			continue
+		}
+		switch {
+		case w.Draining:
+			draining++
+		case srv.Sessions.CountForWorker(wid) > 0:
+			busy++
+		default:
+			idle++
+		}
+	}
+	srv.Metrics.WorkersByState.WithLabelValues(telemetry.StateBusy).Set(busy)
+	srv.Metrics.WorkersByState.WithLabelValues(telemetry.StateIdle).Set(idle)
+	srv.Metrics.WorkersByState.WithLabelValues(telemetry.StateDraining).Set(draining)
 }
 
 // evictUnhealthy checks each worker's health and evicts any that have
@@ -122,7 +153,7 @@ func evictUnhealthy(ctx context.Context, srv *server.Server, workerIDs []string)
 			healthy = append(healthy, wid)
 		} else {
 			slog.Warn("autoscaler: evicting crashed worker", "worker_id", wid)
-			ops.EvictWorker(ctx, srv, wid)
+			ops.EvictWorker(ctx, srv, wid, telemetry.ReasonCrashed)
 		}
 	}
 	return healthy

--- a/internal/proxy/coldstart.go
+++ b/internal/proxy/coldstart.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cynkra/blockyard/internal/ops"
 	"github.com/cynkra/blockyard/internal/pkgstore"
 	"github.com/cynkra/blockyard/internal/server"
+	"github.com/cynkra/blockyard/internal/telemetry"
 )
 
 var (
@@ -113,7 +114,7 @@ func ensureWorker(ctx context.Context, srv *server.Server, app *db.AppRow) (work
 		}
 		// Worker unreachable — evict and fall through to spawn.
 		slog.Warn("evicting stale worker", "worker_id", wid, "error", addrErr)
-		ops.EvictWorker(ctx, srv, wid)
+		ops.EvictWorker(ctx, srv, wid, telemetry.ReasonCrashed)
 	}
 
 	// No worker with capacity — spawn a new one.

--- a/internal/proxy/metrics_integration_test.go
+++ b/internal/proxy/metrics_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cynkra/blockyard/internal/backend/mock"
 	"github.com/cynkra/blockyard/internal/ops"
 	"github.com/cynkra/blockyard/internal/server"
+	"github.com/cynkra/blockyard/internal/telemetry"
 	"github.com/cynkra/blockyard/internal/testutil"
 )
 
@@ -55,7 +56,8 @@ func TestMetricsProxyRequestCounter(t *testing.T) {
 	srv, ts := testProxyServer(t)
 	createAndStartApp(t, ts, "metrics-app")
 
-	beforeCount := counterValue(srv.Metrics.ProxyRequests)
+	ok2xx := srv.Metrics.ProxyRequests.WithLabelValues("metrics-app", "2xx")
+	beforeCount := counterValue(ok2xx)
 	beforeHist := histogramCount(srv.Metrics.ProxyRequestDuration)
 
 	// Two requests
@@ -75,11 +77,11 @@ func TestMetricsProxyRequestCounter(t *testing.T) {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
 
-	afterCount := counterValue(srv.Metrics.ProxyRequests)
+	afterCount := counterValue(ok2xx)
 	afterHist := histogramCount(srv.Metrics.ProxyRequestDuration)
 
 	if delta := afterCount - beforeCount; delta != 2 {
-		t.Errorf("expected proxy_requests_total to increase by 2, got %v", delta)
+		t.Errorf("expected proxy_requests_total{app=metrics-app,status=2xx} +2, got %v", delta)
 	}
 	if delta := afterHist - beforeHist; delta != 2 {
 		t.Errorf("expected proxy_request_seconds observation count to increase by 2, got %v", delta)
@@ -171,14 +173,15 @@ func TestMetricsSessionActive(t *testing.T) {
 
 	// Evict the worker directly — sessions_active should drop
 	beforeEvict := gaugeValue(srv.Metrics.SessionsActive)
-	beforeStopped := counterValue(srv.Metrics.WorkersStopped)
+	stoppedGraceful := srv.Metrics.WorkersStopped.WithLabelValues(telemetry.ReasonGraceful)
+	beforeStopped := counterValue(stoppedGraceful)
 
 	workerIDs := srv.Workers.All()
 	if len(workerIDs) == 0 {
 		t.Fatal("expected at least one worker to evict")
 	}
 	for _, wid := range workerIDs {
-		ops.EvictWorker(context.Background(), srv, wid)
+		ops.EvictWorker(context.Background(), srv, wid, telemetry.ReasonGraceful)
 	}
 
 	afterEvict := gaugeValue(srv.Metrics.SessionsActive)
@@ -187,9 +190,9 @@ func TestMetricsSessionActive(t *testing.T) {
 			beforeEvict, afterEvict)
 	}
 
-	afterStopped := counterValue(srv.Metrics.WorkersStopped)
+	afterStopped := counterValue(stoppedGraceful)
 	if delta := afterStopped - beforeStopped; delta < 1 {
-		t.Errorf("expected workers_stopped_total +1 after eviction, got %v", delta)
+		t.Errorf("expected workers_stopped_total{reason=graceful} +1 after eviction, got %v", delta)
 	}
 }
 
@@ -235,7 +238,9 @@ func TestMetricsWebSocketRequest(t *testing.T) {
 	srv.Backend.(*mock.MockBackend).SetWSHandler(wsEchoHandler())
 	createAndStartApp(t, ts, "ws-metrics")
 
-	beforeCount := counterValue(srv.Metrics.ProxyRequests)
+	// WebSocket upgrades complete with HTTP 101 → 1xx class.
+	wsCounter := srv.Metrics.ProxyRequests.WithLabelValues("ws-metrics", "1xx")
+	beforeCount := counterValue(wsCounter)
 
 	ctx := context.Background()
 	wsURL := strings.Replace(ts.URL, "http://", "ws://", 1) +
@@ -259,19 +264,21 @@ func TestMetricsWebSocketRequest(t *testing.T) {
 
 	conn.Close(websocket.StatusNormalClosure, "done")
 
-	afterCount := counterValue(srv.Metrics.ProxyRequests)
+	afterCount := counterValue(wsCounter)
 	if delta := afterCount - beforeCount; delta < 1 {
-		t.Errorf("expected proxy_requests_total to increase for WebSocket, got %v", delta)
+		t.Errorf("expected proxy_requests_total{app=ws-metrics,status=1xx} to increase for WebSocket, got %v", delta)
 	}
 }
 
-// TestMetricsNotFoundDoesNotRecordDuration verifies that requests for
-// non-existent apps still increment proxy_requests_total (the counter
-// fires at the top of the handler) but the request returns 404.
+// TestMetricsNotFoundStillCounts verifies that requests for non-existent
+// apps still increment proxy_requests_total — under the
+// app="unknown",status="4xx" label combination, since we deliberately
+// don't echo the requested name into the label (cardinality bound).
 func TestMetricsNotFoundStillCounts(t *testing.T) {
 	srv, ts := testProxyServer(t)
 
-	before := counterValue(srv.Metrics.ProxyRequests)
+	notFound := srv.Metrics.ProxyRequests.WithLabelValues(telemetry.AppUnknown, "4xx")
+	before := counterValue(notFound)
 
 	resp, err := http.Get(ts.URL + "/app/no-such-app/")
 	if err != nil {
@@ -281,9 +288,9 @@ func TestMetricsNotFoundStillCounts(t *testing.T) {
 		t.Fatalf("expected 404, got %d", resp.StatusCode)
 	}
 
-	after := counterValue(srv.Metrics.ProxyRequests)
+	after := counterValue(notFound)
 	if delta := after - before; delta != 1 {
-		t.Errorf("expected proxy_requests_total +1 even for 404, got %v", delta)
+		t.Errorf("expected proxy_requests_total{app=unknown,status=4xx} +1 for 404, got %v", delta)
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cynkra/blockyard/internal/authz"
 	"github.com/cynkra/blockyard/internal/server"
 	"github.com/cynkra/blockyard/internal/session"
+	"github.com/cynkra/blockyard/internal/telemetry"
 )
 
 // Handler returns an http.Handler that proxies requests to Shiny app
@@ -43,7 +44,25 @@ func Handler(srv *server.Server) http.Handler {
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		srv.Metrics.ProxyRequests.Inc()
+		// Record blockyard_proxy_requests_total once per request, the
+		// moment the response status is decided. Capturing appLabel by
+		// reference (it starts as "unknown" and is overwritten when
+		// the app is resolved) means the increment uses whatever name
+		// was known at status-decision time — "unknown" for 404s and
+		// bad URLs, the app name for everything else. This bounds
+		// cardinality against arbitrary inbound paths.
+		appLabel := telemetry.AppUnknown
+		rec := newStatusRecorder(w, func(code int) {
+			srv.Metrics.ProxyRequests.
+				WithLabelValues(appLabel, telemetry.ProxyStatusClass(code)).
+				Inc()
+		})
+		w = rec
+		// Defensive: if the handler returns without ever writing a
+		// status (no http.Error / Redirect / Write), still record one
+		// sample so the counter never silently misses requests.
+		defer rec.fireDefault()
+
 		appName := chi.URLParam(r, "name")
 
 		// 1. Look up app by ID (UUID) first, then by name.
@@ -72,6 +91,7 @@ func Handler(srv *server.Server) http.Handler {
 				return
 			}
 			if app != nil && phase == "redirect" {
+				appLabel = app.Name
 				newPath := "/app/" + app.Name + "/"
 				if rest := chi.URLParam(r, "*"); rest != "" {
 					newPath += rest
@@ -84,6 +104,7 @@ func Handler(srv *server.Server) http.Handler {
 			http.Error(w, "app not found", http.StatusNotFound)
 			return
 		}
+		appLabel = app.Name
 
 		// Reject requests to disabled apps before session routing.
 		if !app.Enabled {

--- a/internal/proxy/recorder.go
+++ b/internal/proxy/recorder.go
@@ -1,0 +1,70 @@
+package proxy
+
+import (
+	"net/http"
+	"sync"
+)
+
+// statusRecorder wraps http.ResponseWriter and fires onStatus exactly
+// once, the moment the response status is decided (first WriteHeader
+// or first Write — net/http defaults Write-before-WriteHeader to 200).
+//
+// Firing on status decision rather than on handler return matters for
+// long-lived responses: a hijacked WebSocket can stay open for hours,
+// so a deferred-at-handler-exit increment would leave
+// blockyard_proxy_requests_total stale until the client disconnects.
+//
+// Hijack and Flush are deliberately NOT implemented directly. Callers
+// (coder/websocket, httputil.ReverseProxy) walk the wrapper chain via
+// Unwrap and pick up the underlying writer's implementations.
+// Implementing Hijack here would short-circuit that walk and force us
+// to walk the inner chain ourselves — easy to get wrong because the
+// api router wraps with another middleware that does not implement
+// Hijack, so a naive type assertion fails there.
+type statusRecorder struct {
+	http.ResponseWriter
+	status   int
+	once     sync.Once
+	onStatus func(code int)
+}
+
+func newStatusRecorder(w http.ResponseWriter, onStatus func(code int)) *statusRecorder {
+	return &statusRecorder{
+		ResponseWriter: w,
+		status:         http.StatusOK,
+		onStatus:       onStatus,
+	}
+}
+
+func (s *statusRecorder) WriteHeader(code int) {
+	s.fire(code)
+	s.ResponseWriter.WriteHeader(code)
+}
+
+func (s *statusRecorder) Write(b []byte) (int, error) {
+	// net/http treats a Write before WriteHeader as an implicit 200.
+	s.fire(http.StatusOK)
+	return s.ResponseWriter.Write(b)
+}
+
+// fireDefault records http.StatusOK if no real status was ever
+// written. The handler defers this so a request that never produces
+// a response (panic recovered upstream, hijack without WriteHeader,
+// etc.) still contributes one sample.
+func (s *statusRecorder) fireDefault() {
+	s.fire(http.StatusOK)
+}
+
+func (s *statusRecorder) fire(code int) {
+	s.once.Do(func() {
+		s.status = code
+		s.onStatus(code)
+	})
+}
+
+// Unwrap lets http.ResponseController and the coder/websocket
+// hijacker walk past us to the underlying writer's optional methods
+// (Hijack, SetReadDeadline, Flush, …).
+func (s *statusRecorder) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter
+}

--- a/internal/server/refresh_docker_test.go
+++ b/internal/server/refresh_docker_test.go
@@ -87,8 +87,8 @@ func setupDockerServer(t *testing.T) *server.Server {
 		Tasks:    task.NewStore(),
 		LogStore: logstore.NewStore(),
 		PkgStore: pkgstore.NewStore(storeRoot),
-		EvictWorkerFn: func(ctx context.Context, srv *server.Server, workerID string) {
-			ops.EvictWorker(ctx, srv, workerID)
+		EvictWorkerFn: func(ctx context.Context, srv *server.Server, workerID, reason string) {
+			ops.EvictWorker(ctx, srv, workerID, reason)
 		},
 	}
 

--- a/internal/server/state.go
+++ b/internal/server/state.go
@@ -114,7 +114,7 @@ type Server struct {
 
 	// Hooks for operations that would cause import cycles if called
 	// directly from server. Set during initialization in main().
-	EvictWorkerFn    func(ctx context.Context, srv *Server, workerID string)
+	EvictWorkerFn    func(ctx context.Context, srv *Server, workerID, reason string)
 	SpawnLogCaptureFn func(ctx context.Context, srv *Server, workerID, appID string)
 }
 

--- a/internal/server/transfer.go
+++ b/internal/server/transfer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cynkra/blockyard/internal/db"
 	"github.com/cynkra/blockyard/internal/mount"
 	"github.com/cynkra/blockyard/internal/pkgstore"
+	"github.com/cynkra/blockyard/internal/telemetry"
 )
 
 // TransferDir returns the host-side transfer directory for a worker.
@@ -190,7 +191,7 @@ func (srv *Server) completeTransfer(
 	srv.Sessions.RerouteWorker(oldWorkerID, newWorkerID)
 
 	// Evict old worker and clean up its transfer directory.
-	srv.EvictWorkerFn(ctx, srv, oldWorkerID)
+	srv.EvictWorkerFn(ctx, srv, oldWorkerID, telemetry.ReasonGraceful)
 	os.RemoveAll(transferDir) //nolint:errcheck
 
 	slog.Info("transfer complete",

--- a/internal/server/transfer_test.go
+++ b/internal/server/transfer_test.go
@@ -126,7 +126,7 @@ func testServerWithMock(t *testing.T) (*Server, *mock.MockBackend) {
 		Tasks:    task.NewStore(),
 		LogStore: logstore.NewStore(),
 		PkgStore: pkgstore.NewStore(storeRoot),
-		EvictWorkerFn: func(_ context.Context, _ *Server, _ string) {},
+		EvictWorkerFn: func(_ context.Context, _ *Server, _, _ string) {},
 	}
 
 	return srv, be

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -5,6 +5,50 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+// Reason labels for blockyard_workers_stopped_total. Keep the set small
+// and bounded — cardinality is #reasons, shared across all apps.
+const (
+	ReasonGraceful    = "graceful"     // shutdown, app stop/disable, drain completed
+	ReasonCrashed     = "crashed"      // health check failed or backend unreachable
+	ReasonIdleTimeout = "idle_timeout" // autoscaler evicted an idle worker
+)
+
+// State labels for blockyard_workers gauge. Bounded and shared across
+// all apps. States are derived from ActiveWorker fields on each
+// reconciliation tick rather than tracked as explicit transitions, so
+// "starting" and "crashed" (both transient) are not represented —
+// workers only appear in the gauge once WorkersActive sees them, and
+// disappear the moment they're evicted.
+const (
+	StateBusy     = "busy"     // has one or more active sessions
+	StateIdle     = "idle"     // session count is zero, not draining
+	StateDraining = "draining" // marked for drain; no new sessions routed
+)
+
+// AppUnknown is the label value used for proxy requests that do not
+// resolve to an app (e.g. 404 on an unknown name). Using a sentinel
+// keeps cardinality bounded against arbitrary URL paths.
+const AppUnknown = "unknown"
+
+// ProxyStatusClass returns the "Nxx" status class for an HTTP status
+// code. Bucketing to classes (rather than raw codes) keeps label
+// cardinality bounded — upstream apps and proxies emit long-tail codes
+// (418, 499, 520, …) that would otherwise create a new series each.
+func ProxyStatusClass(code int) string {
+	switch {
+	case code >= 500:
+		return "5xx"
+	case code >= 400:
+		return "4xx"
+	case code >= 300:
+		return "3xx"
+	case code >= 200:
+		return "2xx"
+	default:
+		return "1xx"
+	}
+}
+
 // Metrics holds every Prometheus collector used by the blockyard server.
 // Create one instance per server (via [NewMetrics]) and thread it through
 // the types that need to record observations. Tests should use a dedicated
@@ -13,16 +57,17 @@ import (
 type Metrics struct {
 	// Gauges — current state
 	WorkersActive  prometheus.Gauge
+	WorkersByState *prometheus.GaugeVec // labels: state
 	SessionsActive prometheus.Gauge
 
 	// Counters — cumulative totals
 	WorkersSpawned          prometheus.Counter
-	WorkersStopped          prometheus.Counter
+	WorkersStopped          *prometheus.CounterVec // labels: reason
 	BundlesUploaded         prometheus.Counter
 	BundleRestoresSucceeded prometheus.Counter
 	BundleRestoresFailed    prometheus.Counter
-	ProxyRequests           prometheus.Counter
-	HealthChecksFailed      prometheus.Counter
+	ProxyRequests           *prometheus.CounterVec // labels: app, status
+	HealthChecksFailed      *prometheus.CounterVec // labels: app
 	AuditEntriesDropped     prometheus.Counter
 
 	// Histograms — distributions
@@ -42,6 +87,10 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Name: "blockyard_workers_active",
 			Help: "Currently running workers",
 		}),
+		WorkersByState: auto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "blockyard_workers",
+			Help: "Currently running workers, by state (busy/idle/draining)",
+		}, []string{"state"}),
 		SessionsActive: auto.NewGauge(prometheus.GaugeOpts{
 			Name: "blockyard_sessions_active",
 			Help: "Active proxy sessions",
@@ -51,10 +100,10 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Name: "blockyard_workers_spawned_total",
 			Help: "Total workers spawned",
 		}),
-		WorkersStopped: auto.NewCounter(prometheus.CounterOpts{
+		WorkersStopped: auto.NewCounterVec(prometheus.CounterOpts{
 			Name: "blockyard_workers_stopped_total",
-			Help: "Total workers stopped",
-		}),
+			Help: "Total workers stopped, by reason (graceful/crashed/idle_timeout)",
+		}, []string{"reason"}),
 		BundlesUploaded: auto.NewCounter(prometheus.CounterOpts{
 			Name: "blockyard_bundles_uploaded_total",
 			Help: "Total bundles uploaded",
@@ -67,14 +116,14 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Name: "blockyard_bundle_restores_failed_total",
 			Help: "Total failed bundle restores",
 		}),
-		ProxyRequests: auto.NewCounter(prometheus.CounterOpts{
+		ProxyRequests: auto.NewCounterVec(prometheus.CounterOpts{
 			Name: "blockyard_proxy_requests_total",
-			Help: "Total proxied requests",
-		}),
-		HealthChecksFailed: auto.NewCounter(prometheus.CounterOpts{
+			Help: "Total proxied requests, by app and HTTP status class (2xx/3xx/4xx/5xx). app=\"unknown\" for requests that do not resolve to an app",
+		}, []string{"app", "status"}),
+		HealthChecksFailed: auto.NewCounterVec(prometheus.CounterOpts{
 			Name: "blockyard_health_checks_failed_total",
-			Help: "Failed health checks leading to eviction",
-		}),
+			Help: "Failed health checks leading to eviction, by app",
+		}, []string{"app"}),
 		AuditEntriesDropped: auto.NewCounter(prometheus.CounterOpts{
 			Name: "blockyard_audit_entries_dropped_total",
 			Help: "Audit log entries dropped due to full buffer",

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -68,3 +68,41 @@ func TestNewMetricsIsolation(t *testing.T) {
 		t.Errorf("b.WorkersSpawned: expected 0 (isolated), got %v", got)
 	}
 }
+
+func TestProxyStatusClass(t *testing.T) {
+	cases := []struct {
+		code int
+		want string
+	}{
+		{100, "1xx"},
+		{101, "1xx"},
+		{200, "2xx"},
+		{299, "2xx"},
+		{301, "3xx"},
+		{404, "4xx"},
+		{418, "4xx"},
+		{499, "4xx"},
+		{500, "5xx"},
+		{503, "5xx"},
+		{520, "5xx"}, // long-tail upstream code (Cloudflare)
+	}
+	for _, c := range cases {
+		if got := ProxyStatusClass(c.code); got != c.want {
+			t.Errorf("ProxyStatusClass(%d) = %q, want %q", c.code, got, c.want)
+		}
+	}
+}
+
+func TestLabeledMetricsDoNotPanic(t *testing.T) {
+	// Smoke-test the *Vec collectors so a wrong label arity is
+	// caught here rather than at the first scrape in production.
+	m := newTestMetrics(t)
+	m.ProxyRequests.WithLabelValues("app1", "2xx").Inc()
+	m.ProxyRequests.WithLabelValues("app1", "5xx").Inc()
+	m.HealthChecksFailed.WithLabelValues("app1").Inc()
+	m.WorkersStopped.WithLabelValues(ReasonGraceful).Inc()
+	m.WorkersStopped.WithLabelValues(ReasonCrashed).Inc()
+	m.WorkersByState.WithLabelValues(StateBusy).Set(3)
+	m.WorkersByState.WithLabelValues(StateIdle).Set(7)
+	m.WorkersByState.WithLabelValues(StateDraining).Set(1)
+}

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -34,6 +35,11 @@ func newTestServer(t *testing.T, cfg *config.Config) (*server.Server, *httptest.
 
 	be := mock.New()
 	srv := server.NewServer(cfg, be, database)
+	// Track background restore goroutines so cleanup waits for them
+	// before t.TempDir / DB teardown — otherwise the restore can race
+	// with dir removal and DB close (see #234).
+	var wg sync.WaitGroup
+	srv.RestoreWG = &wg
 
 	r := chi.NewRouter()
 	uiHandler := New()
@@ -41,6 +47,8 @@ func newTestServer(t *testing.T, cfg *config.Config) (*server.Server, *httptest.
 
 	ts := httptest.NewServer(r)
 	t.Cleanup(ts.Close)
+	// LIFO order: wg.Wait runs before ts.Close, DB close, TempDir cleanup.
+	t.Cleanup(wg.Wait)
 	return srv, ts
 }
 
@@ -58,6 +66,11 @@ func authServer(t *testing.T, cfg *config.Config, sub string, role auth.Role) (*
 
 	be := mock.New()
 	srv := server.NewServer(cfg, be, database)
+	// Track background restore goroutines so cleanup waits for them
+	// before t.TempDir / DB teardown — otherwise the restore can race
+	// with dir removal and DB close (see #234).
+	var wg sync.WaitGroup
+	srv.RestoreWG = &wg
 
 	uiHandler := New()
 	r := chi.NewRouter()
@@ -82,6 +95,8 @@ func authServer(t *testing.T, cfg *config.Config, sub string, role auth.Role) (*
 
 	ts := httptest.NewServer(r)
 	t.Cleanup(ts.Close)
+	// LIFO order: wg.Wait runs before ts.Close, DB close, TempDir cleanup.
+	t.Cleanup(wg.Wait)
 	return srv, ts
 }
 


### PR DESCRIPTION
## Summary
- `blockyard_proxy_requests_total{app,status}` — status as Nxx class to bound cardinality at #apps × 4. Recorded the moment the response status is decided so long-lived WebSocket upgrades count immediately, not at disconnect.
- `blockyard_health_checks_failed_total{app}` — looked up via worker → app → name at eviction time.
- `blockyard_workers_stopped_total{reason}` — `graceful` / `crashed` / `idle_timeout`, threaded through `EvictWorker` and its `EvictWorkerFn` hook.
- `blockyard_workers{state}` — `busy` / `idle` / `draining`, reconciled from `ActiveWorker` fields on each autoscaler tick.
- Unrelated CI flakes caught while rebasing: GID-remap race in `checkBwrapHostUIDMapping` (fixes #233) and missing `RestoreWG` wait in `internal/ui` test helpers (fixes #234).

Fixes #229