### PR TITLE
feat(ui): admin Updates tab with state-aware version check

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -51,7 +51,7 @@ jobs:
         run: docker compose -f examples/${{ matrix.example }}/docker-compose.yml pull --ignore-pull-failures
       - name: Build blockyard image from source
         if: github.event_name != 'pull_request' && github.event_name != 'push'
-        run: docker build -t ghcr.io/cynkra/blockyard:latest -t ghcr.io/cynkra/blockyard:main --build-arg COVER=1 -f docker/server.Dockerfile .
+        run: docker build -t ghcr.io/cynkra/blockyard:latest -t ghcr.io/cynkra/blockyard:main --build-arg COVER=1 --build-arg "VERSION=$(git describe --always --dirty)" -f docker/server.Dockerfile .
       - name: Block cloud metadata endpoint for containers
         if: github.event_name != 'pull_request' && github.event_name != 'push'
         run: sudo iptables -I DOCKER-USER -d 169.254.169.254/32 -j DROP 2>/dev/null || true
@@ -112,7 +112,7 @@ jobs:
         run: docker compose -f examples/hello-shiny/docker-compose.yml pull --ignore-pull-failures
       - name: Build blockyard image from source
         if: github.event_name != 'pull_request' && github.event_name != 'push'
-        run: docker build -t ghcr.io/cynkra/blockyard:latest -t ghcr.io/cynkra/blockyard:main --build-arg COVER=1 -f docker/server.Dockerfile .
+        run: docker build -t ghcr.io/cynkra/blockyard:latest -t ghcr.io/cynkra/blockyard:main --build-arg COVER=1 --build-arg "VERSION=$(git describe --always --dirty)" -f docker/server.Dockerfile .
       - name: Block cloud metadata endpoint
         if: github.event_name != 'pull_request' && github.event_name != 'push'
         run: sudo iptables -I DOCKER-USER -d 169.254.169.254/32 -j DROP 2>/dev/null || true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build binary
         run: |
-          VERSION="main+$(git rev-parse --short HEAD)"
+          VERSION="$(git describe --always --dirty)"
           EXT=""; if [ "${{ matrix.goos }}" = "windows" ]; then EXT=".exe"; fi
           CGO_ENABLED=0 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build \
             -ldflags "-s -w -X main.version=${VERSION}" \
@@ -74,7 +74,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="main+$(git rev-parse --short HEAD)"
+          VERSION="$(git describe --always --dirty)"
           gh release delete main --cleanup-tag --yes 2>/dev/null || true
           gh release create main \
             --title "${VERSION}" \

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -72,9 +72,9 @@ jobs:
         run: |
           V="${{ inputs.version }}"
           if [ -z "$V" ]; then
-            V="dev"
+            V="$(git describe --always --dirty)"
           elif [ "$V" = "main" ]; then
-            V="main+$(git rev-parse --short HEAD)"
+            V="$(git describe --always --dirty)"
           else
             V="${V#v}"
           fi

--- a/cmd/blockyard/main.go
+++ b/cmd/blockyard/main.go
@@ -449,6 +449,9 @@ func main() {
 			ops.SpawnSoftDeleteSweeper(bgCtx, srv)
 		}()
 
