### PR TITLE
chore(*): tidy Trivy alerts; enforce review-after + exec guardrail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,11 @@ jobs:
       - name: Check no exec of tools whose CVEs are silenced
         run: |
           tools='readelf|objdump|ld|as|nm|strip|addr2line|ar|ranlib|gprof|size'
-          # exec.Command("X", ...) — tool name is the first arg
-          # exec.CommandContext(ctx, "X", ...) — tool name is the second arg
-          pattern="exec\\.Command\\(\"(${tools})\"|exec\\.CommandContext\\([^,]+, *\"(${tools})\""
+          # Catches both bare names and absolute paths:
+          #   exec.Command("tool", ...)
+          #   exec.Command("/usr/bin/tool", ...)
+          #   exec.CommandContext(ctx, "tool", ...)
+          pattern='exec\.Command\("(/[^"]*/)?('"$tools"')"|exec\.CommandContext\([^,]+, *"(/[^"]*/)?('"$tools"')"'
           if grep -rnE "$pattern" --include='*.go' .; then
             echo "::error::Go code invokes a binutils tool whose CVEs are silenced via package-level ignore in .trivyignore.rego. Drop the ignore to CVE-level, or remove the invocation."
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,34 +50,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-  security-invariants:
+  # Enforces the "Go code does not exec these tools" half of the
+  # binutils-family package-level ignore in .trivyignore.rego. If any
+  # of these binaries is legitimately needed from Go code, drop the
+  # ignore to CVE-level first so the trust boundary is explicit.
+  # Review-after dates are tracked via .github/workflows/review-reminders.yml
+  # which opens a GitHub issue rather than blocking CI.
+  exec-guard:
     runs-on: ubuntu-24.04
     timeout-minutes: 2
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      # Every `ignore if` rule in .trivyignore.rego must be preceded
-      # by `# review-after: YYYY-MM-DD`. Fails once any date is past,
-      # forcing a fresh look at the rule's justification.
-      - name: Check review-after dates in .trivyignore.rego
-        run: |
-          today=$(date -u +%Y-%m-%d)
-          failed=0
-          while IFS= read -r line; do
-            lineno="${line%%:*}"
-            review_date="${line##* }"
-            if [[ "$review_date" < "$today" ]]; then
-              echo "::error file=.trivyignore.rego,line=${lineno}::review-after ${review_date} has passed — re-check the rule's justification and bump the date (or narrow/remove the rule)"
-              failed=1
-            fi
-          done < <(grep -nE '^# *review-after:' .trivyignore.rego)
-          exit $failed
-      # Enforces the "Go code does not exec these tools" half of the
-      # binutils-family package-level ignore in .trivyignore.rego.
-      # If any of these binaries is legitimately needed from Go code,
-      # drop the ignore to CVE-level first so the trust boundary is
-      # explicit.
       - name: Check no exec of tools whose CVEs are silenced
         run: |
           tools='readelf|objdump|ld|as|nm|strip|addr2line|ar|ranlib|gprof|size'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,45 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+  security-invariants:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      # Every `ignore if` rule in .trivyignore.rego must be preceded
+      # by `# review-after: YYYY-MM-DD`. Fails once any date is past,
+      # forcing a fresh look at the rule's justification.
+      - name: Check review-after dates in .trivyignore.rego
+        run: |
+          today=$(date -u +%Y-%m-%d)
+          failed=0
+          while IFS= read -r line; do
+            lineno="${line%%:*}"
+            review_date="${line##* }"
+            if [[ "$review_date" < "$today" ]]; then
+              echo "::error file=.trivyignore.rego,line=${lineno}::review-after ${review_date} has passed — re-check the rule's justification and bump the date (or narrow/remove the rule)"
+              failed=1
+            fi
+          done < <(grep -nE '^# *review-after:' .trivyignore.rego)
+          exit $failed
+      # Enforces the "Go code does not exec these tools" half of the
+      # binutils-family package-level ignore in .trivyignore.rego.
+      # If any of these binaries is legitimately needed from Go code,
+      # drop the ignore to CVE-level first so the trust boundary is
+      # explicit.
+      - name: Check no exec of tools whose CVEs are silenced
+        run: |
+          tools='readelf|objdump|ld|as|nm|strip|addr2line|ar|ranlib|gprof|size'
+          # exec.Command("X", ...) — tool name is the first arg
+          # exec.CommandContext(ctx, "X", ...) — tool name is the second arg
+          pattern="exec\\.Command\\(\"(${tools})\"|exec\\.CommandContext\\([^,]+, *\"(${tools})\""
+          if grep -rnE "$pattern" --include='*.go' .; then
+            echo "::error::Go code invokes a binutils tool whose CVEs are silenced via package-level ignore in .trivyignore.rego. Drop the ignore to CVE-level, or remove the invocation."
+            exit 1
+          fi
+
   dependencies:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04

