### PR TITLE
ci(misc): bind release smoke on 0.0.0.0 so the port mapping works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,11 @@ jobs:
               -e BLOCKYARD_PROCESS_BWRAP_PATH=/usr/bin/bwrap
             )
           fi
+          # Bind on 0.0.0.0 so `-p 18080:8080` reaches the server —
+          # the baked-in config binds 127.0.0.1 (fronted by a reverse
+          # proxy in production), which Docker's published-port NAT
+          # can't target.
+          BACKEND_ARGS+=(-e BLOCKYARD_SERVER_BIND=0.0.0.0:8080)
           if [ "${{ matrix.variant }}" != "docker" ]; then
             # Override the entrypoint — the image's default entrypoint
             # is ["blockyard", "--config", ...], so without


### PR DESCRIPTION
## Summary
- Previous two smoke fixes got the server to `"server listening"` but curl from outside the container still couldn't reach it — the baked-in config binds `127.0.0.1` (fine in production behind a reverse proxy) and Docker's published-port NAT can't target a loopback listener
- Override via `BLOCKYARD_SERVER_BIND=0.0.0.0:8080` in every variant so `-p 18080:8080` actually hits the server socket