### PR TITLE
feat(db): self-mint Postgres creds via vault static-creds

### DIFF
--- a/cmd/blockyard/main.go
+++ b/cmd/blockyard/main.go
@@ -176,11 +176,97 @@ func main() {
 		defer rc.Close()
 	}
 
+	// Background goroutine context — used for vault token renewal and
+	// others. Declared up here so the token-renewer goroutine (started
+	// below, before db.Open) can enlist in bgWg.
+	bgCtx, bgCancel := context.WithCancel(context.Background()) //nolint:gosec // G118: bgCancel is called by Drainer.Finish/Shutdown, not defer
+	var bgWg sync.WaitGroup
+
+	// ── Initialize OpenBao (before db.Open so the Postgres pool can
+	// seed creds from vault when database.vault_role is set, and
+	// before OIDC for vault reference resolution). ──
+	var (
+		vaultClient       *integration.Client
+		vaultAdminToken   func() string
+		vaultTokenHealthy func() bool
+		vaultTokenCache   *integration.VaultTokenCache
+	)
+
+	if cfg.Openbao != nil {
+		tokenFilePath := cfg.Openbao.TokenFile
+
+		if cfg.Openbao.RoleID != "" {
+			// AppRole auth flow.
+			token, ttl, err := integration.InitAppRole(context.Background(), cfg.Openbao.Address, cfg.Openbao.RoleID, tokenFilePath)
+			if err != nil {
+				slog.Error("vault authentication failed", "error", err)
+				os.Exit(1)
+			}
+
+			// Start token renewal goroutine.
+			renewer := integration.NewTokenRenewer(cfg.Openbao.Address, token, tokenFilePath)
+			vaultAdminToken = renewer.Token
+			vaultTokenHealthy = renewer.Healthy
+
+			bgWg.Add(1)
+			go func() {
+				defer bgWg.Done()
+				renewer.Run(bgCtx, ttl)
+			}()
+		} else {
+			// Deprecated static admin_token.
+			vaultAdminToken = cfg.Openbao.AdminToken.MustExpose
+		}
+
+		vaultClient = integration.NewClient(cfg.Openbao.Address, vaultAdminToken)
+		vaultTokenCache = integration.NewVaultTokenCache()
+
+		// Resolve vault references in config (e.g. "vault:path#key").
+		if err := config.ResolveSecrets(context.Background(), cfg, vaultClient); err != nil {
+			slog.Error("failed to resolve vault references in config", "error", err)
+			os.Exit(1)
+		}
+
+		// Auto-generate session_secret if empty and vault is available.
+		if cfg.OIDC != nil && (cfg.Server.SessionSecret == nil || cfg.Server.SessionSecret.IsEmpty()) {
+			secret, err := integration.ResolveSessionSecret(context.Background(), vaultClient)
+			if err != nil {
+				slog.Error("failed to resolve session_secret", "error", err)
+				os.Exit(1)
+			}
+			s := config.NewSecret(secret)
+			cfg.Server.SessionSecret = &s
+		}
+
+		// Bootstrap verification.
+		if err := integration.Bootstrap(context.Background(), vaultClient, cfg.Openbao.JWTAuthPath, cfg.Openbao.SkipPolicyScopeCheck); err != nil {
+			slog.Error("OpenBao bootstrap failed", "error", err)
+			os.Exit(1)
+		}
+	}
+
 	// Database init happens BEFORE backend construction for the same
 	// reason as Redis above: the process backend's Postgres-primary
 	// port / UID allocators (#288) need the *sqlx.DB at construction
 	// time. The Docker backend factory ignores the database argument.