--- a/.github/workflows/review-reminders.yml
+++ b/.github/workflows/review-reminders.yml
@@ -1,0 +1,57 @@
+name: Review Reminders
+
+# Scheduled workflow that scans .trivyignore.rego for expired
+# `# review-after: YYYY-MM-DD` comments and opens (or updates) a
+# tracker issue. Chosen over a blocking CI check so unrelated PRs
+# aren't held hostage by an expired date — the issue is the forcing
+# function instead.
+
+on:
+  schedule:
+    - cron: "0 12 * * 1"  # Monday noon UTC — after the Monday 6 AM publish rebuild
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  trivyignore-expired:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE_TITLE: "security: expired review-after dates in .trivyignore.rego"
+    steps:
+      - uses: actions/checkout@v6
+      - name: Scan and manage tracker issue
+        run: |
+          today=$(date -u +%Y-%m-%d)
+          expired=$(grep -nE '^# *review-after:' .trivyignore.rego \
+            | awk -F'[: ]+' -v t="$today" '$NF < t { printf "- line %d: %s\n", $1, $NF }') || true
+
+          existing=$(gh issue list --state open --limit 100 --json number,title \
+            | jq -r --arg title "$ISSUE_TITLE" '[.[] | select(.title == $title) | .number] | .[0] // empty')
+
+          if [ -z "$expired" ]; then
+            if [ -n "$existing" ]; then
+              gh issue close "$existing" --comment "All review-after dates are now in the future."
+            fi
+            exit 0
+          fi
+
+          body=$(cat <<EOF
+          The review-after comments in .trivyignore.rego below have expired. Re-check each rule's justification:
+
+          - If the invariant still holds, bump the date.
+          - If not, narrow the rule to specific CVE IDs or remove it.
+
+          $expired
+          EOF
+          )
+
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body "$body"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body "$body"
+          fi

--- a/.trivyignore.rego
+++ b/.trivyignore.rego
@@ -13,10 +13,14 @@
 #     so a future CVE in the same package forces fresh triage.
 #
 # Every `ignore if` rule must be preceded by a `# review-after: YYYY-MM-DD`
-# comment. The Review Reminders workflow (.github/workflows/review-reminders.yml)
-# runs weekly and opens a tracker issue listing any expired dates — the
-# issue is the forcing function, not a blocked PR. On re-review: if the
-# argument still holds, bump the date; if not, remove or narrow the rule.
+# comment. Default cadence is 3 months from the time the rule is added
+# or last re-reviewed — use a shorter date for fragile invariants; do
+# not extend beyond 3 months without an explicit reason. The Review
+# Reminders workflow (.github/workflows/review-reminders.yml) runs
+# weekly and opens a tracker issue listing any expired dates — the
+# issue is the forcing function, not a blocked PR. On re-review: if
+# the argument still holds, bump the date; if not, remove or narrow
+# the rule.
 #
 # For exec-reachable invariants ("Go code does not invoke tool X"), the
 # `exec-guard` job in .github/workflows/ci.yml greps the Go source for

--- a/.trivyignore.rego
+++ b/.trivyignore.rego
@@ -14,3 +14,25 @@ default ignore := false
 # vulnerabilities — containers use the host kernel, not a kernel
 # built from these headers, so they are not container-exploitable.
 ignore if input.PkgName == "linux-libc-dev"
