### PR TITLE
fix: decouple vault token file path from database driver

### DIFF
--- a/cmd/blockyard/main.go
+++ b/cmd/blockyard/main.go
@@ -207,7 +207,7 @@ func main() {
 	// ── Initialize OpenBao (must happen before OIDC for vault reference resolution) ──
 
 	if cfg.Openbao != nil {
-		tokenFilePath := filepath.Join(filepath.Dir(cfg.Database.Path), ".vault-token")
+		tokenFilePath := cfg.Openbao.TokenFile
 
 		var adminTokenFunc func() string
 

--- a/docs/content/docs/reference/config.md
+++ b/docs/content/docs/reference/config.md
@@ -330,6 +330,7 @@ role_id       = "blockyard-server"    # AppRole role identifier (recommended)
 # admin_token = "vault-admin-token"   # deprecated: use role_id instead
 token_ttl     = "1h"
 jwt_auth_path = "jwt"
+# token_file  = "/data/.vault-token"  # where the AppRole token is persisted
 ```
 
 | Field | Type | Default | Required | Description |
@@ -339,6 +340,7 @@ jwt_auth_path = "jwt"
 | `admin_token` | `string` | — | One of `role_id` or `admin_token` | **Deprecated.** Static admin token. Supports [vault references](#vault-references). Use `role_id` with AppRole auth instead. |
 | `token_ttl` | `duration` | `1h` | No | TTL for issued credential tokens |
 | `jwt_auth_path` | `string` | `jwt` | No | Auth method mount path in OpenBao |
+| `token_file` | `string` | `/data/.vault-token` | No | Path where the persisted AppRole token is stored. The parent directory must be writable. |
 | `skip_policy_scope_check` | `boolean` | `false` | No | Skip the policy scope check during OpenBao bootstrap. Useful when the OpenBao policy format differs from what Blockyard expects. |
 
 > [!TIP]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -177,6 +177,7 @@ type OpenbaoConfig struct {
 	RoleID               string          `toml:"role_id"`                  // AppRole role identifier
 	TokenTTL             Duration        `toml:"token_ttl"`                // default: 1h
 	JWTAuthPath          string          `toml:"jwt_auth_path"`            // default: "jwt"
+	TokenFile            string          `toml:"token_file"`               // persisted vault token path; default: "/data/.vault-token"
 	SkipPolicyScopeCheck bool            `toml:"skip_policy_scope_check"`
 	Services             []ServiceConfig `toml:"services"`
 }
@@ -371,6 +372,12 @@ func openbaoDefaults(c *OpenbaoConfig) {
 	}
 	if c.JWTAuthPath == "" {
 		c.JWTAuthPath = "jwt"
+	}
+	if c.TokenFile == "" {
+		// Lives at /data/.vault-token so it survives restarts regardless
+		// of database.driver. Previously derived from database.path,
+		// which broke Postgres deployments that don't mount /data/db/.
+		c.TokenFile = "/data/.vault-token"
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -871,6 +871,28 @@ func TestParseOpenbaoConfig(t *testing.T) {
 	if cfg.Openbao.JWTAuthPath != "jwt" {
 		t.Errorf("expected default jwt_auth_path 'jwt', got %q", cfg.Openbao.JWTAuthPath)
 	}
+	if cfg.Openbao.TokenFile != "/data/.vault-token" {
+		t.Errorf("expected default token_file '/data/.vault-token', got %q", cfg.Openbao.TokenFile)
+	}
+}
+
+func TestOpenbaoTokenFileOverride(t *testing.T) {
+	toml := strings.Replace(
+		openbaoTOML(t),
+		`admin_token = "hvs.admin123"`,
+		`admin_token = "hvs.admin123"`+"\n"+`token_file   = "/var/lib/blockyard/.vault-token"`,
+		1,
+	)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "blockyard.toml")
+	os.WriteFile(path, []byte(toml), 0o644)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Openbao.TokenFile != "/var/lib/blockyard/.vault-token" {
+		t.Errorf("token_file = %q, want /var/lib/blockyard/.vault-token", cfg.Openbao.TokenFile)
+	}
 }
 
 func TestParseConfigWithoutOpenbao(t *testing.T) {


### PR DESCRIPTION
## Summary
- `openbao.token_file` now controls where the AppRole token is persisted; the old derivation from `database.path` broke Postgres deployments that don't mount `/data/db/`.
- Default is `/data/.vault-token`, so token caching works out-of-the-box on both SQLite and Postgres.
- Existing deployments that relied on the SQLite-adjacent path will do one extra AppRole login on upgrade, then cache normally.

Fixes #226.