### PR TITLE
fix(misc): drain old workers on redeploy without evicting sessions

### DIFF
--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -720,10 +720,9 @@ func RollbackApp(srv *server.Server) http.HandlerFunc {
 		// Capture previous bundle before switching.
 		previousBundle := app.ActiveBundle
 
-		// Drain and stop running workers.
-		ops.StopAppSync(srv, app.ID)
-
-		// Switch active bundle and record deployment tracking.
+		// Switch the active bundle before draining so any cold-start
+		// spawn that races the drain window uses the target bundle,
+		// not the one we're about to evict.
 		if err := srv.DB.SetActiveBundle(app.ID, body.BundleID); err != nil {
 			serverError(w, "set active bundle: "+err.Error())
 			return
@@ -732,6 +731,9 @@ func RollbackApp(srv *server.Server) http.HandlerFunc {
 			slog.Warn("rollback: failed to update deployment tracking", //nolint:gosec // G706: slog structured logging handles this
 				"bundle_id", body.BundleID, "error", err)
 		}
+
+		// Drain and stop workers still running the previous bundle.
+		ops.StopAppSync(srv, app.ID)
 
 		// Re-read app to get updated state.
 		app, err = srv.DB.GetApp(app.ID)

--- a/internal/api/bundles.go
+++ b/internal/api/bundles.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cynkra/blockyard/internal/auth"
 	"github.com/cynkra/blockyard/internal/bundle"
 	"github.com/cynkra/blockyard/internal/manifest"
+	"github.com/cynkra/blockyard/internal/ops"
 	"github.com/cynkra/blockyard/internal/server"
 )
 
@@ -150,6 +151,9 @@ func UploadBundle(srv *server.Server) http.HandlerFunc {
 			AuditActor:       actorSub,
 			Metrics:          srv.Metrics,
 			WG:               srv.RestoreWG,
+			StopAppWorkers: func(appID string) {
+				ops.StopAppSync(srv, appID)
+			},
 		})
 
 		srv.Metrics.BundlesUploaded.Inc()

--- a/internal/api/bundles.go
+++ b/internal/api/bundles.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cynkra/blockyard/internal/auth"
 	"github.com/cynkra/blockyard/internal/bundle"
 	"github.com/cynkra/blockyard/internal/manifest"
-	"github.com/cynkra/blockyard/internal/ops"
 	"github.com/cynkra/blockyard/internal/server"
 )
 
@@ -151,8 +150,8 @@ func UploadBundle(srv *server.Server) http.HandlerFunc {
 			AuditActor:       actorSub,
 			Metrics:          srv.Metrics,
 			WG:               srv.RestoreWG,
-			StopAppWorkers: func(appID string) {
-				ops.StopAppSync(srv, appID)
+			DrainOldWorkers: func(appID string) {
+				srv.Workers.MarkDraining(appID)
 			},
 		})
 

--- a/internal/bundle/restore.go
+++ b/internal/bundle/restore.go
@@ -44,11 +44,13 @@ type RestoreParams struct {
 	AuditActor       string // sub of the user who triggered the upload
 	Metrics          *telemetry.Metrics // records restore duration + outcome
 	WG               *sync.WaitGroup    // if non-nil, Add(1) before goroutine, Done() on exit
-	// StopAppWorkers, if set, is invoked just before the new bundle is
-	// activated. It must drain and evict any workers still running the
-	// previous bundle so new sessions spawn with the new code. Blocks
-	// until workers are stopped (up to the server's shutdown_timeout).
-	StopAppWorkers func(appID string)
+	// DrainOldWorkers, if set, is invoked just before the new bundle is
+	// activated. It marks workers of the previous bundle as draining so
+	// that new sessions cold-start against the new bundle while existing
+	// sessions keep running on the old workers until they end naturally.
+	// Must not force-evict; the autoscaler's idle-timeout reaps drained
+	// workers once their sessions complete.
+	DrainOldWorkers func(appID string)
 }
 
 // SpawnRestore launches the restore pipeline in a background goroutine.