+
+# binutils and its transitive libraries are pulled in by rig to
+# support the R source-build path (R CMD INSTALL compiles C/C++
+# in user-supplied packages). They are a build toolchain, not a
+# runtime parser of external input: nothing on the request path
+# (Go server, R runtime, bubblewrap) links libbfd or invokes
+# readelf/objdump against untrusted data. CVEs in this family
+# are therefore only reachable by a malicious R package, which
+# already has arbitrary code execution inside its worker — so
+# they add no capability the threat model doesn't already accept.
+# Re-review if anything on the request path starts feeding
+# untrusted binaries to these tools or links libbfd directly.
+ignore if input.PkgName in {
+	"binutils",
+	"binutils-common",
+	"binutils-x86-64-linux-gnu",
+	"libbinutils",
+	"libctf0",
+	"libctf-nobfd0",
+	"libgprofng0",
+	"libsframe1",
+}

--- a/.trivyignore.rego
+++ b/.trivyignore.rego
@@ -29,14 +29,14 @@ import rego.v1
 
 default ignore := false
 
-# review-after: 2027-04-17
+# review-after: 2026-07-17
 # linux-libc-dev ships kernel header files pulled in transitively
 # by rig's R installation. The CVEs describe running-kernel
 # vulnerabilities — containers use the host kernel, not a kernel
 # built from these headers, so they are not container-exploitable.
 ignore if input.PkgName == "linux-libc-dev"
 
-# review-after: 2027-04-17
+# review-after: 2026-07-17
 # binutils and its transitive libraries are pulled in by rig to
 # support the R source-build path (R CMD INSTALL compiles C/C++
 # in user-supplied packages). They are a build toolchain, not a
@@ -60,7 +60,7 @@ ignore if input.PkgName in {
 	"libsframe1",
 }
 
-# review-after: 2027-04-17
+# review-after: 2026-07-17
 # GNU tar path-traversal via symlink + two-stage extraction. Not
 # exploitable in blockyard's current paths: bundle upload uses Go's
 # stdlib archive/tar (no /usr/bin/tar exec), and R's own tar usage