+		if cfg.Update != nil && cfg.Update.Repo != "" {
+			update.SetRepo(cfg.Update.Repo)
+		}
 		bgWg.Add(1)
 		go func() {
 			defer bgWg.Done()
@@ -495,7 +498,7 @@ func main() {
 			_, err := be.ListManaged(ctx)
 			return err
 		},
-		UpdateVersion: func() *string { return srv.UpdateAvailable.Load() },
+		UpdateAvailable: srv.UpdateAvailableVersion,
 	}
 	if srv.Config.OIDC != nil {
 		checkerDeps.IDPCheck = func(ctx context.Context) error {

--- a/cmd/by/selfupdate_test.go
+++ b/cmd/by/selfupdate_test.go
@@ -17,11 +17,16 @@ func TestInferChannel(t *testing.T) {
 		version string
 		want    string
 	}{
-		{"dev", "stable"},
+		// Clean semver tags map to the stable release stream.
 		{"0.0.3", "stable"},
 		{"1.2.3", "stable"},
+		{"v1.2.3", "stable"},
+		// SHA-shaped builds (legacy main+, git describe, bare hash) and
+		// the unidentified "dev" placeholder all default to main.
 		{"main+abc1234", "main"},
-		{"main+0000000", "main"},
+		{"v0.0.3-3-gabc1234", "main"},
+		{"abc1234", "main"},
+		{"dev", "main"},
 	}
 	for _, tt := range tests {
 		got := update.InferChannel(tt.version)

--- a/cmd/by/updatenotice.go
+++ b/cmd/by/updatenotice.go
@@ -14,9 +14,11 @@ import (
 const updateCheckInterval = 24 * time.Hour
 
 // updateCache is persisted to disk to throttle GitHub API calls.
+// State mirrors update.State so a stale "available" entry can be
+// distinguished from "checked, up to date".
 type updateCache struct {
+	State         string    `json:"state"`
 	LatestVersion string    `json:"latest_version"`
-	Channel       string    `json:"channel"`
 	CheckedAt     time.Time `json:"checked_at"`
 }
 
@@ -59,62 +61,52 @@ var updateNoticeState struct {
 	ch chan updateResult
 }
 
-// startUpdateCheck kicks off a background update check if the cache is stale.
-// Called from PersistentPreRun so the HTTP request runs concurrently with the
-// actual command.
+// startUpdateCheck kicks off a background update check if the cache
+// is stale. Called from PersistentPreRun so the HTTP request runs
+// concurrently with the actual command.
 func startUpdateCheck() {
 	cache := loadUpdateCache()
-	channel := update.InferChannel(version)
 
-	// If the cache is fresh and no update is available, skip entirely.
-	if cache != nil && cache.Channel == channel &&
-		time.Since(cache.CheckedAt) < updateCheckInterval &&
-		cache.LatestVersion == version {
+	// Cache is fresh — skip the network call. finishUpdateCheck
+	// will print from cache if there's still an update to flag.
+	if cache != nil && time.Since(cache.CheckedAt) < updateCheckInterval {
 		return
 	}
 
-	// If the cache is fresh and shows an update, we'll print from cache
-	// in finishUpdateCheck — no need for a network call.
-	if cache != nil && cache.Channel == channel &&
-		time.Since(cache.CheckedAt) < updateCheckInterval {
-		return
-	}
-
-	// Cache is stale or missing — start a background check.
 	ch := make(chan updateResult, 1)
 	updateNoticeState.ch = ch
 	go func() {
-		res, err := update.CheckLatest(channel, version)
+		res, err := update.CheckLatest(version)
 		ch <- updateResult{result: res, err: err}
 	}()
 }
 
-// finishUpdateCheck collects the background check result (if any) and prints
-// a one-line notice to stderr when an update is available.
+// finishUpdateCheck collects the background check result (if any) and
+// prints a one-line notice to stderr when an update is available.
 // Called from PersistentPostRunE after the command finishes.
 func finishUpdateCheck() {
-	channel := update.InferChannel(version)
-
 	if updateNoticeState.ch != nil {
-		// A background check is running — collect the result.
 		ur := <-updateNoticeState.ch
 		updateNoticeState.ch = nil
-		if ur.err == nil && ur.result != nil {
-			saveUpdateCache(&updateCache{
-				LatestVersion: ur.result.LatestVersion,
-				Channel:       ur.result.Channel,
-				CheckedAt:     time.Now(),
-			})
-			if ur.result.UpdateAvailable {
-				printUpdateNotice(ur.result.LatestVersion)
-			}
+		if ur.err != nil || ur.result == nil {
+			return
+		}
+		saveUpdateCache(&updateCache{
+			State:         string(ur.result.State),
+			LatestVersion: ur.result.LatestVersion,
+			CheckedAt:     time.Now(),
+		})
+		if ur.result.State == update.StateUpdateAvailable {
+			printUpdateNotice(ur.result.LatestVersion)
 		}
 		return
 	}
 
-	// No background check — use cached result.
+	// No background check — surface the cached "update available"
+	// notice if it's still relevant.
 	cache := loadUpdateCache()
-	if cache != nil && cache.Channel == channel && cache.LatestVersion != version {
+	if cache != nil && cache.State == string(update.StateUpdateAvailable) &&
+		cache.LatestVersion != version {
 		printUpdateNotice(cache.LatestVersion)
 	}
 }

--- a/cmd/by/updatenotice_test.go
+++ b/cmd/by/updatenotice_test.go
@@ -20,7 +20,7 @@ func TestLoadUpdateCache_Valid(t *testing.T) {
 	cacheDir := filepath.Join(dir, "by")
 	os.MkdirAll(cacheDir, 0o700)
 	os.WriteFile(filepath.Join(cacheDir, "update-check.json"),
-		[]byte(`{"latest_version":"2.0.0","channel":"stable","checked_at":"2026-01-01T00:00:00Z"}`),
+		[]byte(`{"latest_version":"2.0.0","state":"update_available","checked_at":"2026-01-01T00:00:00Z"}`),
 		0o600)
 
 	c := loadUpdateCache()
@@ -30,8 +30,8 @@ func TestLoadUpdateCache_Valid(t *testing.T) {
 	if c.LatestVersion != "2.0.0" {
 		t.Errorf("LatestVersion = %q, want 2.0.0", c.LatestVersion)
 	}
-	if c.Channel != "stable" {
-		t.Errorf("Channel = %q, want stable", c.Channel)
+	if c.State != "update_available" {
+		t.Errorf("State = %q, want update_available", c.State)
 	}
 }
 
@@ -55,7 +55,7 @@ func TestSaveUpdateCache(t *testing.T) {
 
 	saveUpdateCache(&updateCache{
 		LatestVersion: "3.0.0",
-		Channel:       "main",
+		State:         "update_available",
 	})
 
 	// Verify file was created.

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -30,6 +30,10 @@ ARG VERSION=dev
 # Docker implementation back in. The resulting binary does not
 # import internal/backend/process and cannot speak to a process
 # backend config.
+#
+# Callers should pass VERSION as the release tag or `git describe`
+# output so the update check has a real identifier to compare. The
+# "dev" fallback only kicks in for ad-hoc builds with no build-arg.
 RUN CGO_ENABLED=0 go build ${COVER:+-cover} \
     -tags "minimal,docker_backend" \
     -ldflags "-X main.version=${VERSION}" \

--- a/internal/api/readyz.go
+++ b/internal/api/readyz.go
@@ -163,8 +163,8 @@ func readyzHandler(srv *server.Server, trusted bool) http.HandlerFunc {
 		}
 		if trusted || isAuthenticated(r, srv) {
 			result["checks"] = checks
-			if v := srv.UpdateAvailable.Load(); v != nil {
-				result["update_available"] = *v
+			if v := srv.UpdateAvailableVersion(); v != "" {
+				result["update_available"] = v
 			}
 		}
 		json.NewEncoder(w).Encode(result)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -194,7 +194,7 @@ func NewRouter(srv *server.Server, startBG func(), orch *orchestrator.Orchestrat
 	uiHandler := ui.New()
 	r.Group(func(r chi.Router) {
 		r.Use(auth.AppAuthMiddleware(authDeps))
-		uiHandler.RegisterRoutes(r, srv)
+		uiHandler.RegisterRoutes(r, srv, orch, bgCtx)
 	})
 
 	// Self-hosted documentation (embedded Hugo build).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,12 @@ type UpdateConfig struct {
 	Channel     string   `toml:"channel"`       // "stable" (default) or "main"
 	WatchPeriod Duration `toml:"watch_period"`  // health monitoring after update completes
 
+	// Repo is the GitHub owner/repo to query for releases and the
+	// origin/main HEAD comparison (e.g. "cynkra/blockyard"). Empty
+	// keeps the upstream default. Operators of forks override this
+	// to point the update check at their own repo.
+	Repo string `toml:"repo"`
+
 	// AltBindRange is the port range the process orchestrator picks
 	// an alternate bind from when spawning the new server during a
 	// rolling update. Operator-configured, separate from

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -41,16 +41,18 @@ type Orchestrator struct {
 	state atomic.Value // "idle"/"updating"/"watching"/"rolling_back"
 }
 
-// updateAPI abstracts the GitHub release check so tests can mock it.
+// updateAPI abstracts the GitHub release lookup so tests can mock
+// it. FetchInstallTarget returns the version string to install on
+// the given channel, or "" when current already matches.
 type updateAPI interface {
-	CheckLatest(channel, currentVersion string) (*update.Result, error)
+	FetchInstallTarget(channel, currentVersion string) (string, error)
 }
 
-// DefaultChecker wraps the existing update.CheckLatest function.
+// DefaultChecker wraps the update package's install-target lookup.
 type DefaultChecker struct{}
 
-func (DefaultChecker) CheckLatest(channel, currentVersion string) (*update.Result, error) {
-	return update.CheckLatest(channel, currentVersion)
+func (DefaultChecker) FetchInstallTarget(channel, currentVersion string) (string, error) {
+	return update.FetchInstallTarget(channel, currentVersion)
 }
 
 // New creates an Orchestrator wired to a ServerFactory. The factory
@@ -118,8 +120,8 @@ func newForTestWithFactory(f ServerFactory) *Orchestrator {
 
 type noopChecker struct{}
 
-func (noopChecker) CheckLatest(_, _ string) (*update.Result, error) {
-	return &update.Result{UpdateAvailable: false}, nil
+func (noopChecker) FetchInstallTarget(_, _ string) (string, error) {
+	return "", nil
 }
 
 // stubFactory is a minimal ServerFactory used by NewForTest. All
@@ -185,21 +187,20 @@ func (o *Orchestrator) Update(
 	channel string,
 	sender task.Sender,
 ) (bool, error) {
-	// 1. Check for newer version.
-	result, err := o.update.CheckLatest(channel, o.version)
+	// 1. Resolve install target for the configured channel.
+	target, err := o.update.FetchInstallTarget(channel, o.version)
 	if err != nil {
-		return false, fmt.Errorf("check latest: %w", err)
+		return false, fmt.Errorf("fetch install target: %w", err)
 	}
-	if !result.UpdateAvailable {
-		sender.Write("Already up to date (" + result.CurrentVersion + ").")
+	if target == "" {
+		sender.Write("Already up to date (" + o.version + ").")
 		return false, nil
 	}
-	newRef := imageWithTag(o.factory.CurrentImageBase(ctx), result.LatestVersion)
-	sender.Write(fmt.Sprintf("Update available: %s → %s",
-		result.CurrentVersion, result.LatestVersion))
+	newRef := imageWithTag(o.factory.CurrentImageBase(ctx), target)
+	sender.Write(fmt.Sprintf("Update target: %s → %s", o.version, target))
 
 	// 2. Variant-specific prep (Docker: pull image; process: no-op).
-	if err := o.factory.PreUpdate(ctx, result.LatestVersion, sender); err != nil {
+	if err := o.factory.PreUpdate(ctx, target, sender); err != nil {
 		return false, fmt.Errorf("pre-update: %w", err)
 	}
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cynkra/blockyard/internal/config"
 	"github.com/cynkra/blockyard/internal/db"
 	"github.com/cynkra/blockyard/internal/task"
-	"github.com/cynkra/blockyard/internal/update"
 )
 
 // --- fake server factory (backend-agnostic) ---
@@ -75,12 +74,12 @@ func (f *fakeServerFactory) SupportsRollback() bool {
 // --- mock update checker ---
 
 type mockChecker struct {
-	result *update.Result
+	target string // install target version; "" = up to date
 	err    error
 }
 
-func (m *mockChecker) CheckLatest(_, _ string) (*update.Result, error) {
-	return m.result, m.err
+func (m *mockChecker) FetchInstallTarget(_, _ string) (string, error) {
+	return m.target, m.err
 }
 
 // --- test helpers ---
@@ -137,11 +136,7 @@ func newSender(t *testing.T) task.Sender {
 
 func TestUpdateAlreadyCurrent(t *testing.T) {
 	checker := &mockChecker{
-		result: &update.Result{
-			CurrentVersion:  "1.0.0",
-			LatestVersion:   "1.0.0",
-			UpdateAvailable: false,
-		},
+		target: "",
 	}
 	o, tracker := newTestOrchestrator(t, &fakeServerFactory{}, checker)
 	sender := newSender(t)
@@ -160,11 +155,7 @@ func TestUpdateAlreadyCurrent(t *testing.T) {
 
 func TestUpdatePreUpdateFails(t *testing.T) {
 	checker := &mockChecker{
-		result: &update.Result{
-			CurrentVersion:  "1.0.0",
-			LatestVersion:   "2.0.0",
-			UpdateAvailable: true,
-		},
+		target: "2.0.0",
 	}
 	factory := &fakeServerFactory{
 		preUpdateErr: io.ErrUnexpectedEOF,
@@ -183,11 +174,7 @@ func TestUpdatePreUpdateFails(t *testing.T) {
 
 func TestUpdateCreateFails(t *testing.T) {
 	checker := &mockChecker{
-		result: &update.Result{
-			CurrentVersion:  "1.0.0",
-			LatestVersion:   "2.0.0",
-			UpdateAvailable: true,
-		},
+		target: "2.0.0",
 	}
 	factory := &fakeServerFactory{
 		createInstanceFn: func(context.Context, string, []string, task.Sender) (newServerInstance, error) {
@@ -208,11 +195,7 @@ func TestUpdateCreateFails(t *testing.T) {
 
 func TestUpdateHappyPath(t *testing.T) {
 	checker := &mockChecker{
-		result: &update.Result{
-			CurrentVersion:  "1.0.0",
-			LatestVersion:   "2.0.0",
-			UpdateAvailable: true,
-		},
+		target: "2.0.0",
 	}
 
 	readyzServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -263,11 +246,7 @@ func TestUpdateConcurrencyGuard(t *testing.T) {
 
 func TestUpdateReadyTimeout(t *testing.T) {
 	checker := &mockChecker{
-		result: &update.Result{
-			CurrentVersion:  "1.0.0",
-			LatestVersion:   "2.0.0",
-			UpdateAvailable: true,
-		},
+		target: "2.0.0",
 	}
 
 	var killed atomic.Bool
@@ -301,9 +280,7 @@ func TestUpdateReadyTimeout(t *testing.T) {
 
 func TestUpdateBackupFailsNoDrain(t *testing.T) {
 	checker := &mockChecker{
-		result: &update.Result{
-			CurrentVersion: "1.0.0", LatestVersion: "2.0.0", UpdateAvailable: true,
-		},
+		target: "2.0.0",
 	}
 	o, tracker := newTestOrchestrator(t, &fakeServerFactory{}, checker)
 	memDB, err := db.Open(config.DatabaseConfig{Driver: "sqlite", Path: ":memory:"})
@@ -325,9 +302,7 @@ func TestUpdateBackupFailsNoDrain(t *testing.T) {
 
 func TestUpdateActivateFailsAfterDrain(t *testing.T) {
 	checker := &mockChecker{
-		result: &update.Result{
-			CurrentVersion: "1.0.0", LatestVersion: "2.0.0", UpdateAvailable: true,
-		},
+		target: "2.0.0",
 	}
 
 	activateCalled := false
@@ -789,11 +764,7 @@ func TestScheduledSkipsInProgress(t *testing.T) {
 
 func TestRunScheduledCancellation(t *testing.T) {
 	checker := &mockChecker{
-		result: &update.Result{
-			CurrentVersion:  "1.0.0",
-			LatestVersion:   "1.0.0",
-			UpdateAvailable: false,
-		},
+		target: "",
 	}
 	o, _ := newTestOrchestrator(t, &fakeServerFactory{}, checker)
 	o.cfg.Update = &config.UpdateConfig{
@@ -826,7 +797,7 @@ func TestRunScheduledInvalidCron(t *testing.T) {
 
 func TestRunScheduledOnceNoUpdate(t *testing.T) {
 	checker := &mockChecker{
-		result: &update.Result{UpdateAvailable: false},
+		target: "",
 	}
 	o, _ := newTestOrchestrator(t, &fakeServerFactory{}, checker)
 	if o.runScheduledOnce(context.Background(), "stable") {
@@ -844,7 +815,7 @@ func TestRunScheduledOnceCheckError(t *testing.T) {
 
 func TestRunScheduledOnceCASFails(t *testing.T) {
 	checker := &mockChecker{
-		result: &update.Result{UpdateAvailable: true, CurrentVersion: "1.0.0", LatestVersion: "2.0.0"},
+		target: "2.0.0",
 	}
 	o, _ := newTestOrchestrator(t, &fakeServerFactory{}, checker)
 	o.state.Store("updating")
@@ -855,7 +826,7 @@ func TestRunScheduledOnceCASFails(t *testing.T) {
 
 func TestRunScheduledOnceUpdateFails(t *testing.T) {
 	checker := &mockChecker{
-		result: &update.Result{UpdateAvailable: true, CurrentVersion: "1.0.0", LatestVersion: "2.0.0"},
+		target: "2.0.0",
 	}
 	factory := &fakeServerFactory{
 		preUpdateErr: io.ErrUnexpectedEOF,
@@ -871,11 +842,7 @@ func TestRunScheduledOnceUpdateFails(t *testing.T) {
 
 func TestRunScheduledNoUpdate(t *testing.T) {
 	checker := &mockChecker{
-		result: &update.Result{
-			CurrentVersion:  "1.0.0",
-			LatestVersion:   "1.0.0",
-			UpdateAvailable: false,
-		},
+		target: "",
 	}
 	o, _ := newTestOrchestrator(t, &fakeServerFactory{}, checker)
 	o.cfg.Update = &config.UpdateConfig{

--- a/internal/orchestrator/process_integration_test.go
+++ b/internal/orchestrator/process_integration_test.go
@@ -49,7 +49,6 @@ import (
 	"github.com/cynkra/blockyard/internal/db"
 	"github.com/cynkra/blockyard/internal/orchestrator"
 	"github.com/cynkra/blockyard/internal/task"
-	"github.com/cynkra/blockyard/internal/update"
 )
 
 var builtBlockyardBinary string
@@ -291,11 +290,7 @@ func TestProcessOrchestratorFullUpdate(t *testing.T) {
 	}
 	t.Cleanup(func() { database.Close() })
 
-	checker := &e2eChecker{result: &update.Result{
-		CurrentVersion:  "1.0.0",
-		LatestVersion:   "2.0.0",
-		UpdateAvailable: true,
-	}}
+	checker := &e2eChecker{target: "2.0.0"}
 
 	var drainCalls, undrainCalls, exitCalls atomic.Int32
 	orch := orchestrator.New(
@@ -381,14 +376,14 @@ func TestProcessOrchestratorFullUpdate(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 }
 
-// e2eChecker is a test-only update checker that returns a fixed result.
+// e2eChecker is a test-only updateAPI that returns a fixed install target.
 type e2eChecker struct {
-	result *update.Result
+	target string
 	err    error
 }
 
-func (c *e2eChecker) CheckLatest(_, _ string) (*update.Result, error) {
-	return c.result, c.err
+func (c *e2eChecker) FetchInstallTarget(_, _ string) (string, error) {
+	return c.target, c.err
 }
 
 // findFreePort asks the kernel for an ephemeral port and immediately

--- a/internal/orchestrator/scheduled.go
+++ b/internal/orchestrator/scheduled.go
@@ -57,12 +57,12 @@ func (o *Orchestrator) RunScheduled(
 // (successful update), false to continue the schedule loop.
 func (o *Orchestrator) runScheduledOnce(ctx context.Context, channel string) bool {
 	slog.Info("update scheduler: checking for updates")
-	result, err := o.update.CheckLatest(channel, o.version)
+	target, err := o.update.FetchInstallTarget(channel, o.version)
 	if err != nil {
 		slog.Warn("update scheduler: check failed", "error", err)
 		return false
 	}
-	if !result.UpdateAvailable {
+	if target == "" {
 		slog.Info("update scheduler: already up to date")
 		return false
 	}
@@ -74,8 +74,8 @@ func (o *Orchestrator) runScheduledOnce(ctx context.Context, channel string) boo
 	}
 
 	slog.Info("update scheduler: starting update",
-		"current", result.CurrentVersion,
-		"latest", result.LatestVersion)
+		"current", o.version,
+		"target", target)
 
 	sender := o.tasks.Create(uuid.New().String(), "scheduled-update")
 	updated, err := o.Update(ctx, channel, sender)

--- a/internal/preflight/checker.go
+++ b/internal/preflight/checker.go
@@ -17,8 +17,8 @@ type RuntimeDeps struct {
 	IDPCheck      func(ctx context.Context) error // OIDC IdP health (nil = no OIDC)
 	VaultCheck    func(ctx context.Context) error // OpenBao health (nil = no vault)
 	VaultTokenOK  func() bool                     // AppRole token health (nil = no AppRole)
-	UpdateVersion func() *string                  // latest available version (nil = not checked)
-	ServerVersion string
+	UpdateAvailable func() string                 // latest version when an update is recommended; "" otherwise
+	ServerVersion   string
 }
 
 // Checker runs system checks and caches the latest report. It

--- a/internal/preflight/runtime_checks.go
+++ b/internal/preflight/runtime_checks.go
@@ -34,7 +34,7 @@ func runDynamicChecks(ctx context.Context, deps RuntimeDeps) *Report {
 	if deps.StorePath != "" {
 		r.Add(checkDiskSpace(deps.StorePath))
 	}
-	if deps.UpdateVersion != nil {
+	if deps.UpdateAvailable != nil {
 		r.Add(checkUpdateAvailable(deps))
 	}
 
@@ -249,12 +249,12 @@ func checkUpdateAvailable(deps RuntimeDeps) Result {
 	const name = "update_available"
 	const category = "runtime"
 
-	latest := deps.UpdateVersion()
-	if latest == nil {
+	latest := deps.UpdateAvailable()
+	if latest == "" {
 		return Result{
 			Name:     name,
 			Severity: SeverityOK,
-			Message:  "running " + deps.ServerVersion + " (update check pending)",
+			Message:  "running " + deps.ServerVersion,
 			Category: category,
 		}
 	}
@@ -262,7 +262,7 @@ func checkUpdateAvailable(deps RuntimeDeps) Result {
 	return Result{
 		Name:     name,
 		Severity: SeverityInfo,
-		Message:  fmt.Sprintf("running %s; version %s is available", deps.ServerVersion, *latest),
+		Message:  fmt.Sprintf("running %s; version %s is available", deps.ServerVersion, latest),
 		Category: category,
 	}
 }

--- a/internal/preflight/runtime_checks_test.go
+++ b/internal/preflight/runtime_checks_test.go
@@ -150,8 +150,8 @@ func TestCheckDiskSpaceBadPath(t *testing.T) {
 func TestCheckUpdateAvailable(t *testing.T) {
 	t.Run("no update", func(t *testing.T) {
 		deps := RuntimeDeps{
-			UpdateVersion: func() *string { return nil },
-			ServerVersion: "1.0.0",
+			UpdateAvailable: func() string { return "" },
+			ServerVersion:   "1.0.0",
 		}
 		res := checkUpdateAvailable(deps)
 		if res.Severity != SeverityOK {
@@ -160,10 +160,9 @@ func TestCheckUpdateAvailable(t *testing.T) {
 	})
 
 	t.Run("update available", func(t *testing.T) {
-		v := "1.1.0"
 		deps := RuntimeDeps{
-			UpdateVersion: func() *string { return &v },
-			ServerVersion: "1.0.0",
+			UpdateAvailable: func() string { return "1.1.0" },
+			ServerVersion:   "1.0.0",
 		}
 		res := checkUpdateAvailable(deps)
 		if res.Severity != SeverityInfo {
@@ -180,9 +179,9 @@ func TestRunDynamicChecks(t *testing.T) {
 		IDPCheck:      func(ctx context.Context) error { return nil },
 		VaultCheck:    func(ctx context.Context) error { return nil },
 		VaultTokenOK:  func() bool { return true },
-		StorePath:     t.TempDir(),
-		UpdateVersion: func() *string { return nil },
-		ServerVersion: "1.0.0",
+		StorePath:       t.TempDir(),
+		UpdateAvailable: func() string { return "" },
+		ServerVersion:   "1.0.0",
 	}
 
 	report := runDynamicChecks(context.Background(), deps)

--- a/internal/server/state.go
+++ b/internal/server/state.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cynkra/blockyard/internal/session"
 	"github.com/cynkra/blockyard/internal/task"
 	"github.com/cynkra/blockyard/internal/telemetry"
+	"github.com/cynkra/blockyard/internal/update"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -106,9 +107,15 @@ type Server struct {
 	// Version is the server version string, set at build time.
 	Version string
 
-	// UpdateAvailable stores the latest available version string when
-	// a newer release is detected. Nil means no update or not yet checked.
-	UpdateAvailable atomic.Pointer[string]
+	// UpdateStatus holds the most recent CheckLatest result. Nil
+	// until the first check runs. The richer State enum lets readers
+	// distinguish "update available" from "ahead of latest" / "dev
+	// build" / "couldn't reach GitHub" / etc.
+	UpdateStatus atomic.Pointer[update.Result]
+
+	// UpdateLastChecked records the wall-clock time of the most recent
+	// update check (scheduled or manual). Nil until the first check runs.
+	UpdateLastChecked atomic.Pointer[time.Time]
 
 	// RestoreWG is used in tests to wait for background restore goroutines
 	// to complete before cleanup. Nil in production.
@@ -120,9 +127,25 @@ type Server struct {
 	SpawnLogCaptureFn func(ctx context.Context, srv *Server, workerID, appID string)
 }
 
-// SetUpdateAvailable records that a newer version is available.
-func (srv *Server) SetUpdateAvailable(v string) {
-	srv.UpdateAvailable.Store(&v)
+// SetUpdateStatus records the latest update check result and stamps
+// UpdateLastChecked with the current time. Satisfies the
+// update.UpdateStore interface so the periodic checker and the UI's
+// manual-refresh handler can both feed results in.
+func (srv *Server) SetUpdateStatus(r *update.Result) {
+	srv.UpdateStatus.Store(r)
+	now := time.Now()
+	srv.UpdateLastChecked.Store(&now)
+}
+
+// UpdateAvailableVersion returns the upstream version string when an
+// update is recommended, or "" otherwise. Convenience for consumers
+// (preflight, readyz) that previously only cared about the boolean.
+func (srv *Server) UpdateAvailableVersion() string {
+	s := srv.UpdateStatus.Load()
+	if s == nil || s.State != update.StateUpdateAvailable {
+		return ""
+	}
+	return s.LatestVersion
 }
 
 // GetVersion returns the running server version.

--- a/internal/server/state_test.go
+++ b/internal/server/state_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cynkra/blockyard/internal/auth"
 	"github.com/cynkra/blockyard/internal/backend/mock"
 	"github.com/cynkra/blockyard/internal/config"
+	"github.com/cynkra/blockyard/internal/update"
 )
 
 func TestWorkerMapCountForApp(t *testing.T) {
@@ -411,12 +412,34 @@ func TestSetIdleSinceIfZero(t *testing.T) {
 	}
 }
 
-func TestSetUpdateAvailable(t *testing.T) {
+func TestSetUpdateStatus(t *testing.T) {
 	srv := &Server{}
-	srv.SetUpdateAvailable("2.0.0")
-	got := srv.UpdateAvailable.Load()
-	if got == nil || *got != "2.0.0" {
-		t.Errorf("expected 2.0.0, got %v", got)
+	srv.SetUpdateStatus(&update.Result{
+		State:          update.StateUpdateAvailable,
+		CurrentVersion: "1.0.0",
+		LatestVersion:  "2.0.0",
+	})
+	got := srv.UpdateStatus.Load()
+	if got == nil || got.LatestVersion != "2.0.0" {
+		t.Errorf("expected LatestVersion=2.0.0, got %+v", got)
+	}
+	if srv.UpdateLastChecked.Load() == nil {
+		t.Error("expected UpdateLastChecked to be stamped")
+	}
+}
+
+func TestUpdateAvailableVersion(t *testing.T) {
+	srv := &Server{}
+	if v := srv.UpdateAvailableVersion(); v != "" {
+		t.Errorf("expected empty before any check, got %q", v)
+	}
+	srv.SetUpdateStatus(&update.Result{State: update.StateUpToDate, LatestVersion: "1.0.0"})
+	if v := srv.UpdateAvailableVersion(); v != "" {
+		t.Errorf("up_to_date should not surface an available version, got %q", v)
+	}
+	srv.SetUpdateStatus(&update.Result{State: update.StateUpdateAvailable, LatestVersion: "2.0.0"})
+	if v := srv.UpdateAvailableVersion(); v != "2.0.0" {
+		t.Errorf("expected 2.0.0, got %q", v)
 	}
 }
 

--- a/internal/ui/templates/admin.html
+++ b/internal/ui/templates/admin.html
@@ -42,6 +42,17 @@
         <span class="badge badge-xs badge-soft badge-warning ml-2">{{.Errors.Count}}</span>
         {{end}}
     </button>
+    <button class="tab {{if eq .ActiveTab "version"}}tab-active{{end}}"
+            hx-get="/ui/admin/tab/version"
+            hx-target="#admin-tab-content"
+            hx-swap="innerHTML"
+            hx-push-url="/admin?tab=version"
+            hx-on::after-request="setAdminActiveTab(this)">
+        Updates
+        {{if .Updates.UpdateAvailable}}
+        <span class="badge badge-xs badge-soft badge-warning ml-2">new</span>
+        {{end}}
+    </button>
 </nav>
 
 <div id="admin-tab-content" class="admin-tab-content">
@@ -49,6 +60,8 @@
         {{template "adminTabSystem" .}}
     {{else if eq .ActiveTab "errors"}}
         {{template "adminErrors" .Errors}}
+    {{else if eq .ActiveTab "version"}}
+        {{template "adminVersion" .Updates}}
     {{else}}
         {{template "adminUsers" .Users}}
     {{end}}

--- a/internal/ui/templates/admin_version.html
+++ b/internal/ui/templates/admin_version.html
@@ -1,0 +1,103 @@
+{{define "adminVersion"}}
+<div id="admin-version-card">
+    {{template "adminVersionCard" .}}
+</div>
+{{end}}
+
+{{define "adminVersionCard"}}
+{{$badge := .StatusBadge}}
+<div class="flex items-start justify-between gap-4 mb-4">
+    <div class="space-y-1">
+        <div class="text-sm">
+            <span class="text-base-content/60">Running:</span>
+            <span class="font-mono">{{.CurrentVersion}}</span>
+            {{if .LastCheckedStr}}
+            <span class="badge badge-sm badge-soft {{$badge.Class}} ml-1">{{$badge.Label}}</span>
+            {{end}}
+        </div>
+        {{if .LatestVersion}}
+        <div class="text-sm">
+            <span class="text-base-content/60">{{if .UpdateAvailable}}Latest:{{else}}Reference:{{end}}</span>
+            <span class="font-mono">{{.LatestVersion}}</span>
+        </div>
+        {{end}}
+        {{if .Detail}}
+        <div class="text-xs text-base-content/70">{{.Detail}}</div>
+        {{end}}
+        <div class="text-xs text-base-content/60">
+            {{if .LastCheckedStr}}
+            Last checked <span class="time-ago" data-timestamp="{{.LastCheckedStr}}" title="{{.LastCheckedStr}}">{{timeAgo .LastCheckedStr}}</span>.
+            {{else}}
+            No check has run yet.
+            {{end}}
+        </div>
+        {{if .CheckError}}
+        <div class="text-sm text-error">Check failed: {{.CheckError}}</div>
+        {{end}}
+    </div>
+    <div class="flex items-center gap-2 shrink-0">
+        <button class="btn btn-soft btn-sm"
+                hx-post="/ui/admin/update/check"
+                hx-target="#admin-version-card"
+                hx-swap="innerHTML"
+                hx-disabled-elt="this">
+            Check for updates
+        </button>
+        {{if .UpdateAvailable}}
+        <button class="btn btn-primary btn-sm"
+                hx-post="/ui/admin/update/start"
+                hx-target="#admin-version-card"
+                hx-swap="innerHTML"
+                hx-disabled-elt="this"
+                hx-confirm="Start rolling update to {{.LatestVersion}}? The server will restart when the new version is healthy."
+                {{if not .UpdateSupported}}disabled title="This deployment is managed by the container runtime; update through there."{{end}}
+                {{if and .UpdateSupported (ne .UpdateState "idle")}}disabled title="Update already in progress ({{.UpdateState}})."{{end}}>
+            Update to {{.LatestVersion}}
+        </button>
+        {{end}}
+    </div>
+</div>
+{{if and .UpdateAvailable (not .UpdateSupported)}}
+<div class="alert alert-info alert-soft text-sm">
+    <span>This server runs as a managed container. Apply the update through your container runtime (e.g. redeploy with the new image tag).</span>
+</div>
+{{end}}
+{{end}}
+
+{{define "adminUpdateProgress"}}
+<div id="admin-update-progress"
+     hx-get="/ui/admin/update/progress"
+     hx-trigger="every 2s"
+     hx-swap="outerHTML"
+     data-state="{{.UpdateState}}">
+    <div class="flex items-center gap-3">
+        <span class="loading loading-spinner loading-sm"></span>
+        <div class="text-sm">
+            <div>Update in progress — server will restart when the new version is healthy.</div>
+            <div class="text-xs text-base-content/60">State: <span class="font-mono">{{.UpdateState}}</span></div>
+        </div>
+    </div>
+</div>
+<script>
+(function() {
+    if (window.__adminUpdateWatcherInstalled) return;
+    window.__adminUpdateWatcherInstalled = true;
+    document.body.addEventListener('htmx:sendError', onDrop);
+    document.body.addEventListener('htmx:responseError', onDrop);
+    function onDrop() {
+        if (!document.getElementById('admin-update-progress')) return;
+        showReloadOverlay();
+    }
+    function showReloadOverlay() {
+        if (document.getElementById('update-reload-overlay')) return;
+        var o = document.createElement('div');
+        o.id = 'update-reload-overlay';
+        o.className = 'fixed inset-0 bg-base-100/90 flex items-center justify-center z-[9999]';
+        o.innerHTML = '<div class="text-center space-y-3"><span class="loading loading-spinner loading-lg"></span>' +
+                      '<p class="text-sm">Server restarting — reloading…</p></div>';
+        document.body.appendChild(o);
+        setTimeout(function() { window.location.reload(); }, 5000);
+    }
+})();
+</script>
+{{end}}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -19,8 +19,11 @@ import (
 
 	"github.com/cynkra/blockyard/internal/auth"
 	"github.com/cynkra/blockyard/internal/db"
+	"github.com/cynkra/blockyard/internal/orchestrator"
 	"github.com/cynkra/blockyard/internal/preflight"
 	"github.com/cynkra/blockyard/internal/server"
+	"github.com/cynkra/blockyard/internal/task"
+	updatepkg "github.com/cynkra/blockyard/internal/update"
 )
 
 //go:embed templates/*.html static/*
@@ -220,7 +223,7 @@ func New() *UI {
 		),
 	)
 	// Re-parse admin.html with the shared system_checks, admin_users,
-	// admin_errors, and admin_tabs fragments.
+	// admin_errors, admin_tabs, and admin_version fragments.
 	pages["admin.html"] = template.Must(
 		template.New("").Funcs(funcMap).ParseFS(
 			content,
@@ -230,6 +233,7 @@ func New() *UI {
 			"templates/admin_users.html",
 			"templates/admin_errors.html",
 			"templates/admin_tabs.html",
+			"templates/admin_version.html",
 		),
 	)
 
@@ -241,6 +245,7 @@ func New() *UI {
 		"system_banner.html",
 		"admin_users.html",
 		"admin_errors.html",
+		"admin_version.html",
 		"sidebar.html",
 		"tab_overview.html",
 		"tab_settings.html",
@@ -273,17 +278,23 @@ func New() *UI {
 	return &UI{pages: pages, fragments: fragments, static: static}
 }
 
-// RegisterRoutes mounts the UI routes on the router.
-func (ui *UI) RegisterRoutes(r chi.Router, srv *server.Server) {
+// RegisterRoutes mounts the UI routes on the router. The orchestrator
+// and bgCtx are only used by the admin Updates tab; tests without
+// rolling-update support may pass nil for orch.
+func (ui *UI) RegisterRoutes(r chi.Router, srv *server.Server, orch *orchestrator.Orchestrator, bgCtx context.Context) {
 	r.Get("/", ui.appsPage(srv))
 	r.Get("/deployments", ui.deploymentsPage(srv))
 	r.Get("/api-keys", ui.apiKeysPage(srv))
-	r.Get("/admin", ui.adminPage(srv))
+	r.Get("/admin", ui.adminPage(srv, orch))
 	r.Get("/ui/admin/users", ui.adminUsersFragment(srv))
 	r.Get("/ui/admin/errors", ui.adminErrorsFragment(srv))
 	r.Get("/ui/admin/tab/users", ui.adminTabUsersFragment(srv))
 	r.Get("/ui/admin/tab/system", ui.adminTabSystemFragment(srv))
 	r.Get("/ui/admin/tab/errors", ui.adminTabErrorsFragment(srv))
+	r.Get("/ui/admin/tab/version", ui.adminTabVersionFragment(srv, orch))
+	r.Post("/ui/admin/update/check", ui.adminUpdateCheck(srv, orch))
+	r.Post("/ui/admin/update/start", ui.adminUpdateStart(srv, orch, bgCtx))
+	r.Get("/ui/admin/update/progress", ui.adminUpdateProgress(srv, orch))
 	r.Get("/profile", ui.profilePage(srv))
 	r.Post("/ui/tokens", ui.createToken(srv))
 	r.Post("/ui/system/run", ui.systemRunFragment(srv))
@@ -365,10 +376,58 @@ type systemData struct {
 
 type adminData struct {
 	layoutData
-	ActiveTab string // "users" (default), "system", "errors"
+	ActiveTab string // "users" (default), "system", "errors", "version"
 	Report    *preflight.Report
 	Users     adminUsersData
 	Errors    adminErrorsData
+	Updates   adminVersionData // field name avoids shadowing layoutData.Version
+}
+
+type adminVersionData struct {
+	CurrentVersion  string
+	State           updatepkg.State // up_to_date, update_available, ahead, diverged, dev_build, no_remote, local_not_found, unknown
+	LatestVersion   string          // tag or short SHA; empty when no check has run
+	Detail          string          // extra context: "3 commits behind", error message, etc.
+	LastCheckedStr  string          // RFC3339 for the time-ago helper; empty when never checked
+	CheckError      string          // surfaced when a manual refresh raised an error from CheckLatest
+	UpdateSupported bool            // false on the containerized backend (orch is nil)
+	UpdateState     string          // orchestrator state: idle, updating, watching, rolling_back
+}
+
+// UpdateAvailable reports whether the Updates tab should show the
+// "new" badge and the "Update to ..." button. Used by the template.
+func (d adminVersionData) UpdateAvailable() bool {
+	return d.State == updatepkg.StateUpdateAvailable
+}
+
+// StatusBadge bundles the label and daisyUI variant class the
+// template uses to render the state pill. Returned as a struct
+// because html/template can only call zero-or-one-return-value
+// methods.
+type adminVersionBadge struct {
+	Label string
+	Class string
+}
+
+func (d adminVersionData) StatusBadge() adminVersionBadge {
+	switch d.State {
+	case updatepkg.StateUpdateAvailable:
+		return adminVersionBadge{"update available", "badge-warning"}
+	case updatepkg.StateUpToDate:
+		return adminVersionBadge{"up to date", "badge-success"}
+	case updatepkg.StateAhead:
+		return adminVersionBadge{"ahead of latest", "badge-info"}
+	case updatepkg.StateDiverged:
+		return adminVersionBadge{"diverged from main", "badge-warning"}
+	case updatepkg.StateDevBuild:
+		return adminVersionBadge{"development build", "badge-ghost"}
+	case updatepkg.StateNoRemote:
+		return adminVersionBadge{"check failed", "badge-error"}
+	case updatepkg.StateLocalNotFound:
+		return adminVersionBadge{"commit not on origin", "badge-ghost"}
+	default:
+		return adminVersionBadge{"not checked", "badge-ghost"}
+	}
 }
 
 type adminErrorsData struct {
@@ -735,7 +794,7 @@ func (ui *UI) profilePage(srv *server.Server) http.HandlerFunc {
 	}
 }
 
-func (ui *UI) adminPage(srv *server.Server) http.HandlerFunc {
+func (ui *UI) adminPage(srv *server.Server, orch *orchestrator.Orchestrator) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user := requireAuth(w, r)
 		if user == nil {
@@ -765,6 +824,7 @@ func (ui *UI) adminPage(srv *server.Server) http.HandlerFunc {
 			Report:     report,
 			Users:      usersData,
 			Errors:     buildAdminErrors(srv),
+			Updates:    buildAdminVersion(srv, orch, ""),
 		}
 
 		if err := ui.pages["admin.html"].ExecuteTemplate(w, "base", data); err != nil {
@@ -806,7 +866,7 @@ func (ui *UI) adminUsersFragment(srv *server.Server) http.HandlerFunc {
 // Unknown or empty values fall back to "users".
 func parseAdminTab(v string) string {
 	switch v {
-	case "system", "errors":
+	case "system", "errors", "version":
 		return v
 	default:
 		return "users"
@@ -868,6 +928,163 @@ func (ui *UI) adminTabErrorsFragment(srv *server.Server) http.HandlerFunc {
 			http.Error(w, "Internal error", http.StatusInternalServerError)
 		}
 	}
+}
+
+// adminTabVersionFragment renders the Updates tab body.
+func (ui *UI) adminTabVersionFragment(srv *server.Server, orch *orchestrator.Orchestrator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller := auth.CallerFromContext(r.Context())
+		if caller == nil || !caller.Role.CanManageRoles() {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		if err := ui.fragments["admin_version.html"].ExecuteTemplate(w, "adminVersion", buildAdminVersion(srv, orch, "")); err != nil {
+			http.Error(w, "Internal error", http.StatusInternalServerError)
+		}
+	}
+}
+
+// adminUpdateCheck runs a live GitHub check and re-renders the
+// version card. Runs synchronously so the user sees the fresh result
+// without a polling loop.
+func (ui *UI) adminUpdateCheck(srv *server.Server, orch *orchestrator.Orchestrator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller := auth.CallerFromContext(r.Context())
+		if caller == nil || !caller.Role.CanManageRoles() {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+		var checkErr string
+		if _, err := updatepkg.PerformCheck(srv); err != nil {
+			checkErr = err.Error()
+		}
+		w.Header().Set("Content-Type", "text/html")
+		if err := ui.fragments["admin_version.html"].ExecuteTemplate(w, "adminVersionCard", buildAdminVersion(srv, orch, checkErr)); err != nil {
+			http.Error(w, "Internal error", http.StatusInternalServerError)
+		}
+	}
+}
+
+// adminUpdateStart triggers a rolling update and swaps the card for
+// a progress panel. Mirrors the goroutine kickoff in
+// api.handleAdminUpdate; kept separate because the UI returns HTML
+// instead of a task-id JSON payload and imports of internal/api here
+// would close a cycle.
+func (ui *UI) adminUpdateStart(srv *server.Server, orch *orchestrator.Orchestrator, bgCtx context.Context) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller := auth.CallerFromContext(r.Context())
+		if caller == nil || !caller.Role.CanManageRoles() {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+		if orch == nil {
+			w.Header().Set("Content-Type", "text/html")
+			data := buildAdminVersion(srv, orch, "Rolling updates are not supported on this deployment; update through your container runtime.")
+			_ = ui.fragments["admin_version.html"].ExecuteTemplate(w, "adminVersionCard", data)
+			return
+		}
+
+		channel := ""
+		if srv.Config.Update != nil {
+			channel = srv.Config.Update.Channel
+		}
+		if channel == "" {
+			channel = "stable"
+		}
+
+		if !orch.CASState("idle", "updating") {
+			w.Header().Set("Content-Type", "text/html")
+			data := buildAdminVersion(srv, orch, "Update already in progress ("+orch.State()+").")
+			_ = ui.fragments["admin_version.html"].ExecuteTemplate(w, "adminVersionCard", data)
+			return
+		}
+
+		taskID := uuid.New().String()
+		sender := srv.Tasks.Create(taskID, "admin-update")
+
+		go func() {
+			updated, err := orch.Update(bgCtx, channel, sender)
+			if err != nil {
+				sender.Write(err.Error())
+				sender.Complete(task.Failed)
+				orch.SetState("idle")
+				return
+			}
+			if !updated {
+				sender.Complete(task.Completed)
+				orch.SetState("idle")
+				return
+			}
+
+			watchPeriod := 5 * time.Minute
+			if srv.Config.Update != nil && srv.Config.Update.WatchPeriod.Duration > 0 {
+				watchPeriod = srv.Config.Update.WatchPeriod.Duration
+			}
+			if err := orch.Watchdog(bgCtx, watchPeriod, sender); err != nil {
+				sender.Write(err.Error())
+				sender.Complete(task.Failed)
+				return
+			}
+			sender.Write("Update successful. Shutting down old server.")
+			sender.Complete(task.Completed)
+			orch.Exit()
+		}()
+
+		w.Header().Set("Content-Type", "text/html")
+		data := buildAdminVersion(srv, orch, "")
+		if err := ui.fragments["admin_version.html"].ExecuteTemplate(w, "adminUpdateProgress", data); err != nil {
+			http.Error(w, "Internal error", http.StatusInternalServerError)
+		}
+	}
+}
+
+// adminUpdateProgress returns the current orchestrator state as an
+// HTMX-polled fragment. When the state returns to "idle" the page
+// reloads to pick up the new version (or the old state, if the update
+// failed and the orchestrator rolled back).
+func (ui *UI) adminUpdateProgress(srv *server.Server, orch *orchestrator.Orchestrator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller := auth.CallerFromContext(r.Context())
+		if caller == nil || !caller.Role.CanManageRoles() {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+		data := buildAdminVersion(srv, orch, "")
+		w.Header().Set("Content-Type", "text/html")
+		if data.UpdateState == "idle" {
+			_ = ui.fragments["admin_version.html"].ExecuteTemplate(w, "adminVersionCard", data)
+			return
+		}
+		_ = ui.fragments["admin_version.html"].ExecuteTemplate(w, "adminUpdateProgress", data)
+	}
+}
+
+// buildAdminVersion assembles the data shown on the Updates tab from
+// the server's cached state and the orchestrator's current phase.
+// checkErr is surfaced in the UI when a manual refresh raised an
+// error from CheckLatest itself (rare — most failures fold into
+// State=NoRemote on the cached Result).
+func buildAdminVersion(srv *server.Server, orch *orchestrator.Orchestrator, checkErr string) adminVersionData {
+	data := adminVersionData{
+		CurrentVersion:  srv.Version,
+		State:           updatepkg.StateUnknown,
+		UpdateSupported: orch != nil,
+		UpdateState:     "idle",
+		CheckError:      checkErr,
+	}
+	if status := srv.UpdateStatus.Load(); status != nil {
+		data.State = status.State
+		data.LatestVersion = status.LatestVersion
+		data.Detail = status.Detail
+	}
+	if t := srv.UpdateLastChecked.Load(); t != nil {
+		data.LastCheckedStr = t.UTC().Format(time.RFC3339)
+	}
+	if orch != nil {
+		data.UpdateState = orch.State()
+	}
+	return data
 }
 
 // adminErrorsFragment serves the recent-errors table fragment, polled

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -45,7 +46,7 @@ func newTestServer(t *testing.T, cfg *config.Config) (*server.Server, *httptest.
 
 	r := chi.NewRouter()
 	uiHandler := New()
-	uiHandler.RegisterRoutes(r, srv)
+	uiHandler.RegisterRoutes(r, srv, nil, context.Background())
 
 	ts := httptest.NewServer(r)
 	t.Cleanup(ts.Close)
@@ -93,7 +94,7 @@ func authServer(t *testing.T, cfg *config.Config, sub string, role auth.Role) (*
 		})
 	})
 
-	uiHandler.RegisterRoutes(r, srv)
+	uiHandler.RegisterRoutes(r, srv, nil, context.Background())
 
 	ts := httptest.NewServer(r)
 	t.Cleanup(ts.Close)
@@ -689,7 +690,7 @@ func TestAppsPageNoCaller(t *testing.T) {
 			next.ServeHTTP(w, req.WithContext(ctx))
 		})
 	})
-	uiHandler.RegisterRoutes(r, srv)
+	uiHandler.RegisterRoutes(r, srv, nil, context.Background())
 
 	ts := httptest.NewServer(r)
 	t.Cleanup(ts.Close)
@@ -1211,7 +1212,7 @@ func TestCreateTokenForbiddenForPATSource(t *testing.T) {
 			next.ServeHTTP(w, req.WithContext(ctx))
 		})
 	})
-	uiHandler.RegisterRoutes(r, srv)
+	uiHandler.RegisterRoutes(r, srv, nil, context.Background())
 	ts := httptest.NewServer(r)
 	t.Cleanup(ts.Close)
 

--- a/internal/update/server.go
+++ b/internal/update/server.go
@@ -6,25 +6,25 @@ import (
 	"time"
 )
 
-// UpdateStore is the interface the checker needs to record its result.
-// Satisfied by server.Server via its UpdateAvailable atomic field.
+// UpdateStore is the interface a long-lived caller (the server)
+// implements to receive check results. Satisfied by server.Server.
 type UpdateStore interface {
-	SetUpdateAvailable(version string)
+	SetUpdateStatus(*Result)
 	GetVersion() string
 }
 
-// SpawnChecker periodically checks GitHub for a newer release and stores
-// the result. It performs an initial check after 1 minute, then every 24
+// SpawnChecker periodically checks GitHub for a newer release and
+// stores the result on store. Performs an initial check after one
+// minute (so startup isn't slowed by network), then once every 24
 // hours. Blocks until ctx is cancelled.
 func SpawnChecker(ctx context.Context, version string, store UpdateStore) {
-	// Initial delay — let the server finish starting up.
 	select {
 	case <-ctx.Done():
 		return
 	case <-time.After(1 * time.Minute):
 	}
 
-	check(version, store)
+	check(store)
 
 	ticker := time.NewTicker(24 * time.Hour)
 	defer ticker.Stop()
@@ -34,24 +34,32 @@ func SpawnChecker(ctx context.Context, version string, store UpdateStore) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			check(version, store)
+			check(store)
 		}
 	}
 }
 
-func check(version string, store UpdateStore) {
-	channel := InferChannel(version)
-	result, err := CheckLatest(channel, version)
+func check(store UpdateStore) {
+	_, _ = PerformCheck(store)
+}
+
+// PerformCheck runs a single update check synchronously and writes
+// the outcome to store. Always writes — even when the result is
+// "up to date" or "dev build" — so the UI can display the most
+// recent check time. Returns the result so a UI handler can render
+// it directly.
+func PerformCheck(store UpdateStore) (*Result, error) {
+	result, err := CheckLatest(store.GetVersion())
 	if err != nil {
-		slog.Warn("update check failed", "error", err)
-		return
+		return nil, err
 	}
-	if result.UpdateAvailable {
-		store.SetUpdateAvailable(result.LatestVersion)
+	store.SetUpdateStatus(result)
+	if result.State == StateUpdateAvailable {
 		slog.Warn("a newer version is available",
-			"current", version,
+			"current", result.CurrentVersion,
 			"latest", result.LatestVersion,
-			"channel", channel,
+			"detail", result.Detail,
 		)
 	}
+	return result, nil
 }

--- a/internal/update/server_test.go
+++ b/internal/update/server_test.go
@@ -5,70 +5,92 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
 
 type mockStore struct {
-	version   string
-	available string
+	version string
+	last    *Result
 }
 
-func (m *mockStore) SetUpdateAvailable(v string) { m.available = v }
-func (m *mockStore) GetVersion() string           { return m.version }
+func (m *mockStore) SetUpdateStatus(r *Result) { m.last = r }
+func (m *mockStore) GetVersion() string        { return m.version }
 
-func TestCheck_UpdateAvailable(t *testing.T) {
+func TestPerformCheck_Semver_UpdateAvailable(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(GitHubRelease{TagName: "v2.0.0"})
 	}))
 	defer srv.Close()
-
 	old := APIBase
 	APIBase = srv.URL
 	defer func() { APIBase = old }()
 
 	store := &mockStore{version: "1.0.0"}
-	check("1.0.0", store)
-
-	if store.available != "2.0.0" {
-		t.Errorf("expected available=2.0.0, got %q", store.available)
+	res, err := PerformCheck(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.State != StateUpdateAvailable {
+		t.Errorf("State = %q", res.State)
+	}
+	if store.last == nil || store.last.State != StateUpdateAvailable {
+		t.Errorf("store not updated, got %+v", store.last)
 	}
 }
 
-func TestCheck_NoUpdate(t *testing.T) {
+func TestPerformCheck_Semver_UpToDateStillRecorded(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(GitHubRelease{TagName: "v1.0.0"})
 	}))
 	defer srv.Close()
-
 	old := APIBase
 	APIBase = srv.URL
 	defer func() { APIBase = old }()
 
 	store := &mockStore{version: "1.0.0"}
-	check("1.0.0", store)
-
-	if store.available != "" {
-		t.Errorf("expected no update, got %q", store.available)
+	_, _ = PerformCheck(store)
+	if store.last == nil || store.last.State != StateUpToDate {
+		t.Errorf("expected up_to_date recorded, got %+v", store.last)
 	}
 }
 
-func TestCheck_FetchError(t *testing.T) {
+// Regression: a previous "update available" record must be replaced
+// by a fresh "up to date" record once the user upgrades, otherwise
+// the post-upgrade banner would linger forever.
+func TestPerformCheck_OverwritesPriorAvailable(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "error", http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(GitHubRelease{TagName: "v1.0.0"})
 	}))
 	defer srv.Close()
-
 	old := APIBase
 	APIBase = srv.URL
 	defer func() { APIBase = old }()
 
-	store := &mockStore{version: "1.0.0"}
-	// Should not panic or set update.
-	check("1.0.0", store)
+	store := &mockStore{
+		version: "1.0.0",
+		last:    &Result{State: StateUpdateAvailable, LatestVersion: "2.0.0"},
+	}
+	_, _ = PerformCheck(store)
+	if store.last.State != StateUpToDate {
+		t.Errorf("expected stale available record cleared, got %+v", store.last)
+	}
+}
 
-	if store.available != "" {
-		t.Errorf("expected no update on error, got %q", store.available)
+func TestPerformCheck_DevBuild(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(GitHubRelease{TagName: "v0.0.2"})
+	}))
+	defer srv.Close()
+	old := APIBase
+	APIBase = srv.URL
+	defer func() { APIBase = old }()
+
+	store := &mockStore{version: "dev"}
+	_, _ = PerformCheck(store)
+	if store.last == nil || store.last.State != StateDevBuild {
+		t.Errorf("expected dev_build state, got %+v", store.last)
 	}
 }
 
@@ -85,8 +107,31 @@ func TestSpawnChecker_CancelledImmediately(t *testing.T) {
 
 	select {
 	case <-done:
-		// Returned as expected.
 	case <-time.After(2 * time.Second):
 		t.Fatal("SpawnChecker did not return after context cancel")
+	}
+}
+
+// Smoke test that the http server fixture echoes a recognizable
+// response (sanity check for the test infra; not exercising new
+// behaviour).
+func TestFetchBranchHEAD(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/branches/") {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"commit":{"sha":"deadbeef00000000000000000000000000000000"}}`))
+	}))
+	defer srv.Close()
+	old := APIBase
+	APIBase = srv.URL
+	defer func() { APIBase = old }()
+
+	sha, err := FetchBranchHEAD("main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sha != "deadbeef00000000000000000000000000000000" {
+		t.Errorf("sha = %q", sha)
 	}
 }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,5 +1,18 @@
 // Package update provides shared logic for checking GitHub releases
-// and determining whether a newer version is available.
+// and determining whether the running build is older than the latest
+// publicly available version.
+//
+// The check distinguishes two version shapes:
+//
+//   - Semver builds (vX.Y.Z, with optional v prefix): compared
+//     numerically against the repo's latest stable release.
+//   - SHA builds (any string carrying a commit hash — bare hex,
+//     git describe, the legacy main+SHA): compared against the
+//     origin/main HEAD via the GitHub commits-compare API.
+//
+// Anything we can't classify (e.g. the literal "dev") is reported as
+// State=DevBuild — current is unrecognized, latest release is shown
+// for reference but no update is offered.
 package update
 
 import (
@@ -7,12 +20,195 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
+	"strconv"
 	"strings"
 )
 
-// APIBase is the GitHub API base URL for the blockyard repository.
-// It is a var (not const) so tests can point it at a local server.
+// APIBase is the GitHub API root pointing at the configured repo
+// (e.g. https://api.github.com/repos/cynkra/blockyard). It is a var
+// so SetRepo can rewrite it from config and tests can point it at a
+// local httptest server.
 var APIBase = "https://api.github.com/repos/cynkra/blockyard"
+
+// SetRepo points subsequent API calls at the given owner/repo
+// (e.g. "cynkra/blockyard"). Called once at server startup from
+// config so forks can self-host without recompiling.
+func SetRepo(repo string) {
+	APIBase = "https://api.github.com/repos/" + repo
+}
+
+// State enumerates how the running build compares to the upstream
+// version the check found.
+type State string
+
+const (
+	StateUnknown          State = "unknown"           // no check has run yet
+	StateUpToDate         State = "up_to_date"        // matches latest release / origin/main HEAD
+	StateUpdateAvailable  State = "update_available"  // older than latest release / behind origin/main
+	StateAhead            State = "ahead"             // newer than latest release / ahead of origin/main
+	StateDiverged         State = "diverged"          // SHA build that diverged from origin/main
+	StateDevBuild         State = "dev_build"         // unparseable version string (e.g. "dev")
+	StateNoRemote         State = "no_remote"         // GitHub unreachable or returned an error
+	StateLocalNotFound    State = "local_not_found"   // SHA known but origin/main doesn't have it
+)
+
+// Result is what consumers persist and render. LatestVersion is a
+// display string (semver tag, short SHA, or empty when unknown);
+// Detail carries human-readable extra context (e.g. "3 commits behind").
+type Result struct {
+	State          State  `json:"state"`
+	CurrentVersion string `json:"current_version"`
+	LatestVersion  string `json:"latest_version,omitempty"`
+	Detail         string `json:"detail,omitempty"`
+}
+
+// Kind tags the version string format.
+type Kind int
+
+const (
+	KindUnknown Kind = iota
+	KindSemver
+	KindSHA
+)
+
+var (
+	semverRe = regexp.MustCompile(`^v?(\d+)\.(\d+)\.(\d+)$`)
+	// Match a commit hash at the end of the string, optionally
+	// followed by -dirty. The hash may stand alone, follow git
+	// describe's "g" prefix, or follow the legacy "main+" prefix.
+	shaRe = regexp.MustCompile(`(?:^|g|\+)([a-f0-9]{7,40})(-dirty)?$`)
+)
+
+// classifyVersion returns the version kind plus, for KindSHA, the
+// extracted commit hash (without any -dirty suffix).
+func classifyVersion(v string) (Kind, string) {
+	if v == "" {
+		return KindUnknown, ""
+	}
+	if semverRe.MatchString(v) {
+		return KindSemver, ""
+	}
+	if m := shaRe.FindStringSubmatch(v); m != nil {
+		return KindSHA, m[1]
+	}
+	return KindUnknown, ""
+}
+
+func parseSemver(v string) (tuple [3]int, ok bool) {
+	m := semverRe.FindStringSubmatch(v)
+	if m == nil {
+		return tuple, false
+	}
+	tuple[0], _ = strconv.Atoi(m[1])
+	tuple[1], _ = strconv.Atoi(m[2])
+	tuple[2], _ = strconv.Atoi(m[3])
+	return tuple, true
+}
+
+func compareSemver(a, b [3]int) int {
+	for i := 0; i < 3; i++ {
+		if a[i] < b[i] {
+			return -1
+		}
+		if a[i] > b[i] {
+			return 1
+		}
+	}
+	return 0
+}
+
+// shortSHA truncates a hash to 7 chars for display. Strings shorter
+// than 7 are returned unchanged.
+func shortSHA(s string) string {
+	if len(s) > 7 {
+		return s[:7]
+	}
+	return s
+}
+
+// CheckLatest classifies the current version and queries GitHub to
+// produce a Result. Network errors are folded into the Result as
+// State=NoRemote rather than returned, so callers can render the
+// outcome without an extra error branch — the (error) return is
+// reserved for unrecoverable bugs (none today).
+func CheckLatest(currentVersion string) (*Result, error) {
+	res := &Result{CurrentVersion: currentVersion}
+	kind, sha := classifyVersion(currentVersion)
+
+	switch kind {
+	case KindSemver:
+		rel, err := FetchLatestStableRelease()
+		if err != nil {
+			res.State = StateNoRemote
+			res.Detail = err.Error()
+			return res, nil
+		}
+		latest := strings.TrimPrefix(rel.TagName, "v")
+		res.LatestVersion = latest
+		cur, _ := parseSemver(currentVersion)
+		lat, _ := parseSemver(latest)
+		switch compareSemver(cur, lat) {
+		case -1:
+			res.State = StateUpdateAvailable
+		case 0:
+			res.State = StateUpToDate
+		case 1:
+			res.State = StateAhead
+			res.Detail = fmt.Sprintf("running %s, latest release is %s", currentVersion, latest)
+		}
+		return res, nil
+
+	case KindSHA:
+		head, err := FetchBranchHEAD("main")
+		if err != nil {
+			res.State = StateNoRemote
+			res.Detail = err.Error()
+			return res, nil
+		}
+		res.LatestVersion = shortSHA(head)
+		cmp, err := CompareCommits(sha, head)
+		if err != nil {
+			res.State = StateNoRemote
+			res.Detail = err.Error()
+			return res, nil
+		}
+		if cmp == nil {
+			res.State = StateLocalNotFound
+			res.Detail = "current commit is not on origin/main (fork or unpushed branch?)"
+			return res, nil
+		}
+		switch cmp.Status {
+		case "ahead":
+			// head (origin/main) is ahead of base (us) → we are behind.
+			res.State = StateUpdateAvailable
+			res.Detail = fmt.Sprintf("%d commits behind origin/main", cmp.AheadBy)
+		case "behind":
+			// head (origin/main) is behind base (us) → we are ahead.
+			res.State = StateAhead
+			res.Detail = fmt.Sprintf("%d commits ahead of origin/main", cmp.BehindBy)
+		case "identical":
+			res.State = StateUpToDate
+		case "diverged":
+			res.State = StateDiverged
+			res.Detail = fmt.Sprintf("%d commits ahead, %d commits behind origin/main",
+				cmp.BehindBy, cmp.AheadBy)
+		default:
+			res.State = StateUnknown
+			res.Detail = "unexpected compare status: " + cmp.Status
+		}
+		return res, nil
+
+	default:
+		// KindUnknown — e.g. "dev" with no SHA. Show the latest
+		// release for reference but do not offer an update.
+		res.State = StateDevBuild
+		if rel, err := FetchLatestStableRelease(); err == nil {
+			res.LatestVersion = strings.TrimPrefix(rel.TagName, "v")
+		}
+		return res, nil
+	}
+}
 
 // GitHubRelease represents a GitHub release.
 type GitHubRelease struct {
@@ -27,59 +223,54 @@ type GitHubAsset struct {
 	URL  string `json:"url"` // API URL — use with Accept: application/octet-stream
 }
 
-// Result holds the outcome of an update check.
-type Result struct {
-	Channel         string
-	CurrentVersion  string
-	LatestVersion   string
-	UpdateAvailable bool
-}
-
-// InferChannel returns "main" or "stable" based on the version string format.
-func InferChannel(version string) string {
-	if strings.HasPrefix(version, "main+") {
-		return "main"
-	}
-	return "stable"
-}
-
-// CheckLatest fetches the latest release for the given channel and compares
-// it against currentVersion. Returns a Result indicating whether an update
-// is available.
-func CheckLatest(channel, currentVersion string) (*Result, error) {
-	var rel *GitHubRelease
-	var latestVersion string
-	var err error
-
-	switch channel {
-	case "main":
-		rel, err = FetchReleaseByTag("main")
-		if err != nil {
-			return nil, fmt.Errorf("fetch main release: %w", err)
-		}
-		latestVersion = rel.Name
-	default:
-		rel, err = FetchLatestStableRelease()
-		if err != nil {
-			return nil, fmt.Errorf("fetch latest release: %w", err)
-		}
-		latestVersion = strings.TrimPrefix(rel.TagName, "v")
-	}
-
-	return &Result{
-		Channel:         channel,
-		CurrentVersion:  currentVersion,
-		LatestVersion:   latestVersion,
-		UpdateAvailable: latestVersion != currentVersion,
-	}, nil
-}
-
 // FetchLatestStableRelease fetches the latest tagged (non-prerelease) release.
 func FetchLatestStableRelease() (*GitHubRelease, error) {
 	return FetchRelease(APIBase + "/releases/latest")
 }
 
-// FetchReleaseByTag fetches a release by its Git tag name.
+// InferChannel picks the default release channel for a build given
+// its version string: "stable" when the version is a clean semver
+// tag, "main" otherwise. Used by the CLI self-update flow when the
+// caller doesn't pass --channel explicitly.
+func InferChannel(version string) string {
+	kind, _ := classifyVersion(version)
+	if kind == KindSemver {
+		return "stable"
+	}
+	return "main"
+}
+
+// FetchInstallTarget returns the version string the orchestrator
+// should install on the given channel ("stable" or "main"). Returns
+// "" when current already matches the channel's head, signalling
+// "no update needed". The channel concept is preserved here (vs.
+// the version-classifier used by CheckLatest) because operators
+// pick which release stream to follow independently of how the
+// running build is versioned.
+func FetchInstallTarget(channel, currentVersion string) (string, error) {
+	var target string
+	switch channel {
+	case "main":
+		rel, err := FetchReleaseByTag("main")
+		if err != nil {
+			return "", err
+		}
+		target = rel.Name
+	default:
+		rel, err := FetchLatestStableRelease()
+		if err != nil {
+			return "", err
+		}
+		target = strings.TrimPrefix(rel.TagName, "v")
+	}
+	if target == currentVersion {
+		return "", nil
+	}
+	return target, nil
+}
+
+// FetchReleaseByTag fetches a release by its Git tag name. Used by
+// the orchestrator when applying a rolling update.
 func FetchReleaseByTag(tag string) (*GitHubRelease, error) {
 	return FetchRelease(APIBase + "/releases/tags/" + tag)
 }
@@ -108,6 +299,80 @@ func FetchRelease(url string) (*GitHubRelease, error) {
 		return nil, err
 	}
 	return &rel, nil
+}
+
+// FetchBranchHEAD returns the HEAD commit SHA of the named branch
+// (typically "main"). Used by SHA-build update checks to know what
+// the upstream is currently at.
+func FetchBranchHEAD(branch string) (string, error) {
+	url := APIBase + "/branches/" + branch
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	AddGitHubAuth(req)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub branches API returned %s", resp.Status)
+	}
+
+	var b struct {
+		Commit struct {
+			SHA string `json:"sha"`
+		} `json:"commit"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&b); err != nil {
+		return "", err
+	}
+	return b.Commit.SHA, nil
+}
+
+// CompareResult is the relevant subset of GitHub's compare-commits
+// response. Status is one of "ahead", "behind", "identical",
+// "diverged"; the counts describe head relative to base.
+type CompareResult struct {
+	Status   string `json:"status"`
+	AheadBy  int    `json:"ahead_by"`
+	BehindBy int    `json:"behind_by"`
+}
+
+// CompareCommits asks GitHub how head relates to base. Returns
+// (nil, nil) when the API responds 404 — typically because base
+// isn't reachable on the remote (fork or unpushed branch).
+func CompareCommits(base, head string) (*CompareResult, error) {
+	url := APIBase + "/compare/" + base + "..." + head
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	AddGitHubAuth(req)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub compare API returned %s", resp.Status)
+	}
+
+	var r CompareResult
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return nil, err
+	}
+	return &r, nil
 }
 
 // AddGitHubAuth sets the Authorization header if GITHUB_TOKEN is set.

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -5,24 +5,270 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 )
 
-func TestInferChannel(t *testing.T) {
+func TestClassifyVersion(t *testing.T) {
 	tests := []struct {
-		version string
-		want    string
+		in       string
+		wantKind Kind
+		wantSHA  string
 	}{
-		{"main+abc123", "main"},
-		{"main+2026-03-26-abc", "main"},
-		{"1.0.0", "stable"},
-		{"0.9.0-rc1", "stable"},
-		{"", "stable"},
+		{"v1.2.3", KindSemver, ""},
+		{"1.2.3", KindSemver, ""},
+		{"0.0.2", KindSemver, ""},
+		// git describe outputs
+		{"v0.0.2-3-gabc1234", KindSHA, "abc1234"},
+		{"v0.0.2-3-gabc1234-dirty", KindSHA, "abc1234"},
+		{"abc1234", KindSHA, "abc1234"},
+		{"abc1234-dirty", KindSHA, "abc1234"},
+		{"abcdef0123456789abcdef0123456789abcdef01", KindSHA, "abcdef0123456789abcdef0123456789abcdef01"},
+		// Legacy main+ format
+		{"main+abc1234", KindSHA, "abc1234"},
+		// Anything else
+		{"dev", KindUnknown, ""},
+		{"", KindUnknown, ""},
+		{"some-random-string", KindUnknown, ""},
+		// 6 hex is too short to be a SHA
+		{"abc123", KindUnknown, ""},
 	}
 	for _, tt := range tests {
-		if got := InferChannel(tt.version); got != tt.want {
-			t.Errorf("InferChannel(%q) = %q, want %q", tt.version, got, tt.want)
+		gotKind, gotSHA := classifyVersion(tt.in)
+		if gotKind != tt.wantKind || gotSHA != tt.wantSHA {
+			t.Errorf("classifyVersion(%q) = (%v, %q), want (%v, %q)",
+				tt.in, gotKind, gotSHA, tt.wantKind, tt.wantSHA)
 		}
+	}
+}
+
+func TestCompareSemver(t *testing.T) {
+	tests := []struct {
+		a, b [3]int
+		want int
+	}{
+		{[3]int{1, 0, 0}, [3]int{1, 0, 0}, 0},
+		{[3]int{1, 0, 0}, [3]int{1, 0, 1}, -1},
+		{[3]int{1, 0, 1}, [3]int{1, 0, 0}, 1},
+		{[3]int{1, 1, 0}, [3]int{1, 0, 5}, 1},
+		{[3]int{2, 0, 0}, [3]int{1, 99, 99}, 1},
+		{[3]int{0, 0, 1}, [3]int{0, 0, 2}, -1},
+	}
+	for _, tt := range tests {
+		if got := compareSemver(tt.a, tt.b); got != tt.want {
+			t.Errorf("compareSemver(%v, %v) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+// fakeRemote is a minimal stub of the GitHub endpoints we hit. It
+// records request paths so tests can assert which calls happened.
+type fakeRemote struct {
+	server      *httptest.Server
+	latestTag   string                  // /releases/latest TagName
+	branchHead  string                  // /branches/main commit.sha
+	compareResp *CompareResult          // /compare/{base}...{head} payload
+	compare404  bool                    // when true, /compare returns 404
+	called      map[string]int          // path → count
+}
+
+func newFakeRemote() *fakeRemote {
+	f := &fakeRemote{called: map[string]int{}}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.called[r.URL.Path]++
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/releases/latest"):
+			json.NewEncoder(w).Encode(GitHubRelease{TagName: f.latestTag})
+		case strings.HasPrefix(r.URL.Path, "/branches/"):
+			payload := struct {
+				Commit struct {
+					SHA string `json:"sha"`
+				} `json:"commit"`
+			}{}
+			payload.Commit.SHA = f.branchHead
+			json.NewEncoder(w).Encode(payload)
+		case strings.HasPrefix(r.URL.Path, "/compare/"):
+			if f.compare404 {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			json.NewEncoder(w).Encode(f.compareResp)
+		default:
+			http.Error(w, "unexpected path: "+r.URL.Path, http.StatusInternalServerError)
+		}
+	}))
+	return f
+}
+
+func (f *fakeRemote) Close() { f.server.Close() }
+
+// install points the package APIBase at the fake server for the
+// duration of the test.
+func (f *fakeRemote) install(t *testing.T) {
+	t.Helper()
+	old := APIBase
+	APIBase = f.server.URL
+	t.Cleanup(func() { APIBase = old })
+}
+
+func TestCheckLatest_Semver_UpdateAvailable(t *testing.T) {
+	f := newFakeRemote()
+	defer f.Close()
+	f.latestTag = "v1.5.0"
+	f.install(t)
+
+	res, err := CheckLatest("1.4.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.State != StateUpdateAvailable {
+		t.Errorf("State = %q, want %q", res.State, StateUpdateAvailable)
+	}
+	if res.LatestVersion != "1.5.0" {
+		t.Errorf("LatestVersion = %q", res.LatestVersion)
+	}
+}
+
+func TestCheckLatest_Semver_UpToDate(t *testing.T) {
+	f := newFakeRemote()
+	defer f.Close()
+	f.latestTag = "v1.5.0"
+	f.install(t)
+
+	res, _ := CheckLatest("1.5.0")
+	if res.State != StateUpToDate {
+		t.Errorf("State = %q, want %q", res.State, StateUpToDate)
+	}
+}
+
+func TestCheckLatest_Semver_Ahead(t *testing.T) {
+	f := newFakeRemote()
+	defer f.Close()
+	f.latestTag = "v1.4.0"
+	f.install(t)
+
+	res, _ := CheckLatest("v1.5.0")
+	if res.State != StateAhead {
+		t.Errorf("State = %q, want %q", res.State, StateAhead)
+	}
+	if res.Detail == "" {
+		t.Error("expected non-empty Detail describing the ahead-of-release state")
+	}
+}
+
+func TestCheckLatest_SHA_Behind(t *testing.T) {
+	f := newFakeRemote()
+	defer f.Close()
+	f.branchHead = "feedbeef0000000000000000000000000000aaaa"
+	f.compareResp = &CompareResult{Status: "ahead", AheadBy: 3}
+	f.install(t)
+
+	res, _ := CheckLatest("abc1234")
+	if res.State != StateUpdateAvailable {
+		t.Errorf("State = %q, want %q (origin/main ahead means we are behind)", res.State, StateUpdateAvailable)
+	}
+	if !strings.Contains(res.Detail, "3 commits behind") {
+		t.Errorf("Detail = %q, expected 3-commits-behind note", res.Detail)
+	}
+	if res.LatestVersion != "feedbee" {
+		t.Errorf("LatestVersion = %q, want short SHA %q", res.LatestVersion, "feedbee")
+	}
+}
+
+func TestCheckLatest_SHA_Ahead(t *testing.T) {
+	f := newFakeRemote()
+	defer f.Close()
+	f.branchHead = "abc12340000000000000000000000000000aaaa"
+	f.compareResp = &CompareResult{Status: "behind", BehindBy: 2}
+	f.install(t)
+
+	res, _ := CheckLatest("def5678")
+	if res.State != StateAhead {
+		t.Errorf("State = %q, want %q", res.State, StateAhead)
+	}
+}
+
+func TestCheckLatest_SHA_Identical(t *testing.T) {
+	f := newFakeRemote()
+	defer f.Close()
+	f.branchHead = "abc12340000000000000000000000000000aaaa"
+	f.compareResp = &CompareResult{Status: "identical"}
+	f.install(t)
+
+	res, _ := CheckLatest("abc1234")
+	if res.State != StateUpToDate {
+		t.Errorf("State = %q, want %q", res.State, StateUpToDate)
+	}
+}
+
+func TestCheckLatest_SHA_Diverged(t *testing.T) {
+	f := newFakeRemote()
+	defer f.Close()
+	f.branchHead = "abc12340000000000000000000000000000aaaa"
+	f.compareResp = &CompareResult{Status: "diverged", AheadBy: 2, BehindBy: 1}
+	f.install(t)
+
+	res, _ := CheckLatest("def5678")
+	if res.State != StateDiverged {
+		t.Errorf("State = %q, want %q", res.State, StateDiverged)
+	}
+}
+
+func TestCheckLatest_SHA_LocalNotFound(t *testing.T) {
+	f := newFakeRemote()
+	defer f.Close()
+	f.branchHead = "abc12340000000000000000000000000000aaaa"
+	f.compare404 = true
+	f.install(t)
+
+	res, _ := CheckLatest("def5678")
+	if res.State != StateLocalNotFound {
+		t.Errorf("State = %q, want %q", res.State, StateLocalNotFound)
+	}
+}
+
+func TestCheckLatest_DevBuild_NoUpdateOffer(t *testing.T) {
+	f := newFakeRemote()
+	defer f.Close()
+	f.latestTag = "v0.0.2"
+	f.install(t)
+
+	res, _ := CheckLatest("dev")
+	if res.State != StateDevBuild {
+		t.Errorf("State = %q, want %q", res.State, StateDevBuild)
+	}
+	// The latest release is fetched for informational display,
+	// not as an "update" offer.
+	if res.LatestVersion != "0.0.2" {
+		t.Errorf("LatestVersion = %q, want 0.0.2 (informational)", res.LatestVersion)
+	}
+}
+
+func TestCheckLatest_NoRemote(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	old := APIBase
+	APIBase = srv.URL
+	defer func() { APIBase = old }()
+
+	res, err := CheckLatest("1.4.0")
+	if err != nil {
+		t.Fatalf("expected error folded into result, got %v", err)
+	}
+	if res.State != StateNoRemote {
+		t.Errorf("State = %q, want %q", res.State, StateNoRemote)
+	}
+}
+
+func TestSetRepo(t *testing.T) {
+	old := APIBase
+	defer func() { APIBase = old }()
+
+	SetRepo("acme/widget")
+	if !strings.HasSuffix(APIBase, "/repos/acme/widget") {
+		t.Errorf("APIBase = %q, expected /repos/acme/widget suffix", APIBase)
 	}
 }
 
@@ -33,10 +279,7 @@ func TestFetchRelease(t *testing.T) {
 		}
 		json.NewEncoder(w).Encode(GitHubRelease{
 			TagName: "v1.2.3",
-			Name:    "Release 1.2.3",
-			Assets: []GitHubAsset{
-				{Name: "blockyard-linux-amd64.tar.gz", URL: "https://example.com/asset"},
-			},
+			Assets:  []GitHubAsset{{Name: "blockyard-linux-amd64.tar.gz"}},
 		})
 	}))
 	defer srv.Close()
@@ -46,177 +289,10 @@ func TestFetchRelease(t *testing.T) {
 		t.Fatal(err)
 	}
 	if rel.TagName != "v1.2.3" {
-		t.Errorf("TagName = %q, want %q", rel.TagName, "v1.2.3")
-	}
-	if rel.Name != "Release 1.2.3" {
-		t.Errorf("Name = %q, want %q", rel.Name, "Release 1.2.3")
+		t.Errorf("TagName = %q", rel.TagName)
 	}
 	if len(rel.Assets) != 1 {
 		t.Fatalf("expected 1 asset, got %d", len(rel.Assets))
-	}
-	if rel.Assets[0].Name != "blockyard-linux-amd64.tar.gz" {
-		t.Errorf("Asset name = %q", rel.Assets[0].Name)
-	}
-}
-
-func TestFetchRelease_HTTPError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "not found", http.StatusNotFound)
-	}))
-	defer srv.Close()
-
-	_, err := FetchRelease(srv.URL)
-	if err == nil {
-		t.Fatal("expected error for 404 response")
-	}
-}
-
-func TestFetchRelease_InvalidJSON(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("not json"))
-	}))
-	defer srv.Close()
-
-	_, err := FetchRelease(srv.URL)
-	if err == nil {
-		t.Fatal("expected error for invalid JSON")
-	}
-}
-
-func TestFetchLatestStableRelease(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/releases/latest" {
-			t.Errorf("unexpected path: %s", r.URL.Path)
-		}
-		json.NewEncoder(w).Encode(GitHubRelease{TagName: "v2.0.0"})
-	}))
-	defer srv.Close()
-
-	old := APIBase
-	APIBase = srv.URL
-	defer func() { APIBase = old }()
-
-	rel, err := FetchLatestStableRelease()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if rel.TagName != "v2.0.0" {
-		t.Errorf("TagName = %q, want %q", rel.TagName, "v2.0.0")
-	}
-}
-
-func TestFetchReleaseByTag(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/releases/tags/main" {
-			t.Errorf("unexpected path: %s", r.URL.Path)
-		}
-		json.NewEncoder(w).Encode(GitHubRelease{TagName: "main", Name: "main+abc123"})
-	}))
-	defer srv.Close()
-
-	old := APIBase
-	APIBase = srv.URL
-	defer func() { APIBase = old }()
-
-	rel, err := FetchReleaseByTag("main")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if rel.Name != "main+abc123" {
-		t.Errorf("Name = %q, want %q", rel.Name, "main+abc123")
-	}
-}
-
-func TestCheckLatest_Stable(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(GitHubRelease{TagName: "v1.5.0"})
-	}))
-	defer srv.Close()
-
-	old := APIBase
-	APIBase = srv.URL
-	defer func() { APIBase = old }()
-
-	result, err := CheckLatest("stable", "1.4.0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result.Channel != "stable" {
-		t.Errorf("Channel = %q", result.Channel)
-	}
-	if result.CurrentVersion != "1.4.0" {
-		t.Errorf("CurrentVersion = %q", result.CurrentVersion)
-	}
-	if result.LatestVersion != "1.5.0" {
-		t.Errorf("LatestVersion = %q, want %q", result.LatestVersion, "1.5.0")
-	}
-	if !result.UpdateAvailable {
-		t.Error("expected UpdateAvailable=true")
-	}
-}
-
-func TestCheckLatest_StableUpToDate(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(GitHubRelease{TagName: "v1.4.0"})
-	}))
-	defer srv.Close()
-
-	old := APIBase
-	APIBase = srv.URL
-	defer func() { APIBase = old }()
-
-	result, err := CheckLatest("stable", "1.4.0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result.UpdateAvailable {
-		t.Error("expected UpdateAvailable=false when versions match")
-	}
-}
-
-func TestCheckLatest_Main(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(GitHubRelease{
-			TagName: "main",
-			Name:    "main+newbuild",
-		})
-	}))
-	defer srv.Close()
-
-	old := APIBase
-	APIBase = srv.URL
-	defer func() { APIBase = old }()
-
-	result, err := CheckLatest("main", "main+oldbuild")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result.LatestVersion != "main+newbuild" {
-		t.Errorf("LatestVersion = %q", result.LatestVersion)
-	}
-	if !result.UpdateAvailable {
-		t.Error("expected UpdateAvailable=true for different main builds")
-	}
-}
-
-func TestCheckLatest_FetchError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "error", http.StatusInternalServerError)
-	}))
-	defer srv.Close()
-
-	old := APIBase
-	APIBase = srv.URL
-	defer func() { APIBase = old }()
-
-	_, err := CheckLatest("stable", "1.0.0")
-	if err == nil {
-		t.Fatal("expected error when fetch fails")
-	}
-
-	_, err = CheckLatest("main", "main+abc")
-	if err == nil {
-		t.Fatal("expected error when fetch fails for main channel")
 	}
 }
 
@@ -235,7 +311,7 @@ func TestAddGitHubAuth_WithToken(t *testing.T) {
 	AddGitHubAuth(req)
 
 	if got := req.Header.Get("Authorization"); got != "Bearer test-token-123" {
-		t.Errorf("Authorization = %q, want %q", got, "Bearer test-token-123")
+		t.Errorf("Authorization = %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- New Updates tab on `/admin` with current/latest versions, last-checked timestamp, and Check / Update buttons; "new" badge on the tab when an upgrade is available.
- Reworks `internal/update` to classify builds as semver (numeric compare against latest stable release) or SHA (GitHub `compare/{base}...{head}` against `origin/main` HEAD), so `dev`/SHA builds no longer get told to "update" to an older release.
- Bakes `git describe --always --dirty` into local Docker builds and CI workflows; drops the `main+` version prefix.
- Adds `[update].repo` config so forks can point the check at their own repo.