@@ -375,11 +377,12 @@ func runRestore(p RestoreParams) error {
 	slog.Info("bundle state transition",
 		"app_id", p.AppID, "bundle_id", p.BundleID, "status", "activating")
 
-	// Stop workers running the previous bundle before flipping the
-	// active pointer; otherwise they stay up with stale code and new
-	// sessions get routed to them until they drain on their own.
-	if p.StopAppWorkers != nil {
-		p.StopAppWorkers(p.AppID)
+	// Mark workers of the previous bundle as draining before flipping
+	// the active pointer; the load balancer skips draining workers, so
+	// new sessions will cold-start against the new bundle while old
+	// sessions continue running on their existing workers.
+	if p.DrainOldWorkers != nil {
+		p.DrainOldWorkers(p.AppID)
 	}
 
 	if err := p.DB.ActivateBundle(p.AppID, p.BundleID); err != nil {

--- a/internal/bundle/restore.go
+++ b/internal/bundle/restore.go
@@ -44,6 +44,11 @@ type RestoreParams struct {
 	AuditActor       string // sub of the user who triggered the upload
 	Metrics          *telemetry.Metrics // records restore duration + outcome
 	WG               *sync.WaitGroup    // if non-nil, Add(1) before goroutine, Done() on exit
+	// StopAppWorkers, if set, is invoked just before the new bundle is
+	// activated. It must drain and evict any workers still running the
+	// previous bundle so new sessions spawn with the new code. Blocks
+	// until workers are stopped (up to the server's shutdown_timeout).
+	StopAppWorkers func(appID string)
 }
 
 // SpawnRestore launches the restore pipeline in a background goroutine.
@@ -369,6 +374,13 @@ func runRestore(p RestoreParams) error {
 	p.Sender.Write("Build succeeded. Activating bundle...")
 	slog.Info("bundle state transition",
 		"app_id", p.AppID, "bundle_id", p.BundleID, "status", "activating")
+
+	// Stop workers running the previous bundle before flipping the
+	// active pointer; otherwise they stay up with stale code and new
+	// sessions get routed to them until they drain on their own.
+	if p.StopAppWorkers != nil {
+		p.StopAppWorkers(p.AppID)
+	}
 
 	if err := p.DB.ActivateBundle(p.AppID, p.BundleID); err != nil {
 		return fmt.Errorf("activate bundle: %w", err)

--- a/internal/bundle/restore_test.go
+++ b/internal/bundle/restore_test.go
@@ -220,6 +220,85 @@ func TestSpawnRestore_FailureWithAuditLog(t *testing.T) {
 	}
 }
 
+// TestSpawnRestore_StopAppWorkersCalledBeforeActivate verifies that a
+// successful restore invokes StopAppWorkers and that it runs before
+// ActivateBundle. This is what makes redeploy pick up new code — old
+// workers must be torn down before the active bundle pointer flips.
+func TestSpawnRestore_StopAppWorkersCalledBeforeActivate(t *testing.T) {
+	params, tasks := setupRestoreTest(t, true)
+
+	var stopCalled bool
+	var activeAtStop *string
+	params.StopAppWorkers = func(appID string) {
+		if appID != params.AppID {
+			t.Errorf("StopAppWorkers called with app_id %q, want %q", appID, params.AppID)
+		}
+		stopCalled = true
+		// Snapshot the active bundle at the moment stop fires. It must
+		// still be the old value (nil on a fresh app) because activation
+		// has not happened yet.
+		appRow, err := params.DB.GetApp(params.AppID)
+		if err != nil {
+			t.Fatalf("GetApp during StopAppWorkers: %v", err)
+		}
+		activeAtStop = appRow.ActiveBundle
+	}
+
+	SpawnRestore(params)
+
+	_, _, done, ok := tasks.Subscribe("task-1")
+	if !ok {
+		t.Fatal("task not found")
+	}
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for SpawnRestore to complete")
+	}
+
+	if !stopCalled {
+		t.Fatal("StopAppWorkers was not invoked on successful restore")
+	}
+	if activeAtStop != nil {
+		t.Fatalf("StopAppWorkers ran after activation (active=%q), want before", *activeAtStop)
+	}
+
+	// Sanity check: activation did eventually happen.
+	appRow, err := params.DB.GetApp(params.AppID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if appRow.ActiveBundle == nil || *appRow.ActiveBundle != "b-1" {
+		t.Fatal("expected active bundle to be 'b-1' after restore")
+	}
+}
+
+// TestSpawnRestore_StopAppWorkersSkippedOnFailure verifies that a
+// failed build does not invoke StopAppWorkers. Running workers should
+// keep serving the previous bundle when a new build fails.
+func TestSpawnRestore_StopAppWorkersSkippedOnFailure(t *testing.T) {
+	params, tasks := setupRestoreTest(t, false)
+
+	var stopCalled bool
+	params.StopAppWorkers = func(string) { stopCalled = true }
+
+	SpawnRestore(params)
+
+	_, _, done, ok := tasks.Subscribe("task-1")
+	if !ok {
+		t.Fatal("task not found")
+	}
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for SpawnRestore to complete")
+	}
+
+	if stopCalled {
+		t.Fatal("StopAppWorkers must not fire when the build fails")
+	}
+}
+
 func TestBuildCommand(t *testing.T) {
 	cmd := BuildCommand()
 	if len(cmd) != 4 {

--- a/internal/bundle/restore_test.go
+++ b/internal/bundle/restore_test.go
@@ -220,28 +220,29 @@ func TestSpawnRestore_FailureWithAuditLog(t *testing.T) {
 	}
 }
 
-// TestSpawnRestore_StopAppWorkersCalledBeforeActivate verifies that a
-// successful restore invokes StopAppWorkers and that it runs before
-// ActivateBundle. This is what makes redeploy pick up new code — old
-// workers must be torn down before the active bundle pointer flips.
-func TestSpawnRestore_StopAppWorkersCalledBeforeActivate(t *testing.T) {
+// TestSpawnRestore_DrainOldWorkersCalledBeforeActivate verifies that a
+// successful restore invokes DrainOldWorkers and that it runs before
+// ActivateBundle. Flagging old workers as draining before the active
+// bundle pointer flips is what keeps new cold starts on the new bundle
+// while existing sessions finish on the old workers.
+func TestSpawnRestore_DrainOldWorkersCalledBeforeActivate(t *testing.T) {
 	params, tasks := setupRestoreTest(t, true)
 
-	var stopCalled bool
-	var activeAtStop *string
-	params.StopAppWorkers = func(appID string) {
+	var drainCalled bool
+	var activeAtDrain *string
+	params.DrainOldWorkers = func(appID string) {
 		if appID != params.AppID {
-			t.Errorf("StopAppWorkers called with app_id %q, want %q", appID, params.AppID)
+			t.Errorf("DrainOldWorkers called with app_id %q, want %q", appID, params.AppID)
 		}
-		stopCalled = true
-		// Snapshot the active bundle at the moment stop fires. It must
+		drainCalled = true
+		// Snapshot the active bundle at the moment drain fires. It must
 		// still be the old value (nil on a fresh app) because activation
 		// has not happened yet.
 		appRow, err := params.DB.GetApp(params.AppID)
 		if err != nil {
-			t.Fatalf("GetApp during StopAppWorkers: %v", err)
+			t.Fatalf("GetApp during DrainOldWorkers: %v", err)
 		}
-		activeAtStop = appRow.ActiveBundle
+		activeAtDrain = appRow.ActiveBundle
 	}
 
 	SpawnRestore(params)
@@ -256,11 +257,11 @@ func TestSpawnRestore_StopAppWorkersCalledBeforeActivate(t *testing.T) {
 		t.Fatal("timed out waiting for SpawnRestore to complete")
 	}
 
-	if !stopCalled {
-		t.Fatal("StopAppWorkers was not invoked on successful restore")
+	if !drainCalled {
+		t.Fatal("DrainOldWorkers was not invoked on successful restore")
 	}
-	if activeAtStop != nil {
-		t.Fatalf("StopAppWorkers ran after activation (active=%q), want before", *activeAtStop)
+	if activeAtDrain != nil {
+		t.Fatalf("DrainOldWorkers ran after activation (active=%q), want before", *activeAtDrain)
 	}
 
 	// Sanity check: activation did eventually happen.
@@ -273,14 +274,14 @@ func TestSpawnRestore_StopAppWorkersCalledBeforeActivate(t *testing.T) {
 	}
 }
 
-// TestSpawnRestore_StopAppWorkersSkippedOnFailure verifies that a
-// failed build does not invoke StopAppWorkers. Running workers should
+// TestSpawnRestore_DrainOldWorkersSkippedOnFailure verifies that a
+// failed build does not invoke DrainOldWorkers. Running workers should
 // keep serving the previous bundle when a new build fails.
-func TestSpawnRestore_StopAppWorkersSkippedOnFailure(t *testing.T) {
+func TestSpawnRestore_DrainOldWorkersSkippedOnFailure(t *testing.T) {
 	params, tasks := setupRestoreTest(t, false)
 
-	var stopCalled bool
-	params.StopAppWorkers = func(string) { stopCalled = true }
+	var drainCalled bool
+	params.DrainOldWorkers = func(string) { drainCalled = true }
 
 	SpawnRestore(params)
 
@@ -294,8 +295,8 @@ func TestSpawnRestore_StopAppWorkersSkippedOnFailure(t *testing.T) {
 		t.Fatal("timed out waiting for SpawnRestore to complete")
 	}
 
-	if stopCalled {
-		t.Fatal("StopAppWorkers must not fire when the build fails")
+	if drainCalled {
+		t.Fatal("DrainOldWorkers must not fire when the build fails")
 	}
 }
 

--- a/internal/proxy/autoscaler.go
+++ b/internal/proxy/autoscaler.go
@@ -73,12 +73,11 @@ func autoscaleTick(ctx context.Context, srv *server.Server) {
 	appIDs := srv.Workers.AppIDs()
 
 	for _, appID := range appIDs {
-		if srv.Workers.IsDraining(appID) {
-			continue
-		}
-
 		app, err := srv.DB.GetApp(appID)
 		if err != nil || app == nil {
+			continue
+		}
+		if !app.Enabled {
 			continue
 		}
 
@@ -212,7 +211,7 @@ func preWarmApps(ctx context.Context, srv *server.Server) {
 		return
 	}
 	for _, app := range apps {
-		if !app.Enabled || srv.Workers.IsDraining(app.ID) {
+		if !app.Enabled {
 			continue
 		}
 		ensurePreWarmed(ctx, srv, &app)

--- a/internal/proxy/autoscaler_test.go
+++ b/internal/proxy/autoscaler_test.go
@@ -650,22 +650,41 @@ func TestEnsurePreWarmedClaimedWorkerReplacement(t *testing.T) {
 	}
 }
 
-func TestPreWarmAppsSkipsDraining(t *testing.T) {
+func TestPreWarmAppsSkipsDisabled(t *testing.T) {
+	srv := testAutoscaleServer(t)
+	app := createTestApp(t, srv, "my-app", true)
+
+	sessions := 2
+	srv.DB.UpdateApp(app.ID, db.AppUpdate{PreWarmedSessions: &sessions})
+	srv.DB.SetAppEnabled(app.ID, false)
+
+	before := srv.Workers.Count()
+	preWarmApps(context.Background(), srv)
+
+	if srv.Workers.Count() != before {
+		t.Errorf("expected no new workers for disabled app, got %d total", srv.Workers.Count())
+	}
+}
+
+// TestPreWarmAppsRunsDuringDrain confirms the new semantics: when an
+// app's existing workers are draining (e.g. after a redeploy), the
+// pre-warmer still spawns fresh workers for the new bundle. Under the
+// old "any worker draining = app draining" rule this was blocked.
+func TestPreWarmAppsRunsDuringDrain(t *testing.T) {
 	srv := testAutoscaleServer(t)
 	app := createTestApp(t, srv, "my-app", true)
 
 	sessions := 2
 	srv.DB.UpdateApp(app.ID, db.AppUpdate{PreWarmedSessions: &sessions})
 
-	// Register a draining worker so IsDraining returns true.
 	srv.Workers.Set("drain-w", server.ActiveWorker{AppID: app.ID})
 	srv.Workers.MarkDraining(app.ID)
 
 	before := srv.Workers.Count()
 	preWarmApps(context.Background(), srv)
 
-	if srv.Workers.Count() != before {
-		t.Errorf("expected no new workers for draining app, got %d total", srv.Workers.Count())
+	if srv.Workers.Count() <= before {
+		t.Errorf("expected pre-warm to spawn new workers alongside the drained one, got %d total", srv.Workers.Count())
 	}
 }
 

--- a/internal/proxy/coldstart.go
+++ b/internal/proxy/coldstart.go
@@ -25,7 +25,6 @@ var (
 	errMaxWorkers    = errors.New("max workers reached")
 	errNoBundle      = errors.New("app has no active bundle")
 	errHealthTimeout = errors.New("worker did not become healthy in time")
-	errAppDraining   = errors.New("app is shutting down")
 )
 
 var lb LoadBalancer
@@ -81,10 +80,13 @@ func (g *spawnSingleFlight) do(key string, fn func() (string, string, error)) (s
 // Concurrent calls for the same app are deduplicated — only one spawn
 // runs at a time per app.
 func ensureWorker(ctx context.Context, srv *server.Server, app *db.AppRow) (workerID, addr string, err error) {
-	// Reject new sessions for apps being drained.
-	if srv.Workers.IsDraining(app.ID) {
-		return "", "", errAppDraining
-	}
+	// New sessions for disabled apps are already rejected upstream in
+	// proxy.go. Draining workers are excluded from assignment by
+	// ForAppAvailable, so the load balancer returns "" and the caller
+	// spawns a fresh worker using app.ActiveBundle — which is correct
+	// for bundle changes (redeploy, rollback) where we want old
+	// sessions to finish on old workers while new sessions cold-start
+	// against the new bundle.
 
 	// Try to assign to an existing worker with capacity.
 	wid, err := lb.Assign(

--- a/internal/proxy/coldstart_test.go
+++ b/internal/proxy/coldstart_test.go
@@ -279,18 +279,24 @@ func TestSpawnSingleFlightDedup(t *testing.T) {
 	<-done
 }
 
-// TestEnsureWorkerDrainingRejects covers lines 82-84.
-func TestEnsureWorkerDrainingRejects(t *testing.T) {
+// TestEnsureWorkerDrainingSpawns verifies that when every existing
+// worker for an app is draining, ensureWorker spawns a fresh one
+// rather than rejecting the request. This is the redeploy/rollback
+// path: old workers keep their sessions; new sessions cold-start
+// against the current active bundle.
+func TestEnsureWorkerDrainingSpawns(t *testing.T) {
 	srv := testColdstartServer(t)
 	app := createTestApp(t, srv, "my-app", true)
 
-	// Mark app as draining
 	srv.Workers.Set("drain-worker", server.ActiveWorker{AppID: app.ID})
 	srv.Workers.MarkDraining(app.ID)
 
-	_, _, err := ensureWorker(context.Background(), srv, app)
-	if err != errAppDraining {
-		t.Errorf("expected errAppDraining, got %v", err)
+	wid, _, err := ensureWorker(context.Background(), srv, app)
+	if err != nil {
+		t.Fatalf("expected spawn to succeed, got %v", err)
+	}
+	if wid == "drain-worker" {
+		t.Fatal("ensureWorker returned the drained worker; expected a fresh spawn")
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -215,8 +215,6 @@ func Handler(srv *server.Server) http.Handler {
 					http.Error(w, "server at capacity", http.StatusServiceUnavailable)
 				case errCapacityExhausted:
 					http.Error(w, "app at capacity", http.StatusServiceUnavailable)
-				case errAppDraining:
-					http.Error(w, "app is shutting down", http.StatusServiceUnavailable)
 				case errNoBundle:
 					http.Error(w, "app has no active bundle", http.StatusServiceUnavailable)
 				case errHealthTimeout:

--- a/internal/ui/upload.go
+++ b/internal/ui/upload.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cynkra/blockyard/internal/auth"
 	"github.com/cynkra/blockyard/internal/bundle"
 	"github.com/cynkra/blockyard/internal/manifest"
+	"github.com/cynkra/blockyard/internal/ops"
 	"github.com/cynkra/blockyard/internal/server"
 )
 
@@ -322,6 +323,9 @@ func (ui *UI) createApp(srv *server.Server) http.HandlerFunc {
 			AuditActor:       caller.Sub,
 			Metrics:          srv.Metrics,
 			WG:               srv.RestoreWG,
+			StopAppWorkers: func(appID string) {
+				ops.StopAppSync(srv, appID)
+			},
 		})
 
 		srv.Metrics.BundlesUploaded.Inc()

--- a/internal/ui/upload.go
+++ b/internal/ui/upload.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cynkra/blockyard/internal/auth"
 	"github.com/cynkra/blockyard/internal/bundle"
 	"github.com/cynkra/blockyard/internal/manifest"
-	"github.com/cynkra/blockyard/internal/ops"
 	"github.com/cynkra/blockyard/internal/server"
 )
 
@@ -323,8 +322,8 @@ func (ui *UI) createApp(srv *server.Server) http.HandlerFunc {
 			AuditActor:       caller.Sub,
 			Metrics:          srv.Metrics,
 			WG:               srv.RestoreWG,
-			StopAppWorkers: func(appID string) {
-				ops.StopAppSync(srv, appID)
+			DrainOldWorkers: func(appID string) {
+				srv.Workers.MarkDraining(appID)
 			},
 		})
 


### PR DESCRIPTION
## Summary
- Redeploying an app left old workers running stale code because `ActivateBundle` only updated the DB; new sessions kept routing to them until they happened to idle out.
- `bundle.runRestore` now invokes a `DrainOldWorkers` callback (wired to `srv.Workers.MarkDraining` from both upload handlers) just before the active-bundle pointer flips — existing sessions keep serving on the old workers, new sessions cold-start against the new bundle.
- Removes the `IsDraining(app.ID)` gate in `ensureWorker` and the autoscaler; it conflated "workers are draining" with "app is shutting down". The app-level gate lives on `app.Enabled` (already checked upstream in `proxy.go`).
- `RollbackApp` now flips `SetActiveBundle` before `StopAppSync` so any cold-start that races the drain window uses the target bundle.

Fixes #267