### PR TITLE
ci(misc): fix release scan and smoke; share trivy action

### DIFF
--- a/.github/actions/scan-image/action.yml
+++ b/.github/actions/scan-image/action.yml
@@ -1,0 +1,61 @@
+name: Trivy image scan
+description: >
+  Scan a ghcr.io container image for CVEs, filter through
+  .trivyignore.rego, and upload the SARIF to the GitHub Security tab.
+  Shared between publish.yml (continuous main) and release.yml (tagged
+  releases) so both apply the same severity threshold and ignore policy.
+
+inputs:
+  image-ref:
+    description: Full image reference (e.g. ghcr.io/cynkra/blockyard:build-linux-amd64).
+    required: true
+  variant:
+    description: Variant name (docker | process | everything) — used for the SARIF category and output filename.
+    required: true
+  ghcr-username:
+    description: GHCR username for pulling the image.
+    required: true
+  ghcr-token:
+    description: GHCR token for pulling the image.
+    required: true
+  fail-on-findings:
+    description: When "true", exit non-zero if any unignored vulnerability is found. Release uses true; publish uses false so main continues to publish and the SARIF still reaches the Security tab.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Run Trivy vulnerability scanner (${{ inputs.variant }})
+      uses: aquasecurity/trivy-action@v0.35.0
+      with:
+        image-ref: ${{ inputs.image-ref }}
+        format: sarif
+        output: trivy-results-${{ inputs.variant }}.sarif
+        # Includes MEDIUM because blockyard executes arbitrary R code,
+        # and in-process library CVEs (libssl, libtiff, libcurl, ...)
+        # are trivially exploitable by a malicious R package even when
+        # they're rated medium — nothing isolates a compromised lib
+        # from the process that linked it.
+        severity: CRITICAL,HIGH,MEDIUM
+        # Required for `severity` to actually filter the SARIF output.
+        # Without this the action unsets TRIVY_SEVERITY when format=sarif
+        # and every severity gets uploaded to the Security tab.
+        limit-severities-for-sarif: true
+        # OPA/Rego policy that filters by package name instead of by
+        # CVE ID, so future kernel-header CVEs are silenced
+        # automatically. See the file itself for rationale.
+        ignore-policy: .trivyignore.rego
+        exit-code: ${{ inputs.fail-on-findings == 'true' && '1' || '0' }}
+      env:
+        TRIVY_USERNAME: ${{ inputs.ghcr-username }}
+        TRIVY_PASSWORD: ${{ inputs.ghcr-token }}
+
+    - name: Upload Trivy results to GitHub Security tab
+      if: always()
+      uses: github/codeql-action/upload-sarif@v4
+      with:
+        sarif_file: trivy-results-${{ inputs.variant }}.sarif
+        # Per-variant category so the three scans don't overwrite each
+        # other's alerts in the Security tab.
+        category: trivy-${{ inputs.variant }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,39 +106,12 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v6
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.35.0
+      - uses: ./.github/actions/scan-image
         with:
           image-ref: ${{ env.IMAGE }}${{ matrix.image_suffix }}:build-linux-amd64
-          format: sarif
-          output: trivy-results.sarif
-          # Includes MEDIUM because blockyard executes arbitrary R code,
-          # and in-process library CVEs (libssl, libtiff, libcurl, ...)
-          # are trivially exploitable by a malicious R package even when
-          # they're rated medium — nothing isolates a compromised lib
-          # from the process that linked it.
-          severity: CRITICAL,HIGH,MEDIUM
-          # Required for `severity` to actually filter the SARIF output.
-          # Without this the action unsets TRIVY_SEVERITY when format=sarif
-          # and every severity gets uploaded to the Security tab.
-          limit-severities-for-sarif: true
-          # OPA/Rego policy that filters by package name instead of by
-          # CVE ID, so future kernel-header CVEs are silenced
-          # automatically. See the file itself for rationale.
-          ignore-policy: .trivyignore.rego
-        env:
-          TRIVY_USERNAME: ${{ github.actor }}
-          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload Trivy results to GitHub Security tab
-        if: always()
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: trivy-results.sarif
-          # Per-variant category so the three scans don't overwrite each
-          # other's alerts in the Security tab.
-          category: trivy-${{ matrix.variant }}
+          variant: ${{ matrix.variant }}
+          ghcr-username: ${{ github.actor }}
+          ghcr-token: ${{ secrets.GITHUB_TOKEN }}
 
   manifest:
     needs: [server-image, scan-image]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,25 +49,13 @@ jobs:
             suffix: ""
     steps:
       - uses: actions/checkout@v6
-
-      - name: Run Trivy vulnerability scanner (${{ matrix.variant }})
-        uses: aquasecurity/trivy-action@v0.35.0
+      - uses: ./.github/actions/scan-image
         with:
           image-ref: ${{ env.SERVER_IMAGE }}${{ matrix.suffix }}:build-linux-amd64
-          format: sarif
-          output: trivy-results-${{ matrix.variant }}.sarif
-          severity: CRITICAL,HIGH
-          exit-code: "1"
-        env:
-          TRIVY_USERNAME: ${{ github.actor }}
-          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload Trivy results to GitHub Security tab
-        if: always()
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: trivy-results-${{ matrix.variant }}.sarif
-          category: trivy-${{ matrix.variant }}
+          variant: ${{ matrix.variant }}
+          ghcr-username: ${{ github.actor }}
+          ghcr-token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-findings: "true"
 
   server-manifest:
     needs: scan-image
@@ -141,6 +129,28 @@ jobs:
           IMAGE="${{ env.SERVER_IMAGE }}${{ matrix.suffix }}:build-linux-amd64"
           docker pull "$IMAGE"
           SECCOMP=""
+          BACKEND_ARGS=()
+          case "${{ matrix.variant }}" in
+            docker|everything)
+              # Baked-in config defaults backend=docker, which needs a
+              # reachable Docker daemon to pass the client.Ping in
+              # backend/docker.New. Mount the runner's socket so the
+              # process starts.
+              BACKEND_ARGS=(-v /var/run/docker.sock:/var/run/docker.sock)
+              ;;
+          esac
+          if [ "${{ matrix.variant }}" = "process" ]; then
+            # The process-only build does not register a docker factory,
+            # so the baked-in backend=docker fails fast at startup.
+            # Override via env vars: SERVER_BACKEND selects the process
+            # factory; PROCESS_BWRAP_PATH is the sentinel that forces
+            # applyEnvOverrides to auto-construct the [process] section
+            # (processDefaults fills in the remaining knobs).
+            BACKEND_ARGS=(
+              -e BLOCKYARD_SERVER_BACKEND=process
+              -e BLOCKYARD_PROCESS_BWRAP_PATH=/usr/bin/bwrap
+            )
+          fi
           if [ "${{ matrix.variant }}" != "docker" ]; then
             # Override the entrypoint — the image's default entrypoint
             # is ["blockyard", "--config", ...], so without
