### PR TITLE
test(examples): reuse proxy session to stabilize websocket tests

### DIFF
--- a/tests/examples/hello_pocketbase_test.go
+++ b/tests/examples/hello_pocketbase_test.go
@@ -19,8 +19,9 @@ func TestHelloPocketbase(t *testing.T) {
 	waitForHealth(t, baseURL, 90*time.Second)
 
 	var (
-		cookies1 []*http.Cookie
 		cookies2 []*http.Cookie
+		client1  *http.Client
+		client2  *http.Client
 		token1   string
 	)
 
@@ -40,8 +41,9 @@ func TestHelloPocketbase(t *testing.T) {
 	})
 
 	t.Run("user1_deploy", func(t *testing.T) {
-		cookies1 = dexLogin(t, baseURL, dexURL, dexEmail1, dexPassword)
+		cookies1 := dexLogin(t, baseURL, dexURL, dexEmail1, dexPassword)
 		token1 = createPAT(t, baseURL, cookies1)
+		client1 = newProxyClient(t, baseURL, cookies1)
 
 		// Set access_type and scaling before deploy starts the app.
 		appDir := copyAppDir(t, "../../examples/hello-pocketbase/app")
@@ -60,7 +62,7 @@ func TestHelloPocketbase(t *testing.T) {
 
 		// Enable and trigger cold-start via proxy.
 		runCLI(t, baseURL, token1, "enable", "hello-pocketbase")
-		fetchAppPage(t, baseURL, "hello-pocketbase", cookies1, 120*time.Second)
+		fetchAppPage(t, client1, baseURL, "hello-pocketbase", 120*time.Second)
 	})
 
 	t.Run("user1_app_serves", func(t *testing.T) {
@@ -68,7 +70,7 @@ func TestHelloPocketbase(t *testing.T) {
 			t.Skip("depends on user1_deploy")
 		}
 
-		status, body := fetchAppPage(t, baseURL, "hello-pocketbase", cookies1, 60*time.Second)
+		status, body := fetchAppPage(t, client1, baseURL, "hello-pocketbase", 60*time.Second)
 		if status != 200 {
 			t.Fatalf("expected 200, got %d", status)
 		}
@@ -82,7 +84,7 @@ func TestHelloPocketbase(t *testing.T) {
 			t.Skip("depends on user1_deploy")
 		}
 
-		dialAppWebSocket(t, baseURL, "hello-pocketbase", cookies1)
+		dialAppWebSocket(t, client1, baseURL, "hello-pocketbase")
 	})
 
 	t.Run("user2_access", func(t *testing.T) {
@@ -92,20 +94,21 @@ func TestHelloPocketbase(t *testing.T) {
 
 		// User2 logs in — different session.
 		cookies2 = dexLogin(t, baseURL, dexURL, dexEmail2, dexPassword)
+		client2 = newProxyClient(t, baseURL, cookies2)
 
 		// User2 should be able to access the app (access_type=logged_in).
-		status, _ := fetchAppPage(t, baseURL, "hello-pocketbase", cookies2, 60*time.Second)
+		status, _ := fetchAppPage(t, client2, baseURL, "hello-pocketbase", 60*time.Second)
 		if status != 200 {
 			t.Fatalf("user2 access: expected 200, got %d", status)
 		}
 	})
 
 	t.Run("user2_websocket", func(t *testing.T) {
-		if cookies2 == nil {
+		if client2 == nil {
 			t.Skip("depends on user2_access")
 		}
 
-		dialAppWebSocket(t, baseURL, "hello-pocketbase", cookies2)
+		dialAppWebSocket(t, client2, baseURL, "hello-pocketbase")
 	})
 
 	t.Run("enroll_credential_via_api", func(t *testing.T) {

--- a/tests/examples/hello_postgrest_test.go
+++ b/tests/examples/hello_postgrest_test.go
@@ -22,9 +22,9 @@ func TestHelloPostgrest(t *testing.T) {
 	waitForHealth(t, baseURL, 90*time.Second)
 
 	var (
-		cookies1 []*http.Cookie
-		cookies2 []*http.Cookie
-		token1   string
+		client1 *http.Client
+		client2 *http.Client
+		token1  string
 	)
 
 	t.Run("vault_oidc_configured", func(t *testing.T) {
@@ -86,8 +86,9 @@ func TestHelloPostgrest(t *testing.T) {
 	})
 
 	t.Run("user1_deploy", func(t *testing.T) {
-		cookies1 = dexLogin(t, baseURL, dexURL, dexEmail1, dexPassword)
+		cookies1 := dexLogin(t, baseURL, dexURL, dexEmail1, dexPassword)
 		token1 = createPAT(t, baseURL, cookies1)
+		client1 = newProxyClient(t, baseURL, cookies1)
 
 		appDir := copyAppDir(t, "../../examples/hello-postgrest/app")
 
@@ -105,7 +106,7 @@ func TestHelloPostgrest(t *testing.T) {
 
 		// Enable and trigger cold-start via proxy.
 		runCLI(t, baseURL, token1, "enable", "hello-postgrest")
-		fetchAppPage(t, baseURL, "hello-postgrest", cookies1, 120*time.Second)
+		fetchAppPage(t, client1, baseURL, "hello-postgrest", 120*time.Second)
 	})
 
 	t.Run("user1_app_serves", func(t *testing.T) {
@@ -113,7 +114,7 @@ func TestHelloPostgrest(t *testing.T) {
 			t.Skip("depends on user1_deploy")
 		}
 
-		status, body := fetchAppPage(t, baseURL, "hello-postgrest", cookies1, 60*time.Second)
+		status, body := fetchAppPage(t, client1, baseURL, "hello-postgrest", 60*time.Second)
 		if status != 200 {
 			t.Fatalf("expected 200, got %d", status)
 		}
@@ -127,7 +128,7 @@ func TestHelloPostgrest(t *testing.T) {
 			t.Skip("depends on user1_deploy")
 		}
 
-		dialAppWebSocket(t, baseURL, "hello-postgrest", cookies1)
+		dialAppWebSocket(t, client1, baseURL, "hello-postgrest")
 	})
 
 	t.Run("user2_access", func(t *testing.T) {
@@ -135,20 +136,21 @@ func TestHelloPostgrest(t *testing.T) {
 			t.Skip("depends on user1_deploy")
 		}
 
-		cookies2 = dexLogin(t, baseURL, dexURL, dexEmail2, dexPassword)
+		cookies2 := dexLogin(t, baseURL, dexURL, dexEmail2, dexPassword)
+		client2 = newProxyClient(t, baseURL, cookies2)
 
-		status, _ := fetchAppPage(t, baseURL, "hello-postgrest", cookies2, 60*time.Second)
+		status, _ := fetchAppPage(t, client2, baseURL, "hello-postgrest", 60*time.Second)
 		if status != 200 {
 			t.Fatalf("user2 access: expected 200, got %d", status)
 		}
 	})
 
 	t.Run("user2_websocket", func(t *testing.T) {
-		if cookies2 == nil {
+		if client2 == nil {
 			t.Skip("depends on user2_access")
 		}
 
-		dialAppWebSocket(t, baseURL, "hello-postgrest", cookies2)
+		dialAppWebSocket(t, client2, baseURL, "hello-postgrest")
 	})
 
 	t.Run("stop_and_cleanup", func(t *testing.T) {

--- a/tests/examples/hello_shiny_test.go
+++ b/tests/examples/hello_shiny_test.go
@@ -95,16 +95,17 @@ func TestHelloShiny(t *testing.T) {
 	waitForHealth(t, baseURL, 60*time.Second)
 
 	var (
-		cookies []*http.Cookie
-		token   string
+		client *http.Client
+		token  string
 	)
 
 	t.Run("auth", func(t *testing.T) {
-		cookies = dexLogin(t, baseURL, dexURL, dexEmail1, dexPassword)
+		cookies := dexLogin(t, baseURL, dexURL, dexEmail1, dexPassword)
 		token = createPAT(t, baseURL, cookies)
 		if !strings.HasPrefix(token, "by_") {
 			t.Fatalf("token %q missing by_ prefix", token)
 		}
+		client = newProxyClient(t, baseURL, cookies)
 	})
 
 	t.Run("deploy", func(t *testing.T) {
@@ -137,7 +138,7 @@ func TestHelloShiny(t *testing.T) {
 		// Ensure the app is enabled (should be by default after deploy).
 		runCLI(t, baseURL, token, "enable", "hello")
 
-		status, body := fetchAppPage(t, baseURL, "hello", cookies, 120*time.Second)
+		status, body := fetchAppPage(t, client, baseURL, "hello", 120*time.Second)
 		if status != 200 {
 			t.Fatalf("expected 200, got %d", status)
 		}
@@ -158,7 +159,7 @@ func TestHelloShiny(t *testing.T) {
 			t.Skip("depends on deploy")
 		}
 
-		dialAppWebSocket(t, baseURL, "hello", cookies)
+		dialAppWebSocket(t, client, baseURL, "hello")
 	})
 
 	t.Run("unauthenticated_redirects", func(t *testing.T) {

--- a/tests/examples/helpers_test.go
+++ b/tests/examples/helpers_test.go
@@ -402,22 +402,36 @@ func readVaultSecret(t *testing.T, vaultURL, token, path string) map[string]any 
 // App page fetch (proxy — requires session cookies, not CLI)
 // ---------------------------------------------------------------------------
 
-func fetchAppPage(t *testing.T, baseURL, appName string, cookies []*http.Cookie, timeout time.Duration) (int, string) {
+// newProxyClient returns an http.Client seeded with the given auth cookies
+// and a cookie jar that retains Set-Cookie values across requests. Reusing
+// the same client across fetchAppPage and dialAppWebSocket keeps the proxy
+// session cookie stable so subsequent requests route to the same backend
+// worker instead of cold-starting a fresh one per call.
+func newProxyClient(t *testing.T, baseURL string, cookies []*http.Cookie) *http.Client {
+	t.Helper()
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		t.Fatalf("parse baseURL: %v", err)
+	}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookie jar: %v", err)
+	}
+	jar.SetCookies(u, cookies)
+	return &http.Client{
+		Jar: jar,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+func fetchAppPage(t *testing.T, client *http.Client, baseURL, appName string, timeout time.Duration) (int, string) {
 	t.Helper()
 
 	deadline := time.Now().Add(timeout)
 	for {
-		req, _ := http.NewRequest("GET", baseURL+"/app/"+appName+"/", nil)
-		for _, c := range cookies {
-			req.AddCookie(c)
-		}
-		// Don't follow redirects automatically — we want to see the redirect.
-		client := &http.Client{
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
-				return http.ErrUseLastResponse
-			},
-		}
-		resp, err := client.Do(req)
+		resp, err := client.Get(baseURL + "/app/" + appName + "/")
 		if err != nil {
 			if time.Now().After(deadline) {
 				t.Fatalf("fetch app page: %v", err)
@@ -461,15 +475,21 @@ func fetchAppPageNoRedirect(t *testing.T, baseURL, appName string) (int, string)
 // WebSocket helper (proxy — requires session cookies, not CLI)
 // ---------------------------------------------------------------------------
 
-func dialAppWebSocket(t *testing.T, baseURL, appName string, cookies []*http.Cookie) {
+func dialAppWebSocket(t *testing.T, client *http.Client, baseURL, appName string) {
 	t.Helper()
 
 	// Use http:// (not ws://) since we do a raw HTTP upgrade via RoundTrip.
 	wsURL := baseURL + "/app/" + appName + "/websocket/"
 
-	// Build cookie header.
+	// Build cookie header from the client jar so the blockyard_session
+	// cookie (set on the first fetchAppPage) is included. All retry
+	// attempts therefore share the same backend worker.
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		t.Fatalf("parse baseURL: %v", err)
+	}
 	var cookieStrs []string
-	for _, c := range cookies {
+	for _, c := range client.Jar.Cookies(u) {
 		cookieStrs = append(cookieStrs, c.Name+"="+c.Value)
 	}
 

--- a/tests/examples/refresh_test.go
+++ b/tests/examples/refresh_test.go
@@ -21,17 +21,18 @@ func TestRefreshAndRollback(t *testing.T) {
 	waitForHealth(t, baseURL, 90*time.Second)
 
 	var (
-		cookies []*http.Cookie
+		client  *http.Client
 		token   string
 		appName = "refresh-test"
 	)
 
 	t.Run("auth", func(t *testing.T) {
-		cookies = dexLogin(t, baseURL, dexURL, dexEmail1, dexPassword)
+		cookies := dexLogin(t, baseURL, dexURL, dexEmail1, dexPassword)
 		token = createPAT(t, baseURL, cookies)
 		if !strings.HasPrefix(token, "by_") {
 			t.Fatalf("token %q missing by_ prefix", token)
 		}
+		client = newProxyClient(t, baseURL, cookies)
 	})
 
 	t.Run("deploy_unpinned", func(t *testing.T) {
@@ -51,7 +52,7 @@ func TestRefreshAndRollback(t *testing.T) {
 
 		// Enable and trigger cold-start via proxy.
 		runCLI(t, baseURL, token, "enable", appName)
-		fetchAppPage(t, baseURL, appName, cookies, 120*time.Second)
+		fetchAppPage(t, client, baseURL, appName, 120*time.Second)
 
 		// Verify app is running via CLI.
 		var app map[string]any


### PR DESCRIPTION
## Summary
- Each proxy helper currently sends only the dex auth cookies and discards the `Set-Cookie` from the proxy, so every call creates a fresh blockyard session.
- With `max_sessions_per_worker=1` on hello-shiny, every session cold-starts its own worker; the three-attempt retry in `dialAppWebSocket` therefore spawns up to four workers in rapid succession and amplifies a single-attempt flake into the cascade seen in #249.
- Thread a cookie-jar-backed `*http.Client` through `fetchAppPage` and `dialAppWebSocket` so the `blockyard_session` cookie persists across calls — all retries now hit the same warmed-up worker.

Fixes #249.