### PR TITLE
test(ui): wait for restore goroutines in test cleanup

### DIFF
--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -34,6 +35,9 @@ func newTestServer(t *testing.T, cfg *config.Config) (*server.Server, *httptest.
 
 	be := mock.New()
 	srv := server.NewServer(cfg, be, database)
+	// Track background restore goroutines so cleanup waits for them.
+	var wg sync.WaitGroup
+	srv.RestoreWG = &wg
 
 	r := chi.NewRouter()
 	uiHandler := New()
@@ -41,6 +45,8 @@ func newTestServer(t *testing.T, cfg *config.Config) (*server.Server, *httptest.
 
 	ts := httptest.NewServer(r)
 	t.Cleanup(ts.Close)
+	// Wait for restore goroutines before DB/TempDir cleanup (LIFO order).
+	t.Cleanup(wg.Wait)
 	return srv, ts
 }
 
@@ -58,6 +64,9 @@ func authServer(t *testing.T, cfg *config.Config, sub string, role auth.Role) (*
 
 	be := mock.New()
 	srv := server.NewServer(cfg, be, database)
+	// Track background restore goroutines so cleanup waits for them.
+	var wg sync.WaitGroup
+	srv.RestoreWG = &wg
 
 	uiHandler := New()
 	r := chi.NewRouter()
@@ -82,6 +91,8 @@ func authServer(t *testing.T, cfg *config.Config, sub string, role auth.Role) (*
 
 	ts := httptest.NewServer(r)
 	t.Cleanup(ts.Close)
+	// Wait for restore goroutines before DB/TempDir cleanup (LIFO order).
+	t.Cleanup(wg.Wait)
 	return srv, ts
 }
 


### PR DESCRIPTION
## Summary

- Wires `sync.WaitGroup` into `srv.RestoreWG` in both `newTestServer` and `authServer` helpers, mirroring the existing `internal/api/api_test.go` pattern.
- Registers `wg.Wait` as a `t.Cleanup` after `ts.Close` so background bundle-restore goroutines drain before DB close and TempDir removal (LIFO order).
- Eliminates intermittent "TempDir RemoveAll: directory not empty" and "sql: database is closed" failures in `TestCreateAppUpload*`.

Fixes #234