@@ -148,7 +158,7 @@ jobs:
             docker run --rm --entrypoint cat "$IMAGE" /etc/blockyard/seccomp.json > /tmp/seccomp.json
             SECCOMP="--security-opt seccomp=/tmp/seccomp.json"
           fi
-          docker run -d --name smoke ${SECCOMP} -p 18080:8080 "$IMAGE" || true
+          docker run -d --name smoke ${SECCOMP} "${BACKEND_ARGS[@]}" -p 18080:8080 "$IMAGE" || true
           for i in $(seq 1 30); do
             if curl -sf http://localhost:18080/healthz >/dev/null; then
               docker rm -f smoke


### PR DESCRIPTION
## Summary
- v0.0.3 release exposed two latent bugs never caught before: scan-image used a different Trivy config than publish (no ignore-policy, HIGH+CRITICAL only), and server-smoke (added after v0.0.2) booted each variant with the baked-in `backend=docker` config
- Extract the Trivy invocation to `.github/actions/scan-image` so publish and release share one severity threshold + rego policy; `fail-on-findings` input toggles the exit-1 release wants
- Fix server-smoke: mount `/var/run/docker.sock` for `docker`/`everything`, and override to `backend=process` via `BLOCKYARD_SERVER_BACKEND` + `BLOCKYARD_PROCESS_BWRAP_PATH` env vars for the `process` variant