### PR TITLE
fix(proxy): fix 404 on admin deactivate for email-shaped subs

### DIFF
--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -17,6 +18,18 @@ import (
 	"github.com/cynkra/blockyard/internal/integration"
 	"github.com/cynkra/blockyard/internal/server"
 )
+
+// urlParamSub returns the {sub} path parameter, URL-decoded. Chi returns
+// RawPath-backed params still percent-encoded when the path contains
+// characters Go's net/http preserved as-is (e.g. "@" in email-shaped subs
+// from dex or similar IdPs), so the raw value would miss the DB lookup.
+func urlParamSub(r *http.Request) string {
+	raw := chi.URLParam(r, "sub")
+	if decoded, err := url.PathUnescape(raw); err == nil {
+		return decoded
+	}
+	return raw
+}
 
 // serviceNameRe validates service names: alphanumeric, hyphens, underscores, 1-64 chars.
 var serviceNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
@@ -249,7 +262,7 @@ func GetUser(srv *server.Server) http.HandlerFunc {
 			return
 		}
 
-		sub := chi.URLParam(r, "sub")
+		sub := urlParamSub(r)
 		user, err := srv.DB.GetUser(sub)
 		if err != nil {
 			serverError(w, "failed to get user")
@@ -294,7 +307,7 @@ func UpdateUser(srv *server.Server) http.HandlerFunc {
 			return
 		}
 
-		sub := chi.URLParam(r, "sub")
+		sub := urlParamSub(r)
 
 		// Prevent self-demotion/deactivation.
 		if sub == caller.Sub {

--- a/internal/api/users_test.go
+++ b/internal/api/users_test.go
@@ -522,6 +522,43 @@ func TestUpdateUser_Forbidden(t *testing.T) {
 	}
 }
 
+// TestUpdateUser_EncodedSub exercises the case where the OIDC sub contains
+// a character (like "@") that JS encodeURIComponent percent-escapes and Go's
+// net/http preserves in r.URL.RawPath. chi.URLParam returns the still-encoded
+// value in that case, so the handler must decode before looking up the user
+// — otherwise the deactivate flow returns 404 for email-shaped subs.
+func TestUpdateUser_EncodedSub(t *testing.T) {
+	idp := testutil.NewMockIdP()
+	defer idp.Close()
+	srv, ts := testServerWithOIDC(t, idp)
+
+	const sub = "dex|user@example.com"
+	srv.DB.UpsertUserWithRole("admin-1", "admin@example.com", "Admin", "admin")
+	srv.DB.UpsertUserWithRole(sub, "user@example.com", "User", "viewer")
+	pat := createTestPAT(t, srv.DB, "admin-1")
+
+	// Mirror JS encodeURIComponent, which percent-escapes "@" — Go's
+	// url.URL.EscapedPath leaves "@" alone and wouldn't trigger the bug.
+	encoded := strings.NewReplacer("|", "%7C", "@", "%40").Replace(sub)
+	body := `{"active":false}`
+	resp, err := http.DefaultClient.Do(jwtReq("PATCH", ts.URL+"/api/v1/users/"+encoded, pat, strings.NewReader(body)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	got, err := srv.DB.GetUser(sub)
+	if err != nil || got == nil {
+		t.Fatalf("get user: %v, %v", got, err)
+	}
+	if got.Active {
+		t.Error("expected user to be inactive")
+	}
+}
+
 func TestUpdateUser_InvalidJSON(t *testing.T) {
 	idp := testutil.NewMockIdP()
 	defer idp.Close()


### PR DESCRIPTION
## Summary
- `chi.URLParam` returns the `{sub}` path value still percent-encoded when Go retains `r.URL.RawPath` (happens for chars like `@` that JS's `encodeURIComponent` escapes), so the admin UI's deactivate toggle was querying the DB with `user%40example.com` instead of `user@example.com` and getting a 404 back.
- Added a `urlParamSub` helper that unescapes and used it in `GetUser` and `UpdateUser`.
- Regression test with a `dex|user@example.com`-shaped sub — verified it returns 404 without the fix and 200 with it.