@@ -72,7 +72,7 @@ ignore if input.PkgName in {
 # rather than silence automatically.
 ignore if input.VulnerabilityID == "CVE-2025-45582"
 
-# review-after: 2027-04-17
+# review-after: 2026-07-17
 # libexpat algorithmic-complexity DoS: a ~2 MiB crafted XML causes
 # dozens of seconds of processing. libexpat1 is a transitive dep
 # (likely fontconfig), not linked on any request path in blockyard:
@@ -86,7 +86,7 @@ ignore if input.VulnerabilityID == "CVE-2025-45582"
 # triage rather than silence automatically.
 ignore if input.VulnerabilityID == "CVE-2025-66382"
 
-# review-after: 2027-04-17
+# review-after: 2026-07-17
 # libde265 heap buffer overflows in HEIC decode (38949 targets
 # display444as420; 38950 targets __interceptor_memcpy). libde265-0
 # is pulled in transitively via libheif by the R graphics stack;
@@ -101,7 +101,7 @@ ignore if input.VulnerabilityID in {
 	"CVE-2024-38950",
 }
 
-# review-after: 2027-04-17
+# review-after: 2026-07-17
 # pixman is a 2D graphics rasterization library reached via cairo
 # by R's plotting devices (png, pdf, svg). It operates on
 # in-memory pixel buffers produced by R — no attacker-supplied

--- a/.trivyignore.rego
+++ b/.trivyignore.rego
@@ -13,15 +13,15 @@
 #     so a future CVE in the same package forces fresh triage.
 #
 # Every `ignore if` rule must be preceded by a `# review-after: YYYY-MM-DD`
-# comment. The `security-invariants` job in .github/workflows/ci.yml
-# fails once any date is past, forcing a re-check of the invariant.
-# On re-review: if the argument still holds, bump the date; if not,
-# remove or narrow the rule.
+# comment. The Review Reminders workflow (.github/workflows/review-reminders.yml)
+# runs weekly and opens a tracker issue listing any expired dates — the
+# issue is the forcing function, not a blocked PR. On re-review: if the
+# argument still holds, bump the date; if not, remove or narrow the rule.
 #
 # For exec-reachable invariants ("Go code does not invoke tool X"), the
-# same CI job greps the Go source for `exec.Command("X", ...)` so the
-# promise is enforced, not aspirational. Keep that list in sync with
-# the ignored packages in this file.
+# `exec-guard` job in .github/workflows/ci.yml greps the Go source for
+# `exec.Command("X", ...)` so the promise is enforced, not aspirational.
+# Keep that list in sync with the package-level ignores in this file.
 
 package trivy
 
@@ -47,9 +47,8 @@ ignore if input.PkgName == "linux-libc-dev"
 # already has arbitrary code execution inside its worker — so
 # they add no capability the threat model doesn't already accept.
 # The "Go code does not exec these tools" half of the invariant
-# is enforced by the security-invariants CI job; the "nothing
-# links libbfd at runtime" half is residual risk — re-review if
-# that changes.
+# is enforced by the exec-guard CI job; the "nothing links libbfd
+# at runtime" half is residual risk — re-review if that changes.
 ignore if input.PkgName in {
 	"binutils",
 	"binutils-common",
@@ -60,3 +59,15 @@ ignore if input.PkgName in {
 	"libgprofng0",
 	"libsframe1",
 }
+
+# review-after: 2027-04-17
+# GNU tar path-traversal via symlink + two-stage extraction. Not
+# exploitable in blockyard's current paths: bundle upload uses Go's
+# stdlib archive/tar (no /usr/bin/tar exec), and R's own tar usage
+# (e.g. install.packages extracting source tarballs) only runs
+# after the user has supplied executable R code, which is already
+# RCE-equivalent. Kept at CVE level on purpose — tar is a plausible
+# legitimate exec target in future code, so a new, potentially
+# different-class CVE in the same package should re-trigger triage
+# rather than silence automatically.
+ignore if input.VulnerabilityID == "CVE-2025-45582"

--- a/.trivyignore.rego
+++ b/.trivyignore.rego
@@ -1,7 +1,27 @@
 # Trivy ignore policy for blockyard container images.
 #
-# Rule-by-package, not by CVE ID, so future CVEs in the same
-# package silence automatically on every base rebuild.
+# Two rule styles are supported:
+#
+#   - Package-level (`input.PkgName == "..."` or `input.PkgName in {...}`):
+#     silences all current and future CVEs in the package. Use only when
+#     the reason for ignoring is structural — the package is not linked
+#     or invoked on any code path that processes attacker-controlled
+#     input — so the argument covers CVEs that haven't been filed yet.
+#
+#   - CVE-level (`input.VulnerabilityID == "CVE-..."`): silences one
+#     finding. Use when the argument is specific to the reported bug,
+#     so a future CVE in the same package forces fresh triage.
+#
+# Every `ignore if` rule must be preceded by a `# review-after: YYYY-MM-DD`
+# comment. The `security-invariants` job in .github/workflows/ci.yml
+# fails once any date is past, forcing a re-check of the invariant.
+# On re-review: if the argument still holds, bump the date; if not,
+# remove or narrow the rule.
+#
+# For exec-reachable invariants ("Go code does not invoke tool X"), the
+# same CI job greps the Go source for `exec.Command("X", ...)` so the
+# promise is enforced, not aspirational. Keep that list in sync with
+# the ignored packages in this file.
 
 package trivy
 
@@ -9,12 +29,14 @@ import rego.v1
 
 default ignore := false
 
+# review-after: 2027-04-17
 # linux-libc-dev ships kernel header files pulled in transitively
 # by rig's R installation. The CVEs describe running-kernel
 # vulnerabilities — containers use the host kernel, not a kernel
 # built from these headers, so they are not container-exploitable.
 ignore if input.PkgName == "linux-libc-dev"
 
+# review-after: 2027-04-17
 # binutils and its transitive libraries are pulled in by rig to
 # support the R source-build path (R CMD INSTALL compiles C/C++
 # in user-supplied packages). They are a build toolchain, not a
@@ -24,8 +46,10 @@ ignore if input.PkgName == "linux-libc-dev"
 # are therefore only reachable by a malicious R package, which
 # already has arbitrary code execution inside its worker — so
 # they add no capability the threat model doesn't already accept.
-# Re-review if anything on the request path starts feeding
-# untrusted binaries to these tools or links libbfd directly.
+# The "Go code does not exec these tools" half of the invariant
+# is enforced by the security-invariants CI job; the "nothing
+# links libbfd at runtime" half is residual risk — re-review if
+# that changes.
 ignore if input.PkgName in {
 	"binutils",
 	"binutils-common",

--- a/.trivyignore.rego
+++ b/.trivyignore.rego
@@ -71,3 +71,17 @@ ignore if input.PkgName in {
 # different-class CVE in the same package should re-trigger triage
 # rather than silence automatically.
 ignore if input.VulnerabilityID == "CVE-2025-45582"
+
+# review-after: 2027-04-17
+# libexpat algorithmic-complexity DoS: a ~2 MiB crafted XML causes
+# dozens of seconds of processing. libexpat1 is a transitive dep
+# (likely fontconfig), not linked on any request path in blockyard:
+# the Go server has no encoding/xml usage, R's xml2 links libxml2
+# explicitly installed alongside libexpat, not expat itself. The
+# plausible in-image expat consumers (fontconfig reading fonts.conf)
+# only parse developer-controlled config at process init, never
+# attacker-supplied data. Kept at CVE level because the invariant
+# is library-linkage — not grep-testable — so a future memory-
+# corruption-class CVE in the same package should re-trigger
+# triage rather than silence automatically.
+ignore if input.VulnerabilityID == "CVE-2025-66382"

--- a/.trivyignore.rego
+++ b/.trivyignore.rego
@@ -85,3 +85,32 @@ ignore if input.VulnerabilityID == "CVE-2025-45582"
 # corruption-class CVE in the same package should re-trigger
 # triage rather than silence automatically.
 ignore if input.VulnerabilityID == "CVE-2025-66382"
+
+# review-after: 2027-04-17
+# libde265 heap buffer overflows in HEIC decode (38949 targets
+# display444as420; 38950 targets __interceptor_memcpy). libde265-0
+# is pulled in transitively via libheif by the R graphics stack;
+# no request-path consumer exposes it — the Go server doesn't
+# decode images and blockyard's APIs don't accept HEIC. Reachable
+# only from user R code that invokes HEIC decoding, which is
+# already RCE-equivalent. Kept at CVE level because a future
+# libde265 CVE may have a different shape (e.g. a parser bug on
+# a path we overlooked) and deserves fresh triage.
+ignore if input.VulnerabilityID in {
+	"CVE-2024-38949",
+	"CVE-2024-38950",
+}
+
+# review-after: 2027-04-17
+# pixman is a 2D graphics rasterization library reached via cairo
+# by R's plotting devices (png, pdf, svg). It operates on
+# in-memory pixel buffers produced by R — no attacker-supplied
+# serialized data is fed into it on any blockyard request path;
+# the only consumer is user R code rendering plots, which is
+# already RCE-equivalent. The current CVE (CVE-2023-37769) is
+# additionally in the pixman stress-test binary that does not
+# ship in the libpixman-1-0 runtime package at all. Kept at
+# package level because pixman's role is structurally a
+# rasterizer, not a data parser — re-review if any feature
+# ever processes images server-side outside the R worker.
+ignore if input.PkgName == "libpixman-1-0"


### PR DESCRIPTION
## Summary

- All 138 open Trivy alerts silenced in `.trivyignore.rego`. Package-level for binutils family (128) and libpixman; CVE-level for tar, libexpat, libde265 where a future different-class CVE should re-trigger triage.
- Each rule carries `# review-after: 2026-07-17` (quarterly cadence). A new scheduled workflow opens a tracker issue weekly when any date expires — chosen over blocking CI so unrelated PRs aren't held hostage.
- New `exec-guard` CI job greps Go source for `exec.Command("readelf", ...)` and similar; turns the "Go does not exec these tools" half of the binutils argument into an enforced invariant rather than a comment-only promise.