### PR TITLE
fix(telemetry): preserve http.Hijacker in OTEL tracing middleware

### DIFF
--- a/internal/telemetry/tracing.go
+++ b/internal/telemetry/tracing.go
@@ -1,8 +1,11 @@
 package telemetry
 
 import (
+	"bufio"
 	"context"
+	"errors"
 	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 
@@ -92,4 +95,28 @@ func (w *statusWriter) WriteHeader(code int) {
 		w.wroteHeader = true
 	}
 	w.ResponseWriter.WriteHeader(code)
+}
+
+// Hijack forwards to the underlying ResponseWriter so WebSocket
+// upgrades work when this middleware is in the chain. Without this,
+// wrapping ResponseWriter hides the Hijacker interface and upgrades
+// fail.
+func (w *statusWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h, ok := w.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, errors.New("telemetry: underlying ResponseWriter does not implement http.Hijacker")
+	}
+	if !w.wroteHeader {
+		w.status = http.StatusSwitchingProtocols
+		w.wroteHeader = true
+	}
+	return h.Hijack()
+}
+
+// Flush forwards to the underlying ResponseWriter so streaming
+// responses are not held up by the wrapper.
+func (w *statusWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
 }

--- a/internal/telemetry/tracing_test.go
+++ b/internal/telemetry/tracing_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/coder/websocket"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -119,6 +120,33 @@ func TestStatusWriterWriteHeaderIdempotent(t *testing.T) {
 	if sw.status != http.StatusNotFound {
 		t.Errorf("expected status to remain 404, got %d", sw.status)
 	}
+}
+
+func TestTracingMiddlewarePreservesWebSocketUpgrade(t *testing.T) {
+	// Regression test for #246: the tracing middleware must not hide
+	// the http.Hijacker interface, otherwise WebSocket upgrades fail.
+	shutdown, _ := InitTracing(context.Background(), "")
+	defer shutdown(context.Background())
+
+	mw := TracingMiddleware()
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("websocket.Accept: %v", err)
+			return
+		}
+		c.Close(websocket.StatusNormalClosure, "")
+	}))
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	wsURL := "ws" + srv.URL[len("http"):]
+	c, _, err := websocket.Dial(context.Background(), wsURL, nil)
+	if err != nil {
+		t.Fatalf("websocket.Dial: %v", err)
+	}
+	c.Close(websocket.StatusNormalClosure, "")
 }
 
 func TestTracingMiddlewareWithoutRouteContext(t *testing.T) {


### PR DESCRIPTION
## Summary
- The OTEL tracing middleware wraps `http.ResponseWriter` with a `statusWriter` that only defined `WriteHeader`, hiding the `http.Hijacker` interface from downstream handlers.
- WebSocket upgrades under `/app/<name>/websocket/` could not hijack the connection, so the handshake failed with a 501 and the shiny UI went grey — reproducing the exact symptom reported in #246.
- Forward `Hijack` and `Flush` to the underlying writer and record `101 Switching Protocols` on the span when a hijack happens.
- Added a regression test that runs `websocket.Dial` against a real `httptest` server with the middleware in the chain; it fails on the previous code with `ResponseWriter does not implement http.Hijacker`.

Fixes #246