### PR TITLE
fix(docs): pull submodule in server.yml so images ship real docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,20 @@ jobs:
       BLOCKYARD_TEST_POSTGRES_URL: postgres://blockyard:blockyard@localhost:5432/blockyard_test?sslmode=disable
     steps:
       - uses: actions/checkout@v6
+        with:
+          # docs/themes/hugo-book submodule is required for the Hugo
+          # build below, which produces the real internal/docs/dist
+          # content that TestDocsServesHTML asserts against.
+          submodules: true
+      - uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: "0.147.4"
+          extended: true
+      # Replace the committed stub at internal/docs/dist/index.html
+      # with a real Hugo build so TestDocsServesHTML exercises the
+      # production embed. Mirrors the step in release.yml.
+      - name: Build docs for embed
+        run: cd docs && hugo --baseURL /docs/ --minify && rm -rf ../internal/docs/dist && cp -r public ../internal/docs/dist
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -55,6 +55,11 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          # docs/themes/hugo-book is a submodule; docker/server.Dockerfile's
+          # Hugo stage needs it to produce real docs output. Without this,
+          # the image silently ships near-empty pages under /docs/.
+          submodules: true
       - uses: docker/login-action@v4
         with:
           registry: ghcr.io

--- a/internal/api/docs_test.go
+++ b/internal/api/docs_test.go
@@ -33,10 +33,32 @@ func TestDocsServesHTML(t *testing.T) {
 	router.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d", rec.Code)
+		t.Fatalf("expected 200, got %d", rec.Code)
 	}
 	ct := rec.Header().Get("Content-Type")
 	if !strings.HasPrefix(ct, "text/html") {
 		t.Errorf("expected text/html content type, got %q", ct)
+	}
+
+	body := rec.Body.String()
+	// Guard against the "docs not included" stub at
+	// internal/docs/dist/index.html being served because the Hugo
+	// build step was skipped. The stub is valid HTML, so status +
+	// content-type alone passes silently — that gap is exactly how
+	// broken docs reached production before.
+	if strings.Contains(body, "Documentation was not included in this build") {
+		t.Fatal("served the docs stub placeholder — run `hugo --minify --baseURL /docs/` from docs/ and copy public/ to internal/docs/dist/ before testing (CI unit job does this automatically)")
+	}
+	// Marker from docs/layouts/index.html; only present when Hugo
+	// produced real output with the hugo-book theme submodule. Also
+	// catches the case where the submodule is missing and Hugo
+	// silently produces a body without the baseof-wrapped main
+	// block.
+	if !strings.Contains(body, "bk-hero") {
+		preview := body
+		if len(preview) > 200 {
+			preview = preview[:200]
+		}
+		t.Errorf("expected real docs home page (bk-hero class from docs/layouts/index.html) but got %d bytes; first 200: %q", len(body), preview)
 	}
 }


### PR DESCRIPTION
## Summary
- Docker images have shipped the "docs not included" stub under `/docs/` since 44fddea (Apr 5) migrated the Dockerfile's docs stage from Astro to Hugo — server.yml's checkout never pulled submodules, so `docs/themes/hugo-book` was missing in every image build.
- `TestDocsServesHTML` only asserted status + content-type, both satisfied by the stub; strengthen it to reject the stub marker and require `bk-hero` from the real Hugo home page.
- Add `submodules: true` + a Hugo build step to the unit CI job so the strengthened test has real `internal/docs/dist` content to exercise.