-	database, err := db.Open(cfg.Database)
+	//
+	// When cfg.Database.VaultRole is set, install a rotator that reads
+	// the admin PG creds from `{mount}/static-creds/{role}` (#238).
+	// The static-role lease is owned by vault itself, not by the
+	// caller's token, so the role survives blockyard restarts — the
+	// failure mode that caused the deploy-side cascade revoke.
+	var dbOpts []db.OpenOption
+	if vaultClient != nil && cfg.Database.VaultRole != "" {
+		mount := cfg.Database.VaultMount
+		role := cfg.Database.VaultRole
+		dbOpts = append(dbOpts, db.WithCredsRotator(db.RotatorFunc(
+			func(ctx context.Context) (string, string, error) {
+				u, p, _, err := vaultClient.DatabaseStaticCredsRead(ctx, mount, role)
+				return u, p, err
+			})))
+	}
+
+	database, err := db.Open(cfg.Database, dbOpts...)
 	if err != nil {
 		slog.Error("failed to open database", "error", err)
 		os.Exit(1)
@@ -231,6 +317,9 @@ func main() {
 	// /metrics HTTP endpoint (served by promhttp.Handler) can scrape them.
 	srv := server.NewServerWithDefaultMetrics(cfg, be, database)
 	srv.Version = version
+	srv.VaultClient = vaultClient
+	srv.VaultTokenHealthy = vaultTokenHealthy
+	srv.VaultTokenCache = vaultTokenCache
 	// Point the server at the same ErrorLog store the slog handler has
 	// been feeding since config load, so the admin panel sees startup
 	// warnings too (e.g. preflight errors).
@@ -268,67 +357,6 @@ func main() {
 	// Set operation hooks to avoid import cycles.
 	srv.EvictWorkerFn = ops.EvictWorker
 	srv.SpawnLogCaptureFn = ops.SpawnLogCapture
-
-	// Background goroutine context — used for vault token renewal and others.
-	bgCtx, bgCancel := context.WithCancel(context.Background()) //nolint:gosec // G118: bgCancel is called by Drainer.Finish/Shutdown, not defer
-	var bgWg sync.WaitGroup
-
-	// ── Initialize OpenBao (must happen before OIDC for vault reference resolution) ──
-
-	if cfg.Openbao != nil {
-		tokenFilePath := cfg.Openbao.TokenFile
-
-		var adminTokenFunc func() string
-
-		if cfg.Openbao.RoleID != "" {
-			// AppRole auth flow.
-			token, ttl, err := integration.InitAppRole(context.Background(), cfg.Openbao.Address, cfg.Openbao.RoleID, tokenFilePath)
-			if err != nil {
-				slog.Error("vault authentication failed", "error", err)
-				os.Exit(1)
-			}
-
-			// Start token renewal goroutine.
-			renewer := integration.NewTokenRenewer(cfg.Openbao.Address, token, tokenFilePath)
-			adminTokenFunc = renewer.Token
-			srv.VaultTokenHealthy = renewer.Healthy
-
-			bgWg.Add(1)
-			go func() {
-				defer bgWg.Done()
-				renewer.Run(bgCtx, ttl)
-			}()
-		} else {
-			// Deprecated static admin_token.
-			adminTokenFunc = cfg.Openbao.AdminToken.MustExpose
-		}
-
-		srv.VaultClient = integration.NewClient(cfg.Openbao.Address, adminTokenFunc)
-		srv.VaultTokenCache = integration.NewVaultTokenCache()
-
-		// Resolve vault references in config (e.g. "vault:path#key").
-		if err := config.ResolveSecrets(context.Background(), cfg, srv.VaultClient); err != nil {
-			slog.Error("failed to resolve vault references in config", "error", err)
-			os.Exit(1)
-		}
-
-		// Auto-generate session_secret if empty and vault is available.
-		if cfg.OIDC != nil && (cfg.Server.SessionSecret == nil || cfg.Server.SessionSecret.IsEmpty()) {
-			secret, err := integration.ResolveSessionSecret(context.Background(), srv.VaultClient)
-			if err != nil {
-				slog.Error("failed to resolve session_secret", "error", err)
-				os.Exit(1)
-			}
-			s := config.NewSecret(secret)
-			cfg.Server.SessionSecret = &s
-		}
-
-		// Bootstrap verification.
-		if err := integration.Bootstrap(context.Background(), srv.VaultClient, cfg.Openbao.JWTAuthPath, cfg.Openbao.SkipPolicyScopeCheck); err != nil {
-			slog.Error("OpenBao bootstrap failed", "error", err)
-			os.Exit(1)
-		}
-	}
 
 	// Board-storage provisioner — constructed only when both vault
 	// and board storage are configured. Drives per-user PG role +

--- a/docs/content/docs/reference/config.md
+++ b/docs/content/docs/reference/config.md
@@ -173,13 +173,80 @@ max_bundle_size       = 104857600
 driver = "sqlite"
 path   = "/data/db/blockyard.db"
 # url  = ""   # PostgreSQL connection string (when driver = "postgres")
+
+# Vault-managed Postgres credentials (optional; postgres only):
+# vault_mount = "database"
+# vault_role  = "blockyard_admin"
 ```
 
 | Field | Type | Default | Required | Description |
 |---|---|---|---|---|
 | `driver` | `string` | `sqlite` | No | Database driver: `sqlite` or `postgres` |
 | `path` | `path` | `/data/db/blockyard.db` | When `driver = "sqlite"` | Path to the SQLite database file (created if missing). The parent directory must be writable. |
-| `url` | `string` | — | When `driver = "postgres"` | PostgreSQL connection string (e.g. `postgres://user:pass@host/dbname`) |
+| `url` | `string` | — | When `driver = "postgres"` | PostgreSQL connection string (e.g. `postgres://user:pass@host/dbname`). Userinfo is ignored when `vault_role` is set. |
+| `vault_mount` | `string` | `database` | No | Vault database secrets-engine mount path. Requires `[openbao]` and `driver = "postgres"`. |
+| `vault_role` | `string` | — | No | Vault static-role name. When set, Blockyard reads `{vault_mount}/static-creds/{vault_role}` at startup and uses those credentials instead of any user/password in `url`. Requires `[openbao]` and `driver = "postgres"`. |
+
+### Vault-managed Postgres credentials
+
+When `database.vault_role` is set, Blockyard obtains its Postgres
+credentials from OpenBao's database secrets engine on every startup
+and whenever the cached password stops working. The role's password
+is owned by OpenBao (rotated on the schedule the operator configures
+on the role), not by the token that created the lease — so Blockyard
+restarts, deploy pipelines, and token renewals do not affect database
+access.
+
+One-time operator setup:
+
+1. Create a PostgreSQL role for Blockyard with the privileges it needs
+   (at minimum `LOGIN` plus `CREATE` and `USAGE` on the target
+   database). A typical setup uses a dedicated `blockyard_admin` role:
+
+   ```sql
+   CREATE ROLE blockyard_admin LOGIN PASSWORD '<temp>' CREATEROLE;
+   GRANT ALL PRIVILEGES ON DATABASE blockyard TO blockyard_admin;
+   ```
+
+2. In OpenBao, register the role as a static-role on the database
+   secrets engine. This tells OpenBao to adopt the role and manage
+   its password:
+
+   ```sh
+   bao write database/static-roles/blockyard_admin \
+       db_name=postgresql \
+       username=blockyard_admin \
+       rotation_period=24h
+   ```
+
+   OpenBao immediately rotates the password; subsequent reads of
+   `database/static-creds/blockyard_admin` return the current one.
+
+3. Grant Blockyard's AppRole policy read access to the static-creds
+   endpoint:
+
+   ```hcl
+   path "database/static-creds/blockyard_admin" {
+     capabilities = ["read"]
+   }
+   ```
+
+4. Configure Blockyard:
+
+   ```toml
+   [database]
+   driver     = "postgres"
+   url        = "postgres://postgres.internal/blockyard?sslmode=verify-full"
+   vault_role = "blockyard_admin"
+   ```
+
+   The `url` does not need (and should not include) a username or
+   password — Blockyard injects the vault-issued credentials on every
+   connection.
+
+At runtime, Blockyard re-reads the static-creds endpoint on any
+Postgres authentication failure, so an out-of-band password rotation
+heals automatically on the next health poll.
 
 ## `[proxy]`
 

--- a/internal/db/creds.go
+++ b/internal/db/creds.go
@@ -1,0 +1,83 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+)
+
+// CredsRotator mints fresh Postgres credentials. Implementations must
+// be safe for concurrent use — the startup path and the health poller
+// may both invoke Rotate.
+//
+// The production implementation reads from vault's
+// `{mount}/static-creds/{role}` endpoint; the db package keeps the
+// interface narrow so it stays decoupled from internal/integration.
+type CredsRotator interface {
+	Rotate(ctx context.Context) (user, password string, err error)
+}
+
+// RotatorFunc adapts a bare function into a CredsRotator, so main.go
+// can wire a vault closure without declaring a type.
+type RotatorFunc func(ctx context.Context) (user, password string, err error)
+
+func (f RotatorFunc) Rotate(ctx context.Context) (string, string, error) {
+	return f(ctx)
+}
+
+// pgCredsProvider holds the current Postgres username/password and
+// refreshes them on demand via a CredsRotator. Starts empty — callers
+// are expected to Rotate() once at Open time before the first
+// connection attempt when a rotator is configured.
+//
+// When no rotator is set, the provider stays empty forever and the
+// pool's BeforeConnect hook becomes a no-op, leaving pgx to honor the
+// DSN's userinfo.
+type pgCredsProvider struct {
+	mu       sync.Mutex
+	user     string
+	password string
+	rotator  CredsRotator
+}
+
+func newPgCredsProvider(rot CredsRotator) *pgCredsProvider {
+	return &pgCredsProvider{rotator: rot}
+}
+
+// current returns the current creds. Safe for concurrent use from
+// pgxpool's BeforeConnect hook.
+func (p *pgCredsProvider) current() (user, password string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.user, p.password
+}
+
+func (p *pgCredsProvider) hasRotator() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.rotator != nil
+}
+
+// rotate fetches fresh creds and caches them. Returns an error if no
+// rotator is configured or if the rotator call fails.
+func (p *pgCredsProvider) rotate(ctx context.Context) error {
+	p.mu.Lock()
+	rot := p.rotator
+	p.mu.Unlock()
+	if rot == nil {
+		return fmt.Errorf("no creds rotator configured")
+	}
+
+	user, pass, err := rot.Rotate(ctx)
+	if err != nil {
+		return fmt.Errorf("fetch db creds: %w", err)
+	}
+
+	p.mu.Lock()
+	p.user = user
+	p.password = pass
+	p.mu.Unlock()
+	slog.Info("fetched postgres credentials from vault", "user", user)
+	return nil
+}

--- a/internal/db/creds_test.go
+++ b/internal/db/creds_test.go
@@ -1,0 +1,132 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestPgCredsProvider_RotateUpdatesCache(t *testing.T) {
+	var count atomic.Int32
+	rot := RotatorFunc(func(ctx context.Context) (string, string, error) {
+		n := count.Add(1)
+		return fmt.Sprintf("u%d", n), fmt.Sprintf("p%d", n), nil
+	})
+	p := newPgCredsProvider(rot)
+
+	if u, _ := p.current(); u != "" {
+		t.Fatalf("fresh provider should be empty, got user=%q", u)
+	}
+	if !p.hasRotator() {
+		t.Fatal("hasRotator should be true")
+	}
+
+	if err := p.rotate(context.Background()); err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	u, pw := p.current()
+	if u != "u1" || pw != "p1" {
+		t.Errorf("after first rotate: user=%q pass=%q", u, pw)
+	}
+
+	if err := p.rotate(context.Background()); err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	u, pw = p.current()
+	if u != "u2" || pw != "p2" {
+		t.Errorf("after second rotate: user=%q pass=%q", u, pw)
+	}
+}
+
+func TestPgCredsProvider_NoRotator(t *testing.T) {
+	p := newPgCredsProvider(nil)
+	if p.hasRotator() {
+		t.Fatal("hasRotator should be false with nil rotator")
+	}
+	err := p.rotate(context.Background())
+	if err == nil {
+		t.Fatal("rotate without rotator should error")
+	}
+}
+
+func TestPgCredsProvider_RotatePropagatesError(t *testing.T) {
+	want := errors.New("vault unreachable")
+	rot := RotatorFunc(func(ctx context.Context) (string, string, error) {
+		return "", "", want
+	})
+	p := newPgCredsProvider(rot)
+	err := p.rotate(context.Background())
+	if err == nil || !errors.Is(err, want) {
+		t.Fatalf("want wrapped %v, got %v", want, err)
+	}
+	// On failure the cached creds must not be clobbered.
+	if u, _ := p.current(); u != "" {
+		t.Errorf("creds mutated on failure: user=%q", u)
+	}
+}
+
+func TestPgCredsProvider_ConcurrentRotateAndRead(t *testing.T) {
+	// Race-detector sanity check: readers and rotators interleaving
+	// must not tear the (user, password) pair apart.
+	rot := RotatorFunc(func(ctx context.Context) (string, string, error) {
+		return "alice", "secret-alice", nil
+	})
+	p := newPgCredsProvider(rot)
+	if err := p.rotate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					u, pw := p.current()
+					if (u == "" && pw != "") || (u != "" && pw == "") {
+						t.Errorf("torn pair: user=%q pass=%q", u, pw)
+						return
+					}
+				}
+			}
+		}()
+	}
+	for i := 0; i < 50; i++ {
+		_ = p.rotate(context.Background())
+	}
+	close(stop)
+	wg.Wait()
+}
+
+func TestIsPostgresAuthError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"pgError 28P01", &pgconn.PgError{Code: "28P01", Message: "invalid password"}, true},
+		{"pgError 28000", &pgconn.PgError{Code: "28000"}, true},
+		{"pgError other", &pgconn.PgError{Code: "42P01"}, false},
+		{"string SQLSTATE 28P01", errors.New("connect: FATAL: password authentication failed (SQLSTATE 28P01)"), true},
+		{"string role does not exist", errors.New("FATAL: role \"v-token-XYZ\" does not exist"), true},
+		{"unrelated error", errors.New("connection refused"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPostgresAuthError(tt.err); got != tt.want {
+				t.Errorf("isPostgresAuthError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"embed"
+	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,6 +24,8 @@ import (
 	"github.com/cynkra/blockyard/internal/config"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	_ "modernc.org/sqlite"
 )
@@ -54,17 +58,50 @@ const (
 type DB struct {
 	*sqlx.DB
 	dialect  Dialect
-	tempPath string // non-empty when using a temp file for SQLite :memory:
-	connURL  string // original connection URL, set for PostgreSQL
+	tempPath string           // non-empty when using a temp file for SQLite :memory:
+	connURL  string           // original connection URL, set for PostgreSQL
+	pgPool   *pgxpool.Pool    // non-nil when dialect = DialectPostgres; closed separately from *sql.DB
+	creds    *pgCredsProvider // non-nil when dialect = DialectPostgres; empty when no rotator is wired
+}
+
+// openOptions collects Open customizations — currently the optional
+// vault-backed credentials rotator.
+type openOptions struct {
+	rotator CredsRotator
+}
+
+// OpenOption configures Open.
+type OpenOption func(*openOptions)
+
+// WithCredsRotator installs a CredsRotator that the Postgres pool
+// uses to obtain credentials. When set:
+//
+//   - Open fetches fresh creds from the rotator before the first
+//     connection and uses those (ignoring any user/password in the
+//     DSN).
+//   - Ping retries once on auth failure (SQLSTATE 28P01 or a
+//     "role ... does not exist" message) by rotating and resetting
+//     the pool — this lets the health poller self-heal when vault has
+//     rotated the static-role password out from under blockyard.
+//
+// No-op for SQLite. Intended for wiring `{mount}/static-creds/{role}`
+// via cfg.Database.VaultRole (#238).
+func WithCredsRotator(r CredsRotator) OpenOption {
+	return func(o *openOptions) { o.rotator = r }
 }
 
 // Open opens a database connection based on the config.
-func Open(cfg config.DatabaseConfig) (*DB, error) {
+func Open(cfg config.DatabaseConfig, opts ...OpenOption) (*DB, error) {
+	var options openOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	switch cfg.Driver {
 	case "sqlite":
 		return openSQLite(cfg.Path)
 	case "postgres":
-		return openPostgres(cfg.URL)
+		return openPostgres(cfg.URL, options)
 	default:
 		return nil, fmt.Errorf("unsupported database driver: %q", cfg.Driver)
 	}
@@ -112,8 +149,8 @@ func openSQLite(path string) (*DB, error) {
 	return d, nil
 }
 
-func openPostgres(url string) (*DB, error) {
-	connCfg, err := pgx.ParseConfig(url)
+func openPostgres(url string, options openOptions) (*DB, error) {
+	poolCfg, err := pgxpool.ParseConfig(url)
 	if err != nil {
 		return nil, fmt.Errorf("parse postgres url: %w", err)
 	}
@@ -124,37 +161,152 @@ func openPostgres(url string) (*DB, error) {
 	// create their tables in the v0.0.3 layout. Once 006 lands the
 	// schema exists, blockyard resolves first, and subsequent runtime
 	// queries see the relocated objects.
-	if connCfg.RuntimeParams == nil {
-		connCfg.RuntimeParams = map[string]string{}
+	if poolCfg.ConnConfig.RuntimeParams == nil {
+		poolCfg.ConnConfig.RuntimeParams = map[string]string{}
 	}
-	if _, set := connCfg.RuntimeParams["search_path"]; !set {
-		connCfg.RuntimeParams["search_path"] = pgSchema + ", public"
+	if _, set := poolCfg.ConnConfig.RuntimeParams["search_path"]; !set {
+		poolCfg.ConnConfig.RuntimeParams["search_path"] = pgSchema + ", public"
 	}
-	db := sqlx.NewDb(stdlib.OpenDB(*connCfg), "pgx")
+	// Pool defaults — override via connection string parameters
+	// (e.g. ?pool_max_conns=20) if needed.
+	if poolCfg.MaxConns == 0 {
+		poolCfg.MaxConns = 25
+	}
+	if poolCfg.MaxConnLifetime == 0 {
+		poolCfg.MaxConnLifetime = 5 * time.Minute
+	}
 
-	// Reasonable pool defaults — tune via connection string parameters
-	// if needed (e.g. ?pool_max_conns=20).
-	db.SetMaxOpenConns(25)
-	db.SetMaxIdleConns(5)
-	db.SetConnMaxLifetime(5 * time.Minute)
+	// BeforeConnect fires on every new low-level connection. When a
+	// rotator is wired, this hook injects the provider's current
+	// creds, so refreshing the provider transparently updates every
+	// subsequent connection without a pool rebuild. When no rotator
+	// is wired, the provider stays empty and the hook is a no-op —
+	// pgx falls back to the DSN's userinfo.
+	provider := newPgCredsProvider(options.rotator)
+	poolCfg.BeforeConnect = func(_ context.Context, cc *pgx.ConnConfig) error {
+		if u, p := provider.current(); u != "" {
+			cc.User = u
+			cc.Password = p
+		}
+		return nil
+	}
 
-	if err := db.Ping(); err != nil {
-		db.Close()
+	// Seed creds from vault before the first connection attempt. With
+	// a rotator installed, the DSN's userinfo is irrelevant — the
+	// operator may omit it entirely. Without a rotator, skip the
+	// fetch and let pgx use the DSN credentials.
+	if options.rotator != nil {
+		seedCtx, seedCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		err := provider.rotate(seedCtx)
+		seedCancel()
+		if err != nil {
+			return nil, fmt.Errorf("seed postgres creds from vault: %w", err)
+		}
+	}
+
+	pool, err := pgxpool.NewWithConfig(context.Background(), poolCfg)
+	if err != nil {
+		return nil, fmt.Errorf("open postgres: %w", err)
+	}
+
+	sx := sqlx.NewDb(stdlib.OpenDBFromPool(pool), "pgx")
+	d := &DB{
+		DB:      sx,
+		dialect: DialectPostgres,
+		connURL: url,
+		pgPool:  pool,
+		creds:   provider,
+	}
+
+	// Initial Ping goes through the rotate path: under a rotator,
+	// vault may have rotated the password between our seed fetch and
+	// the first real connect (unlikely but possible), so a 28P01 here
+	// deserves one retry with fresh creds.
+	if err := d.pingWithRotate(context.Background()); err != nil {
+		sx.Close()
+		pool.Close()
 		return nil, fmt.Errorf("ping postgres: %w", err)
 	}
 
-	d := &DB{DB: db, dialect: DialectPostgres, connURL: url}
 	if err := d.runMigrations(); err != nil {
-		db.Close()
+		sx.Close()
+		pool.Close()
 		return nil, err
 	}
 	return d, nil
 }
 
-func (db *DB) newMigrator() (*migrate.Migrate, error) {
-	var fsys fs.FS
-	var err error
+// pingWithRotate pings the pool and, on Postgres auth failure, rotates
+// creds and retries once. A no-op fallback to the naked Ping when no
+// rotator is wired. Callers on the hot path use Ping (below) instead.
+func (db *DB) pingWithRotate(ctx context.Context) error {
+	err := db.DB.PingContext(ctx)
+	if err == nil {
+		return nil
+	}
+	if db.creds == nil || !db.creds.hasRotator() || !isPostgresAuthError(err) {
+		return err
+	}
+	slog.Warn("postgres auth failed, refreshing credentials from vault", "error", err)
+	if rErr := db.creds.rotate(ctx); rErr != nil {
+		return fmt.Errorf("%w; rotate failed: %v", err, rErr)
+	}
+	// Reset the pool so any half-open conns that authenticated with
+	// stale creds are discarded; next Acquire triggers BeforeConnect
+	// with the refreshed pair.
+	db.pgPool.Reset()
+	return db.DB.PingContext(ctx)
+}
 
+// isPostgresAuthError reports whether err is a PostgreSQL auth
+// failure. Matches SQLSTATE 28P01 (invalid_password) and 28000
+// (invalid_authorization_specification), plus the "role ... does not
+// exist" variant that surfaces when the role has been dropped out
+// from under us.
+func isPostgresAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		if pgErr.Code == "28P01" || pgErr.Code == "28000" {
+			return true
+		}
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "SQLSTATE 28P01") || strings.Contains(msg, "SQLSTATE 28000") {
+		return true
+	}
+	if strings.Contains(msg, "role ") && strings.Contains(msg, "does not exist") {
+		return true
+	}
+	return false
+}
+
+func (db *DB) runMigrations() error {
+	m, cleanup, err := db.newMigrator()
+	if err != nil {
+		return fmt.Errorf("create migrator: %w", err)
+	}
+	defer cleanup()
+	if err := m.Up(); err != nil && err != migrate.ErrNoChange {
+		return fmt.Errorf("run migrations: %w", err)
+	}
+	return nil
+}
+
+// newMigrator builds a migrate.Migrate for the active dialect and
+// returns a cleanup closure that releases any acquired resources
+// (notably, the *sql.Conn the Postgres driver hijacks for advisory
+// locking). Callers MUST defer the cleanup — pool.Close() at shutdown
+// blocks until every acquired conn is returned.
+func (db *DB) newMigrator() (*migrate.Migrate, func(), error) {
+	driver, cleanup, err := db.migrateDriver()
+	if err != nil {
+		return nil, nil, fmt.Errorf("migration driver: %w", err)
+	}
+
+	var fsys fs.FS
 	switch db.dialect {
 	case DialectSQLite:
 		fsys, err = fs.Sub(sqliteMigrations, "migrations/sqlite")
@@ -162,48 +314,65 @@ func (db *DB) newMigrator() (*migrate.Migrate, error) {
 		fsys, err = fs.Sub(postgresMigrations, "migrations/postgres")
 	}
 	if err != nil {
-		return nil, fmt.Errorf("migration fs: %w", err)
+		cleanup()
+		return nil, nil, fmt.Errorf("migration fs: %w", err)
 	}
 
 	source, err := iofs.New(fsys, ".")
 	if err != nil {
-		return nil, fmt.Errorf("migration source: %w", err)
+		cleanup()
+		return nil, nil, fmt.Errorf("migration source: %w", err)
 	}
 
-	driver, err := db.migrateDriver()
+	m, err := migrate.NewWithInstance("iofs", source, db.driverName(), driver)
 	if err != nil {
-		return nil, fmt.Errorf("migration driver: %w", err)
+		cleanup()
+		return nil, nil, err
 	}
-
-	return migrate.NewWithInstance("iofs", source, db.driverName(), driver)
+	return m, cleanup, nil
 }
 
-func (db *DB) runMigrations() error {
-	m, err := db.newMigrator()
-	if err != nil {
-		return fmt.Errorf("create migrator: %w", err)
-	}
-	if err := m.Up(); err != nil && err != migrate.ErrNoChange {
-		return fmt.Errorf("run migrations: %w", err)
-	}
-	return nil
-}
-
-func (db *DB) migrateDriver() (migratedb.Driver, error) {
+// migrateDriver returns a migration driver and a cleanup closure that
+// releases any hijacked resources.
+//
+// For Postgres, migrate's driver holds a dedicated *sql.Conn for the
+// advisory lock that serializes concurrent migrators across processes.
+// migratepostgres.WithInstance would keep that conn checked out until
+// its own Close() runs — fine against a standalone *sql.DB, but broken
+// against a pgxpool-backed one: pool.Close() at shutdown blocks on
+// conns that are still "acquired," and the caller never gets to invoke
+// migrate.Close(). Using WithConnection with an explicit
+// conn.Close() in cleanup lets the conn go back to the pool as soon
+// as migrations finish.
+func (db *DB) migrateDriver() (migratedb.Driver, func(), error) {
 	switch db.dialect {
 	case DialectPostgres:
+		ctx := context.Background()
+		conn, err := db.DB.DB.Conn(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
 		// Pin schema_migrations to public. v0.0.3 deployments already
-		// have the table there (migrate's default with an unset
-		// search_path); pinning explicitly keeps the bookkeeping table
-		// stable as search_path flips between `blockyard` and fallback
-		// resolution.
-		return migratepostgres.WithInstance(db.DB.DB, &migratepostgres.Config{
+		// have the table there; pinning explicitly keeps the
+		// bookkeeping table stable as search_path flips between
+		// `blockyard` and fallback resolution.
+		drv, err := migratepostgres.WithConnection(ctx, conn, &migratepostgres.Config{
 			SchemaName: "public",
 		})
+		if err != nil {
+			conn.Close()
+			return nil, nil, err
+		}
+		return drv, func() { _ = conn.Close() }, nil
 	default:
-		return migratesqlite.WithInstance(db.DB.DB, &migratesqlite.Config{
+		drv, err := migratesqlite.WithInstance(db.DB.DB, &migratesqlite.Config{
 			NoTxWrap: true,
 		})
+		if err != nil {
+			return nil, nil, err
+		}
+		// SQLite's WithInstance does not hijack a conn; nothing to release.
+		return drv, func() {}, nil
 	}
 }
 
@@ -231,8 +400,14 @@ func (db *DB) bindType() int {
 }
 
 // Close closes the database and removes any temp file created for :memory:.
+// For PostgreSQL, the underlying pgxpool is closed separately —
+// stdlib.OpenDBFromPool docs explicitly note that closing the *sql.DB
+// does not close the pool.
 func (db *DB) Close() error {
 	err := db.DB.Close()
+	if db.pgPool != nil {
+		db.pgPool.Close()
+	}
 	if db.tempPath != "" {
 		os.Remove(db.tempPath)
 	}
@@ -357,9 +532,28 @@ type DeploymentListOpts struct {
 	PerPage    int
 }
 
-// Ping verifies the database connection is alive.
+// Ping verifies the database connection is alive. For PostgreSQL,
+// a ping that fails with an auth error triggers a one-shot creds
+// refresh when a CredsRotator is wired — the health poller uses this
+// to self-heal after vault rotates the static-role password out from
+// under a pool holding stale creds.
 func (db *DB) Ping(ctx context.Context) error {
 	_, err := db.ExecContext(ctx, "SELECT 1")
+	if err == nil {
+		return nil
+	}
+	if db.dialect != DialectPostgres || db.creds == nil || !db.creds.hasRotator() {
+		return err
+	}
+	if !isPostgresAuthError(err) {
+		return err
+	}
+	slog.Warn("postgres ping auth failed, refreshing credentials from vault", "error", err)
+	if rErr := db.creds.rotate(ctx); rErr != nil {
+		return fmt.Errorf("%w; rotate failed: %v", err, rErr)
+	}
+	db.pgPool.Reset()
+	_, err = db.ExecContext(ctx, "SELECT 1")
 	return err
 }
 

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -10,10 +10,11 @@ import (
 
 // MigrationVersion returns the current migration version and dirty flag.
 func (db *DB) MigrationVersion() (uint, bool, error) {
-	m, err := db.newMigrator()
+	m, cleanup, err := db.newMigrator()
 	if err != nil {
 		return 0, false, fmt.Errorf("migration version: %w", err)
 	}
+	defer cleanup()
 	ver, dirty, err := m.Version()
 	if err != nil {
 		return 0, false, fmt.Errorf("migration version: %w", err)
@@ -23,10 +24,11 @@ func (db *DB) MigrationVersion() (uint, bool, error) {
 
 // MigrateDown runs down migrations to the target version.
 func (db *DB) MigrateDown(targetVersion uint) error {
-	m, err := db.newMigrator()
+	m, cleanup, err := db.newMigrator()
 	if err != nil {
 		return fmt.Errorf("migrate down: %w", err)
 	}
+	defer cleanup()
 
 	currentVer, _, err := m.Version()
 	if err != nil {

--- a/internal/db/migrate_test.go
+++ b/internal/db/migrate_test.go
@@ -721,32 +721,37 @@ func TestMigrateRoundtrip(t *testing.T) {
 func roundtrip(t *testing.T, db *DB) {
 	t.Helper()
 
-	m, err := db.newMigrator()
+	m, cleanup, err := db.newMigrator()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Up
 	if err := m.Up(); err != nil {
+		cleanup()
 		t.Fatalf("initial up: %v", err)
 	}
 	schemaAfterUp := dumpSchema(t, db)
+	cleanup()
 
 	// Need a fresh migrator — golang-migrate is stateful
-	m, err = db.newMigrator()
+	m, cleanup, err = db.newMigrator()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Down
 	if err := m.Down(); err != nil {
+		cleanup()
 		t.Fatalf("down: %v", err)
 	}
+	cleanup()
 
-	m, err = db.newMigrator()
+	m, cleanup, err = db.newMigrator()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer cleanup()
 
 	// Up again
 	if err := m.Up(); err != nil {

--- a/internal/integration/openbao.go
+++ b/internal/integration/openbao.go
@@ -220,6 +220,65 @@ func (c *Client) DatabaseStaticRoleCreate(
 	return nil
 }
 
+// dbStaticCredsResponse is the relevant subset of OpenBao's database
+// secrets-engine static-role credential response.
+type dbStaticCredsResponse struct {
+	Data struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+		TTL      int    `json:"ttl"`
+	} `json:"data"`
+}
+
+// DatabaseStaticCredsRead fetches the current username/password for a
+// vault static DB role. Vault manages the PG user out-of-band (the
+// operator registers the role; vault rotates its password on a
+// schedule) — this call just reads the current credentials, which are
+// stable between rotations.
+//
+// Unlike dynamic creds (`{mount}/creds/{role}`), static-creds leases
+// are not tied to the caller's token, so blockyard can read with its
+// own AppRole token without inheriting a lease that expires with the
+// token. Returned TTL reflects vault's time-to-next-rotation, not a
+// lease bound to this caller.
+//
+// Used for admin creds (#238, via cfg.Database.VaultRole) and by
+// workers for per-user creds (#284, `{mount}/static-creds/user_<id>`).
+// GET {addr}/v1/{mount}/static-creds/{name}
+func (c *Client) DatabaseStaticCredsRead(
+	ctx context.Context, mount, name string,
+) (username, password string, ttl time.Duration, err error) {
+	url := fmt.Sprintf("%s/v1/%s/static-creds/%s", c.addr, mount, name)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("openbao db static-creds: %w", err)
+	}
+	req.Header.Set("X-Vault-Token", c.adminTokenFunc())
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("openbao db static-creds: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return "", "", 0, fmt.Errorf("openbao db static-creds %s: %w", name, ErrNotFound)
+	}
+	if resp.StatusCode != http.StatusOK {
+		io.Copy(io.Discard, resp.Body)
+		return "", "", 0, fmt.Errorf("openbao db static-creds %s: status %d", name, resp.StatusCode)
+	}
+
+	var result dbStaticCredsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", "", 0, fmt.Errorf("openbao db static-creds: decode: %w", err)
+	}
+	if result.Data.Username == "" || result.Data.Password == "" {
+		return "", "", 0, fmt.Errorf("openbao db static-creds %s: empty username or password", name)
+	}
+	return result.Data.Username, result.Data.Password, time.Duration(result.Data.TTL) * time.Second, nil
+}
+
 // AuthMountAccessor returns the opaque accessor of the auth method
 // mounted at `path` (e.g. "jwt"). Accessors are vault-internal
 // identifiers distinct from mount paths; the alias lookup below

--- a/internal/integration/openbao_test.go
+++ b/internal/integration/openbao_test.go
@@ -344,3 +344,70 @@ func TestIdentityLookupEntityByAlias_UnknownAlias(t *testing.T) {
 		t.Errorf("expected 'not found' in error, got %v", err)
 	}
 }
+
+func TestDatabaseStaticCredsRead_Success(t *testing.T) {
+	client := mockBao(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/database/static-creds/blockyard_app" || r.Method != "GET" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("X-Vault-Token") != "test-admin-token" {
+			http.Error(w, "missing admin token", http.StatusForbidden)
+			return
+		}
+		fmt.Fprint(w, `{
+			"data": {
+				"username": "blockyard_admin",
+				"password": "rotated-secret",
+				"ttl": 3600,
+				"rotation_period": 86400
+			}
+		}`)
+	}))
+
+	user, pass, ttl, err := client.DatabaseStaticCredsRead(context.Background(),
+		"database", "blockyard_app")
+	if err != nil {
+		t.Fatalf("DatabaseStaticCredsRead: %v", err)
+	}
+	if user != "blockyard_admin" {
+		t.Errorf("username = %q, want %q", user, "blockyard_admin")
+	}
+	if pass != "rotated-secret" {
+		t.Errorf("password = %q, want %q", pass, "rotated-secret")
+	}
+	if ttl.Seconds() != 3600 {
+		t.Errorf("ttl = %v, want 3600s", ttl)
+	}
+}
+
+func TestDatabaseStaticCredsRead_NotFound(t *testing.T) {
+	// Role not registered in vault — static-creds returns 404.
+	client := mockBao(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	_, _, _, err := client.DatabaseStaticCredsRead(context.Background(), "database", "absent")
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got %v", err)
+	}
+}
+
+func TestDatabaseStaticCredsRead_EmptyCreds(t *testing.T) {
+	// Vault returned 200 but with blank creds — treat as an error so
+	// the caller doesn't hand empty strings to pgx.
+	client := mockBao(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"data": {"username": "", "password": ""}}`)
+	}))
+
+	_, _, _, err := client.DatabaseStaticCredsRead(context.Background(), "database", "blockyard_app")
+	if err == nil {
+		t.Fatal("expected error on empty creds")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("expected 'empty' in error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Postgres creds were minted by the deploy-side OpenBao token, whose lease cascade-revokes the dynamic DB role the moment the provisioner exits — restart loop at first reconnect (yard.blockr.cloud incident).
- When `cfg.Database.VaultRole` is set, blockyard now reads `{VaultMount}/static-creds/{VaultRole}` with its own AppRole token. Static-role passwords are vault-managed and not tied to any caller's token, so the deploy-token death falls out of the lease lifecycle entirely. Aligns the admin path with the per-user static-creds flow from #284.
- `pgxpool.BeforeConnect` injects current creds per connection; `Ping` retries once on 28P01 / "role … does not exist" to self-heal after vault-side password rotations.
- Reference docs (`docs/content/docs/reference/config.md`) gain a walkthrough of the operator setup: create a PG role, register it as a vault static-role, grant the AppRole read on static-creds, point `database.vault_role` at it. No userinfo needed in `database.url`.

Fixes #238