### PR TITLE
docs(install): fix go install command for by CLI

### DIFF
--- a/docs/content/docs/getting-started/installation.md
+++ b/docs/content/docs/getting-started/installation.md
@@ -118,8 +118,12 @@ sudo mv by /usr/local/bin/
 If you have Go 1.25+ installed:
 
 ```bash
-go install github.com/cynkra/blockyard/cmd/by@latest
+go install github.com/cynkra/blockyard/cmd/by@main
 ```
+
+`@main` tracks the current main branch — the most recent release tag
+predates the `by` CLI, so `@latest` will not yet resolve a working
+version.
 
 Or clone and build:
 


### PR DESCRIPTION
## Summary
- `go install github.com/cynkra/blockyard/cmd/by@latest` fails because v0.0.2 predates `cmd/by`.
- Switch the documented command to `@main` and note why `@latest` is not yet usable.

Fixes #243