### PR TITLE
fix: silence Shiny Server version warning in worker logs

### DIFF
--- a/internal/server/rprofile.go
+++ b/internal/server/rprofile.go
@@ -6,10 +6,13 @@ import (
 	"sync"
 )
 
+// SHINY_PORT is unset after reading so Shiny does not mistake the
+// worker for a Shiny Server deployment and emit a version warning.
 const rProfileContent = `local({
   host <- Sys.getenv("SHINY_HOST", "127.0.0.1")
   port <- Sys.getenv("SHINY_PORT", "3838")
   options(shiny.host = host, shiny.port = as.integer(port))
+  Sys.unsetenv(c("SHINY_HOST", "SHINY_PORT"))
 })
 `
 

--- a/internal/server/rprofile_test.go
+++ b/internal/server/rprofile_test.go
@@ -43,6 +43,11 @@ func TestEnsureRProfile(t *testing.T) {
 	if !strings.Contains(content, "shiny.port") {
 		t.Error("profile does not set shiny.port option")
 	}
+	// Must unset SHINY_PORT so Shiny does not misreport itself as
+	// running under Shiny Server (issue #245).
+	if !strings.Contains(content, "Sys.unsetenv") {
+		t.Error("profile does not unset SHINY_* env vars")
+	}
 }
 
 func TestEnsureRProfile_Idempotent(t *testing.T) {


### PR DESCRIPTION
## Summary
- Shiny misreads `SHINY_PORT` in the worker env as a Shiny Server deployment and logs a version warning
- Rprofile already bridges `SHINY_HOST`/`SHINY_PORT` into the corresponding `shiny.*` options
- Unset the two env vars after the bridge so Shiny no longer triggers the check

Fixes #245