### PR TITLE
fix(proxy): don't evict cold-starting workers as crashed

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -88,6 +88,23 @@ jobs:
         if: failure()
         run: |
           docker compose -f "examples/${{ matrix.example }}/docker-compose.yml" logs --no-color 2>/dev/null || true
+          # Workers are spawned by blockyard outside docker-compose,
+          # so their stdout/stderr isn't in the compose logs above.
+          # Dump them by label so we can see R/Shiny startup failures.
+          workers=$(docker ps -a --filter 'label=dev.blockyard/role=worker' --format '{{.ID}} {{.Names}}')
+          if [ -n "$workers" ]; then
+            echo "==> blockyard worker containers"
+            echo "$workers"
+            while IFS= read -r line; do
+              id=${line%% *}
+              name=${line#* }
+              echo "==> worker $name ($id) logs"
+              docker logs "$id" 2>&1 || true
+              echo
+            done <<< "$workers"
+          else
+            echo "==> no blockyard worker containers found"
+          fi
           docker compose -f "examples/${{ matrix.example }}/docker-compose.yml" down -v --remove-orphans 2>/dev/null || true
 
   e2e:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Build blockyard image from source
         if: github.event_name != 'pull_request' && github.event_name != 'push'
         run: docker build -t ghcr.io/cynkra/blockyard:latest -t ghcr.io/cynkra/blockyard:main --build-arg COVER=1 --build-arg "VERSION=$(git describe --always --dirty)" -f docker/server.Dockerfile .
+      - name: Build example worker image
+        if: github.event_name != 'pull_request' && github.event_name != 'push' && matrix.example != 'hello-shiny'
+        run: docker build -t blockyard-example-worker:4.4.3 -f examples/Dockerfile.worker examples
       - name: Block cloud metadata endpoint for containers
         if: github.event_name != 'pull_request' && github.event_name != 'push'
         run: sudo iptables -I DOCKER-USER -d 169.254.169.254/32 -j DROP 2>/dev/null || true

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -58,6 +58,23 @@ jobs:
       - name: Prepare coverage directory
         if: github.event_name != 'pull_request' && github.event_name != 'push'
         run: mkdir -p /tmp/e2e-coverage/{cli,server}
+      - name: Start worker log streamer
+        if: github.event_name != 'pull_request' && github.event_name != 'push'
+        run: |
+          # blockyard removes worker containers when it stops them, so
+          # by the time a failure step runs the containers (and their
+          # logs) are gone. Stream them to files as they appear.
+          mkdir -p /tmp/worker-logs
+          nohup bash -c '
+            docker events --format "{{.Actor.ID}}" \
+              --filter event=start \
+              --filter "label=dev.blockyard/role=worker" \
+              | while read -r id; do
+                short=${id:0:12}
+                ( docker logs -f "$id" >"/tmp/worker-logs/${short}.log" 2>&1 ) &
+              done
+          ' >/tmp/worker-events.log 2>&1 &
+          echo $! > /tmp/worker-events.pid
       - name: Run example tests
         if: github.event_name != 'pull_request' && github.event_name != 'push'
         run: sudo --preserve-env=PATH,E2E_GOCOVERDIR go test -v -tags examples -run ${{ matrix.test }} -timeout 20m ./tests/examples/...
@@ -88,22 +105,18 @@ jobs:
         if: failure()
         run: |
           docker compose -f "examples/${{ matrix.example }}/docker-compose.yml" logs --no-color 2>/dev/null || true
-          # Workers are spawned by blockyard outside docker-compose,
-          # so their stdout/stderr isn't in the compose logs above.
-          # Dump them by label so we can see R/Shiny startup failures.
-          workers=$(docker ps -a --filter 'label=dev.blockyard/role=worker' --format '{{.ID}} {{.Names}}')
-          if [ -n "$workers" ]; then
-            echo "==> blockyard worker containers"
-            echo "$workers"
-            while IFS= read -r line; do
-              id=${line%% *}
-              name=${line#* }
-              echo "==> worker $name ($id) logs"
-              docker logs "$id" 2>&1 || true
+          # Stop the log streamer and dump what it captured. Workers
+          # are removed by blockyard when it stops them, so the only
+          # record of their stdout/stderr is these captured files.
+          [ -f /tmp/worker-events.pid ] && kill "$(cat /tmp/worker-events.pid)" 2>/dev/null || true
+          if ls /tmp/worker-logs/*.log >/dev/null 2>&1; then
+            for f in /tmp/worker-logs/*.log; do
+              echo "==> $(basename "$f")"
+              cat "$f" || true
               echo
-            done <<< "$workers"
+            done
           else
-            echo "==> no blockyard worker containers found"
+            echo "==> no worker logs captured"
           fi
           docker compose -f "examples/${{ matrix.example }}/docker-compose.yml" down -v --remove-orphans 2>/dev/null || true
 

--- a/examples/Dockerfile.worker
+++ b/examples/Dockerfile.worker
@@ -1,0 +1,13 @@
+# Worker image for examples whose bundles depend on R packages that
+# need libuv at runtime (fs → bslib → shiny — every Shiny app, plus
+# blockr boards). rocker/r-ver ships only the R toolchain, so layer
+# libuv1 on top.
+#
+# Built locally (not pulled from a registry):
+#   docker build -t blockyard-example-worker:4.4.3 -f examples/Dockerfile.worker examples
+#
+# CI builds it as a step before example tests run.
+FROM ghcr.io/rocker-org/r-ver:4.4.3
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libuv1 \
+    && rm -rf /var/lib/apt/lists/*

--- a/examples/hello-pocketbase/blockyard.toml
+++ b/examples/hello-pocketbase/blockyard.toml
@@ -4,7 +4,7 @@ shutdown_timeout = "30s"
 
 [docker]
 socket          = "/var/run/docker.sock"
-image           = "ghcr.io/rocker-org/r-ver:4.4.3"
+image           = "blockyard-example-worker:4.4.3"
 shiny_port      = 3838
 pak_version     = "stable"
 service_network = "blockyard-services"

--- a/examples/hello-pocketbase/blockyard.toml
+++ b/examples/hello-pocketbase/blockyard.toml
@@ -21,7 +21,7 @@ path = "/data/db/blockyard.db"
 [proxy]
 ws_cache_ttl         = "60s"
 health_interval      = "15s"
-worker_start_timeout = "60s"
+worker_start_timeout = "120s"
 max_workers          = 100
 log_retention        = "1h"
 # session_idle_ttl   = "0"

--- a/examples/hello-postgrest/blockyard.toml
+++ b/examples/hello-postgrest/blockyard.toml
@@ -18,7 +18,7 @@ max_bundle_size    = 104857600
 [proxy]
 ws_cache_ttl         = "60s"
 health_interval      = "15s"
-worker_start_timeout = "60s"
+worker_start_timeout = "120s"
 max_workers          = 100
 log_retention        = "1h"
 # session_idle_ttl   = "0"

--- a/examples/hello-postgrest/blockyard.toml
+++ b/examples/hello-postgrest/blockyard.toml
@@ -4,7 +4,7 @@ shutdown_timeout = "30s"
 
 [docker]
 socket          = "/var/run/docker.sock"
-image           = "ghcr.io/rocker-org/r-ver:4.4.3"
+image           = "blockyard-example-worker:4.4.3"
 shiny_port      = 3838
 pak_version     = "stable"
 service_network = "blockyard-services"

--- a/internal/ops/ops.go
+++ b/internal/ops/ops.go
@@ -238,6 +238,13 @@ func pollOnce(ctx context.Context, srv *server.Server, misses map[string]int) {
 			delete(misses, r.workerID)
 			continue
 		}
+		// Workers still in their cold-start window are owned by
+		// spawnWorker's pollHealthy; don't count misses against them.
+		if w, ok := srv.Workers.Get(r.workerID); ok {
+			if time.Since(w.StartedAt) < srv.Config.Proxy.WorkerStartTimeout.Duration {
+				continue
+			}
+		}
 		misses[r.workerID]++
 		if misses[r.workerID] >= maxMisses {
 			slog.Warn("health poller: evicting unhealthy worker",

--- a/internal/ops/ops_test.go
+++ b/internal/ops/ops_test.go
@@ -384,6 +384,43 @@ func TestHealthPollerEvictsAfterConsecutiveMisses(t *testing.T) {
 	}
 }
 
+// Regression for #269: the health poller must not count misses against
+// a worker that is still inside its WorkerStartTimeout cold-start
+// window — spawnWorker's pollHealthy owns that phase.
+func TestHealthPollerSkipsColdStartingWorker(t *testing.T) {
+	srv, be := testServer(t)
+	srv.Config.Proxy.WorkerStartTimeout = config.Duration{Duration: time.Minute}
+	spawnWorker(t, srv, be, "w1", "app1")
+	// Mark the worker as just-spawned, inside the cold-start window.
+	w, _ := srv.Workers.Get("w1")
+	w.StartedAt = time.Now()
+	srv.Workers.Set("w1", w)
+
+	be.HealthOK.Store(false)
+	misses := make(map[string]int)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		pollOnce(ctx, srv, misses)
+	}
+	if _, ok := srv.Workers.Get("w1"); !ok {
+		t.Error("cold-starting worker should not be evicted while its window is active")
+	}
+	if misses["w1"] != 0 {
+		t.Errorf("cold-starting worker should not accrue misses, got %d", misses["w1"])
+	}
+
+	// After the window, the usual crash-detection behavior applies.
+	w, _ = srv.Workers.Get("w1")
+	w.StartedAt = time.Now().Add(-2 * time.Minute)
+	srv.Workers.Set("w1", w)
+	pollOnce(ctx, srv, misses)
+	pollOnce(ctx, srv, misses)
+	if _, ok := srv.Workers.Get("w1"); ok {
+		t.Error("post-cold-start unhealthy worker should be evicted after maxMisses")
+	}
+}
+
 func TestHealthPollerResetsOnRecovery(t *testing.T) {
 	srv, be := testServer(t)
 	spawnWorker(t, srv, be, "w1", "app1")

--- a/internal/proxy/autoscaler.go
+++ b/internal/proxy/autoscaler.go
@@ -145,16 +145,24 @@ func reconcileWorkersByState(srv *server.Server) {
 }
 
 // evictUnhealthy checks each worker's health and evicts any that have
-// crashed. Returns the remaining healthy worker IDs.
+// crashed. Returns the remaining healthy worker IDs. Workers still
+// within their cold-start window are left alone — spawnWorker's
+// pollHealthy owns their lifecycle until it returns.
 func evictUnhealthy(ctx context.Context, srv *server.Server, workerIDs []string) []string {
 	healthy := make([]string, 0, len(workerIDs))
+	coldStart := srv.Config.Proxy.WorkerStartTimeout.Duration
+	now := time.Now()
 	for _, wid := range workerIDs {
 		if srv.Backend.HealthCheck(ctx, wid) {
 			healthy = append(healthy, wid)
-		} else {
-			slog.Warn("autoscaler: evicting crashed worker", "worker_id", wid)
-			ops.EvictWorker(ctx, srv, wid, telemetry.ReasonCrashed)
+			continue
 		}
+		if w, ok := srv.Workers.Get(wid); ok && now.Sub(w.StartedAt) < coldStart {
+			healthy = append(healthy, wid)
+			continue
+		}
+		slog.Warn("autoscaler: evicting crashed worker", "worker_id", wid)
+		ops.EvictWorker(ctx, srv, wid, telemetry.ReasonCrashed)
 	}
 	return healthy
 }

--- a/internal/proxy/autoscaler_test.go
+++ b/internal/proxy/autoscaler_test.go
@@ -337,6 +337,11 @@ func TestEvictUnhealthyReturnsHealthy(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Backdate StartedAt past WorkerStartTimeout so these are treated
+	// as post-cold-start — evictUnhealthy's cold-start exemption does
+	// not apply.
+	backdateStart(srv, time.Hour, wid1, wid2, wid3)
+
 	// All unhealthy — should evict all.
 	be.HealthOK.Store(false)
 	healthy := evictUnhealthy(context.Background(), srv, []string{wid1, wid2, wid3})
@@ -358,6 +363,55 @@ func TestEvictUnhealthyReturnsHealthy(t *testing.T) {
 	healthy = evictUnhealthy(context.Background(), srv, []string{wid4, wid5})
 	if len(healthy) != 2 {
 		t.Errorf("expected 2 healthy workers, got %d", len(healthy))
+	}
+}
+
+// Regression for #269: when HealthInterval is shorter than a worker's
+// real cold-start time, the autoscaler tick must not evict a still-
+// starting worker as "crashed" — spawnWorker's pollHealthy owns that
+// window.
+func TestEvictUnhealthySkipsColdStart(t *testing.T) {
+	srv := testAutoscaleServer(t)
+	app := createTestApp(t, srv, "my-app", true)
+	be := srv.Backend.(*mock.MockBackend)
+
+	wid, _, err := spawnWorker(context.Background(), srv, app)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Worker hasn't finished its cold-start window yet and isn't
+	// answering health checks.
+	be.HealthOK.Store(false)
+
+	healthy := evictUnhealthy(context.Background(), srv, []string{wid})
+	if len(healthy) != 1 {
+		t.Fatalf("cold-starting worker must be kept, got %d retained", len(healthy))
+	}
+	if _, ok := srv.Workers.Get(wid); !ok {
+		t.Error("cold-starting worker was evicted from the worker map")
+	}
+
+	// Once the cold-start window elapses, the same unhealthy worker
+	// is correctly treated as crashed.
+	backdateStart(srv, time.Hour, wid)
+	healthy = evictUnhealthy(context.Background(), srv, []string{wid})
+	if len(healthy) != 0 {
+		t.Errorf("post-cold-start unhealthy worker must be evicted, got %d retained", len(healthy))
+	}
+	if _, ok := srv.Workers.Get(wid); ok {
+		t.Error("post-cold-start unhealthy worker was not evicted")
+	}
+}
+
+func backdateStart(srv *server.Server, d time.Duration, workerIDs ...string) {
+	for _, wid := range workerIDs {
+		w, ok := srv.Workers.Get(wid)
+		if !ok {
+			continue
+		}
+		w.StartedAt = time.Now().Add(-d)
+		srv.Workers.Set(wid, w)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Autoscaler's `evictUnhealthy` tick (every `HealthInterval`, 15s default) was treating any worker that failed `HealthCheck` as crashed, including workers still inside their `WorkerStartTimeout` cold-start window.
- When a real cold-start (R + vault + DB) crosses a tick, the autoscaler calls `Backend.Stop` on the worker mid-spawn, and the concurrent `pollHealthy` in `spawnWorker` then times out against the now-dead container — surfacing as `worker did not become healthy in time` in #269.
- Exempt workers younger than `WorkerStartTimeout` from eviction: `spawnWorker`'s `pollHealthy` owns their lifecycle until it returns. Post-cold-start crash detection is unchanged.
- Adds `TestEvictUnhealthySkipsColdStart` covering both the exemption and the post-window crash path.

Fixes #269