### PR TITLE
fix(proxy): count sessions as active WebSockets, not cookies

### DIFF
--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -1005,7 +1005,7 @@ func drainWorkers(srv *server.Server, appID string, workerIDs []string, sender t
 	deadline := time.Now().Add(srv.Config.Server.ShutdownTimeout.Duration)
 
 	for {
-		remaining := srv.Sessions.CountForWorkers(workerIDs)
+		remaining := srv.WsConns.CountForWorkers(workerIDs)
 		if remaining == 0 {
 			sender.Write("all sessions ended")
 			break

--- a/internal/api/runtime.go
+++ b/internal/api/runtime.go
@@ -493,7 +493,7 @@ func DisableApp(srv *server.Server) http.HandlerFunc {
 			go func() { //nolint:gosec // G118: intentional background task, outlives request
 				deadline := time.Now().Add(srv.Config.Server.ShutdownTimeout.Duration)
 				for {
-					remaining := srv.Sessions.CountForWorkers(workerIDs)
+					remaining := srv.WsConns.CountForWorkers(workerIDs)
 					if remaining == 0 || time.Now().After(deadline) {
 						break
 					}

--- a/internal/drain/drain.go
+++ b/internal/drain/drain.go
@@ -134,7 +134,7 @@ func (d *Drainer) waitForIdle(maxWait time.Duration) {
 
 	for {
 		own := d.Srv.Workers.WorkersForServer(d.ServerID)
-		sessions := d.Srv.Sessions.CountForWorkers(own)
+		sessions := d.Srv.WsConns.CountForWorkers(own)
 		if sessions == 0 {
 			slog.Info("finish: session count reached zero",
 				"server_id", d.ServerID)

--- a/internal/drain/drain_test.go
+++ b/internal/drain/drain_test.go
@@ -274,6 +274,7 @@ func TestFinishWaitForIdleDeadlineElapses(t *testing.T) {
 	srv := server.NewServer(&config.Config{}, mock.New(), testDB(t))
 	srv.Workers.Set("w1", server.ActiveWorker{AppID: "app1"})
 	srv.Sessions.Set("sess-never-drains", session.Entry{WorkerID: "w1"})
+	srv.WsConns.TryInc("w1", 1<<30)
 
 	const idleWait = 80 * time.Millisecond
 	d := drainerForIdleTest(t, srv, idleWait, "test-server")
@@ -303,12 +304,14 @@ func TestFinishWaitForIdleSessionDrainsMidWait(t *testing.T) {
 	srv := server.NewServer(&config.Config{}, mock.New(), testDB(t))
 	srv.Workers.Set("w1", server.ActiveWorker{AppID: "app1"})
 	srv.Sessions.Set("sess-clearing", session.Entry{WorkerID: "w1"})
+	srv.WsConns.TryInc("w1", 1<<30)
 
 	// Clear the session after ~50ms — a few polls in, well before
 	// the 1s deadline.
 	go func() {
 		time.Sleep(50 * time.Millisecond)
 		srv.Sessions.Delete("sess-clearing")
+		srv.WsConns.Dec("w1")
 	}()
 
 	d := drainerForIdleTest(t, srv, time.Second, "test-server")
@@ -357,6 +360,7 @@ func TestFinishWaitForIdleFiltersByServerID(t *testing.T) {
 	// The peer's worker has an active session; without the
 	// ServerID filter, Finish would wait for it.
 	srv.Sessions.Set("peer-sess", session.Entry{WorkerID: newWorker})
+	srv.WsConns.TryInc(newWorker, 1<<30)
 
 	d := drainerForIdleTest(t, srv, 500*time.Millisecond, oldServerID)
 

--- a/internal/ops/ops.go
+++ b/internal/ops/ops.go
@@ -32,8 +32,6 @@ func EvictWorker(ctx context.Context, srv *server.Server, workerID, reason strin
 		srv.Metrics.WorkersStopped.WithLabelValues(reason).Inc()
 		srv.Metrics.WorkersActive.Dec()
 	}
-	sessionCount := srv.Sessions.CountForWorkers([]string{workerID})
-
 	// End session records in the database.
 	if err := srv.DB.EndWorkerSessions(workerID); err != nil {
 		slog.Warn("evict: failed to end worker sessions",
@@ -42,8 +40,11 @@ func EvictWorker(ctx context.Context, srv *server.Server, workerID, reason strin
 
 	srv.Registry.Delete(workerID)
 	srv.Sessions.DeleteByWorker(workerID)
+	srv.WsConns.DeleteWorker(workerID)
 	srv.LogStore.MarkEnded(workerID)
-	srv.Metrics.SessionsActive.Sub(float64(sessionCount))
+	// SessionsActive is kept in sync by shuttleWS's TryInc/Dec; the
+	// shuttles backed by this worker will exit when the backend closes,
+	// decrementing the gauge on their own.
 
 	// Clean up worker library from the package store.
 	if srv.PkgStore != nil {
@@ -184,15 +185,15 @@ func appLabelForWorker(srv *server.Server, workerID string) string {
 }
 
 // evictDrainedWorkers checks draining workers and evicts those with
-// zero active sessions. Called from the health poller tick.
+// zero active WebSockets. Called from the health poller tick.
 func evictDrainedWorkers(ctx context.Context, srv *server.Server) {
 	for _, wid := range srv.Workers.All() {
 		w, ok := srv.Workers.Get(wid)
 		if !ok || !w.Draining {
 			continue
 		}
-		if srv.Sessions.CountForWorker(wid) == 0 {
-			slog.Info("evicting drained worker with zero sessions",
+		if srv.WsConns.Count(wid) == 0 {
+			slog.Info("evicting drained worker with zero ws",
 				"worker_id", wid, "app_id", w.AppID)
 			EvictWorker(ctx, srv, wid, telemetry.ReasonGraceful)
 		}
@@ -333,11 +334,11 @@ func drainAndEvictAll(ctx context.Context, srv *server.Server, workerIDs []strin
 		}
 	}
 
-	// Wait for sessions to end (up to half of shutdown timeout).
+	// Wait for sessions (active WebSockets) to end (up to half of shutdown timeout).
 	drainTimeout := srv.Config.Server.ShutdownTimeout.Duration / 2
 	deadline := time.Now().Add(drainTimeout)
 	for time.Now().Before(deadline) {
-		total := srv.Sessions.CountForWorkers(workerIDs)
+		total := srv.WsConns.CountForWorkers(workerIDs)
 		if total == 0 {
 			slog.Info("shutdown: all sessions drained")
 			break
@@ -397,7 +398,7 @@ func StopAppSync(srv *server.Server, appID string) {
 
 	deadline := time.Now().Add(srv.Config.Server.ShutdownTimeout.Duration)
 	for {
-		remaining := srv.Sessions.CountForWorkers(workerIDs)
+		remaining := srv.WsConns.CountForWorkers(workerIDs)
 		if remaining == 0 || time.Now().After(deadline) {
 			break
 		}

--- a/internal/ops/ops_test.go
+++ b/internal/ops/ops_test.go
@@ -341,6 +341,8 @@ func TestEvictDrainedWorkersKeepsWithSessions(t *testing.T) {
 	spawnWorker(t, srv, be, "w-drain", "app1")
 	srv.Workers.SetDraining("w-drain")
 	srv.Sessions.Set("sess1", session.Entry{WorkerID: "w-drain"})
+	// Active WS on the worker — draining should wait for it.
+	srv.WsConns.TryInc("w-drain", 1<<30)
 
 	evictDrainedWorkers(context.Background(), srv)
 

--- a/internal/proxy/autoscaler.go
+++ b/internal/proxy/autoscaler.go
@@ -51,12 +51,12 @@ func autoscaleTick(ctx context.Context, srv *server.Server) {
 		}
 	}
 
-	// Mark workers idle when their last session has been swept.
-	// Without this, HTTP-only workers whose sessions were removed above
-	// would never get their IdleSince set and would run forever.
+	// Mark workers idle when their last WebSocket has gone. A session
+	// is one active WS, so zero WS means nobody is currently using the
+	// worker — cookie pins alone don't keep it alive.
 	now := time.Now()
 	for _, wid := range srv.Workers.All() {
-		if srv.Sessions.CountForWorker(wid) == 0 {
+		if srv.WsConns.Count(wid) == 0 {
 			srv.Workers.SetIdleSinceIfZero(wid, now)
 		}
 	}
@@ -133,7 +133,7 @@ func reconcileWorkersByState(srv *server.Server) {
 		switch {
 		case w.Draining:
 			draining++
-		case srv.Sessions.CountForWorker(wid) > 0:
+		case srv.WsConns.Count(wid) > 0:
 			busy++
 		default:
 			idle++
@@ -172,12 +172,13 @@ func evictUnhealthy(ctx context.Context, srv *server.Server, workerIDs []string)
 func tryScaleUp(ctx context.Context, srv *server.Server, app *db.AppRow, workerIDs []string) {
 	maxSessions := app.MaxSessionsPerWorker
 
-	// Check if all workers are at capacity.
+	// Check if all workers are at capacity. Load is active WebSocket
+	// count — that's what max_sessions_per_worker gates.
 	for _, wid := range workerIDs {
-		count := srv.Sessions.CountForWorker(wid)
+		count := srv.WsConns.Count(wid)
 		slog.Log(ctx, config.LevelTrace, "autoscaler: worker load",
 			"app_id", app.ID, "worker_id", wid,
-			"sessions", count, "max_sessions", maxSessions)
+			"ws", count, "max_sessions", maxSessions)
 		if count < maxSessions {
 			return // at least one worker has room
 		}
@@ -241,11 +242,12 @@ func ensurePreWarmed(ctx context.Context, srv *server.Server, app *db.AppRow) {
 		maxSessions = 1
 	}
 
-	// Sum free session slots across non-draining workers.
+	// Sum free session slots across non-draining workers. A slot is
+	// "free" when no WebSocket is currently occupying it.
 	availableWorkers := srv.Workers.ForAppAvailable(app.ID)
 	freeSlots := 0
 	for _, wid := range availableWorkers {
-		count := srv.Sessions.CountForWorker(wid)
+		count := srv.WsConns.Count(wid)
 		free := maxSessions - count
 		if free > 0 {
 			freeSlots += free

--- a/internal/proxy/autoscaler_test.go
+++ b/internal/proxy/autoscaler_test.go
@@ -22,6 +22,7 @@ func testAutoscaleServer(t *testing.T) *server.Server {
 
 func setSession(srv *server.Server, id, workerID string) {
 	srv.Sessions.Set(id, session.Entry{WorkerID: workerID, LastAccess: time.Now()})
+	srv.WsConns.TryInc(workerID, 1<<30)
 }
 
 func TestAutoscaleScaleUp(t *testing.T) {

--- a/internal/proxy/coldstart.go
+++ b/internal/proxy/coldstart.go
@@ -90,7 +90,7 @@ func ensureWorker(ctx context.Context, srv *server.Server, app *db.AppRow) (work
 	wid, err := lb.Assign(
 		app.ID,
 		srv.Workers,
-		srv.Sessions,
+		srv.WsConns,
 		app.MaxSessionsPerWorker,
 		app.MaxWorkersPerApp,
 	)
@@ -125,7 +125,7 @@ func ensureWorker(ctx context.Context, srv *server.Server, app *db.AppRow) (work
 		wid, err := lb.Assign(
 			app.ID,
 			srv.Workers,
-			srv.Sessions,
+			srv.WsConns,
 			app.MaxSessionsPerWorker,
 			app.MaxWorkersPerApp,
 		)

--- a/internal/proxy/coldstart_test.go
+++ b/internal/proxy/coldstart_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cynkra/blockyard/internal/db"
 	"github.com/cynkra/blockyard/internal/pkgstore"
 	"github.com/cynkra/blockyard/internal/server"
-	"github.com/cynkra/blockyard/internal/session"
 )
 
 func testColdstartServer(t *testing.T) *server.Server {
@@ -311,8 +310,8 @@ func TestEnsureWorkerCapacityExhausted(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Fill its session capacity
-	srv.Sessions.Set("sess-1", session.Entry{WorkerID: wid})
+	// Fill its session capacity (one active WS on this worker).
+	srv.WsConns.TryInc(wid, 1)
 
 	// Now ensureWorker should return errCapacityExhausted
 	_, _, err = ensureWorker(context.Background(), srv, app)
@@ -392,7 +391,7 @@ func TestEnsureWorkerRecheckAfterSpawnSlot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	srv.Sessions.Set("sess-1", session.Entry{WorkerID: wid1})
+	srv.WsConns.TryInc(wid1, 1<<30)
 
 	// Now spawn a second concurrent request: first call to lb.Assign
 	// returns "", nil (no capacity, but can spawn). Inside spawnGroup.do,
@@ -407,10 +406,10 @@ func TestEnsureWorkerRecheckAfterSpawnSlot(t *testing.T) {
 	}
 
 	// Free the session from wid1 so re-check can find capacity
-	srv.Sessions.Delete("sess-1")
+	srv.WsConns.Dec(wid1)
 
 	// Saturate wid2 so we need to check existing workers
-	srv.Sessions.Set("sess-2", session.Entry{WorkerID: wid2})
+	srv.WsConns.TryInc(wid2, 1<<30)
 
 	// Now ensureWorker should reuse wid1 via the outer lb.Assign (not
 	// entering the spawn path at all). To cover the inner re-check path

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -1640,3 +1640,76 @@ func TestProxyMultiplexSessions(t *testing.T) {
 		t.Errorf("expected 2 backend WS accepts on same worker, got %d", accepts)
 	}
 }
+
+// TestSecondWebSocketRejectedAtCapacity is the regression test for
+// issue #268. With max_workers_per_app=1 and max_sessions_per_worker=1,
+// the second WebSocket from the same browser (sharing the session
+// cookie) must be rejected — not silently share the worker. A session
+// is now one active WebSocket, so the second tab hits capacity.
+func TestSecondWebSocketRejectedAtCapacity(t *testing.T) {
+	srv, ts := testProxyServer(t)
+	srv.Backend.(*mock.MockBackend).SetWSHandler(wsEchoHandler())
+
+	// Create, bundle, start.
+	req, _ := http.NewRequest("POST", ts.URL+"/api/v1/apps",
+		bytes.NewReader([]byte(`{"name":"cap-app"}`)))
+	req.Header.Set("Authorization", "Bearer "+testPAT)
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := http.DefaultClient.Do(req)
+	var created map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&created)
+	id := created["id"].(string)
+
+	req, _ = http.NewRequest("POST",
+		ts.URL+"/api/v1/apps/"+id+"/bundles",
+		bytes.NewReader(testutil.MakeBundle(t)))
+	req.Header.Set("Authorization", "Bearer "+testPAT)
+	http.DefaultClient.Do(req)
+	waitForBundleActive(t, ts, id, testPAT)
+
+	// Enforce max_workers_per_app=1, max_sessions_per_worker=1.
+	body := `{"max_workers_per_app":1,"max_sessions_per_worker":1}`
+	req, _ = http.NewRequest("PATCH", ts.URL+"/api/v1/apps/"+id,
+		strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+testPAT)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil || resp.StatusCode >= 400 {
+		t.Fatalf("patch app failed: %v, status=%d", err, resp.StatusCode)
+	}
+
+	req, _ = http.NewRequest("POST",
+		ts.URL+"/api/v1/apps/"+id+"/start", nil)
+	req.Header.Set("Authorization", "Bearer "+testPAT)
+	http.DefaultClient.Do(req)
+
+	ctx := context.Background()
+	wsURL := strings.Replace(ts.URL, "http://", "ws://", 1) + "/app/cap-app/"
+
+	// First WS opens successfully and holds the only seat.
+	conn1, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("first WS dial failed: %v", err)
+	}
+	defer conn1.CloseNow()
+
+	// Prove the first WS is live — round-trip a message.
+	if err := conn1.Write(ctx, websocket.MessageText, []byte("hi")); err != nil {
+		t.Fatalf("first WS write failed: %v", err)
+	}
+	if _, _, err := conn1.Read(ctx); err != nil {
+		t.Fatalf("first WS read failed: %v", err)
+	}
+
+	// Second WS must be rejected by the proxy at capacity.
+	_, rejResp, err := websocket.Dial(ctx, wsURL, nil)
+	if err == nil {
+		t.Fatal("expected second WS to be rejected at capacity, got success")
+	}
+	if rejResp == nil {
+		t.Fatalf("expected HTTP response for rejected WS, got nil: %v", err)
+	}
+	if rejResp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("second WS: expected status 503, got %d", rejResp.StatusCode)
+	}
+}

--- a/internal/proxy/loadbalancer.go
+++ b/internal/proxy/loadbalancer.go
@@ -5,17 +5,23 @@ import (
 	"log/slog"
 
 	"github.com/cynkra/blockyard/internal/server"
-	"github.com/cynkra/blockyard/internal/session"
 )
 
 var errCapacityExhausted = errors.New("all workers at capacity")
 
 // LoadBalancer assigns new sessions to workers using a least-loaded
 // strategy. Stateless — decisions are based on current worker and
-// session state at call time.
+// WebSocket state at call time.
 type LoadBalancer struct{}
 
 // Assign picks a worker for a new session belonging to appID.
+//
+// A session here is one active Shiny WebSocket (one tab). Load is
+// measured via the WsConnCounter: handshakes that have been accepted
+// and haven't closed yet. The cookie-level session store tracks
+// browser-to-worker pinning for HTTP routing but does not gate
+// capacity — two tabs in the same browser share the cookie but open
+// two distinct WebSockets, so the counter sees the second tab.
 //
 // Returns a worker ID when an existing worker has available capacity.
 // Returns ("", nil) when no worker has capacity but the per-app limit
@@ -25,7 +31,7 @@ type LoadBalancer struct{}
 func (lb *LoadBalancer) Assign(
 	appID string,
 	workers server.WorkerMap,
-	sessions session.Store,
+	wsConns *server.WsConnCounter,
 	maxSessionsPerWorker int,
 	maxWorkersPerApp *int,
 ) (string, error) {
@@ -41,7 +47,7 @@ func (lb *LoadBalancer) Assign(
 	bestCount := maxSessionsPerWorker // upper bound
 
 	for _, wid := range workerIDs {
-		count := sessions.CountForWorker(wid)
+		count := wsConns.Count(wid)
 		if count < maxSessionsPerWorker && count < bestCount {
 			bestID = wid
 			bestCount = count
@@ -51,7 +57,7 @@ func (lb *LoadBalancer) Assign(
 	if bestID != "" {
 		slog.Debug("lb: assigned to least-loaded worker", //nolint:gosec // G706: slog structured logging handles this
 			"app_id", appID, "worker_id", bestID,
-			"session_count", bestCount,
+			"ws_count", bestCount,
 			"available_workers", len(workerIDs))
 		return bestID, nil
 	}

--- a/internal/proxy/loadbalancer_test.go
+++ b/internal/proxy/loadbalancer_test.go
@@ -4,15 +4,14 @@ import (
 	"testing"
 
 	"github.com/cynkra/blockyard/internal/server"
-	"github.com/cynkra/blockyard/internal/session"
 )
 
 func TestAssignEmptyWorkers(t *testing.T) {
 	lb := LoadBalancer{}
 	workers := server.NewMemoryWorkerMap()
-	sessions := session.NewMemoryStore()
+	ws := server.NewWsConnCounter()
 
-	wid, err := lb.Assign("app-1", workers, sessions, 5, nil)
+	wid, err := lb.Assign("app-1", workers, ws, 5, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -24,12 +23,12 @@ func TestAssignEmptyWorkers(t *testing.T) {
 func TestAssignSingleWorkerWithCapacity(t *testing.T) {
 	lb := LoadBalancer{}
 	workers := server.NewMemoryWorkerMap()
-	sessions := session.NewMemoryStore()
+	ws := server.NewWsConnCounter()
 
 	workers.Set("w1", server.ActiveWorker{AppID: "app-1"})
-	sessions.Set("s1", session.Entry{WorkerID: "w1"})
+	ws.TryInc("w1", 100)
 
-	wid, err := lb.Assign("app-1", workers, sessions, 5, nil)
+	wid, err := lb.Assign("app-1", workers, ws, 5, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -41,18 +40,18 @@ func TestAssignSingleWorkerWithCapacity(t *testing.T) {
 func TestAssignLeastLoaded(t *testing.T) {
 	lb := LoadBalancer{}
 	workers := server.NewMemoryWorkerMap()
-	sessions := session.NewMemoryStore()
+	ws := server.NewWsConnCounter()
 
 	workers.Set("w1", server.ActiveWorker{AppID: "app-1"})
 	workers.Set("w2", server.ActiveWorker{AppID: "app-1"})
 
-	// w1 has 3 sessions, w2 has 1 session
-	sessions.Set("s1", session.Entry{WorkerID: "w1"})
-	sessions.Set("s2", session.Entry{WorkerID: "w1"})
-	sessions.Set("s3", session.Entry{WorkerID: "w1"})
-	sessions.Set("s4", session.Entry{WorkerID: "w2"})
+	// w1 has 3 ws, w2 has 1 ws
+	for i := 0; i < 3; i++ {
+		ws.TryInc("w1", 100)
+	}
+	ws.TryInc("w2", 100)
 
-	wid, err := lb.Assign("app-1", workers, sessions, 5, nil)
+	wid, err := lb.Assign("app-1", workers, ws, 5, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -64,14 +63,14 @@ func TestAssignLeastLoaded(t *testing.T) {
 func TestAssignNoCapacityCanScale(t *testing.T) {
 	lb := LoadBalancer{}
 	workers := server.NewMemoryWorkerMap()
-	sessions := session.NewMemoryStore()
+	ws := server.NewWsConnCounter()
 
 	workers.Set("w1", server.ActiveWorker{AppID: "app-1"})
-	sessions.Set("s1", session.Entry{WorkerID: "w1"})
-	sessions.Set("s2", session.Entry{WorkerID: "w1"})
+	ws.TryInc("w1", 100)
+	ws.TryInc("w1", 100)
 
 	// max_sessions_per_worker = 2, worker is full, max_workers_per_app = nil (unlimited)
-	wid, err := lb.Assign("app-1", workers, sessions, 2, nil)
+	wid, err := lb.Assign("app-1", workers, ws, 2, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -83,14 +82,14 @@ func TestAssignNoCapacityCanScale(t *testing.T) {
 func TestAssignNoCapacityCanScaleWithLimit(t *testing.T) {
 	lb := LoadBalancer{}
 	workers := server.NewMemoryWorkerMap()
-	sessions := session.NewMemoryStore()
+	ws := server.NewWsConnCounter()
 
 	workers.Set("w1", server.ActiveWorker{AppID: "app-1"})
-	sessions.Set("s1", session.Entry{WorkerID: "w1"})
+	ws.TryInc("w1", 100)
 
 	maxWorkers := 3
 	// max_sessions = 1 (full), but max_workers = 3 (can scale)
-	wid, err := lb.Assign("app-1", workers, sessions, 1, &maxWorkers)
+	wid, err := lb.Assign("app-1", workers, ws, 1, &maxWorkers)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -102,16 +101,16 @@ func TestAssignNoCapacityCanScaleWithLimit(t *testing.T) {
 func TestAssignCapacityExhausted(t *testing.T) {
 	lb := LoadBalancer{}
 	workers := server.NewMemoryWorkerMap()
-	sessions := session.NewMemoryStore()
+	ws := server.NewWsConnCounter()
 
 	workers.Set("w1", server.ActiveWorker{AppID: "app-1"})
 	workers.Set("w2", server.ActiveWorker{AppID: "app-1"})
-	sessions.Set("s1", session.Entry{WorkerID: "w1"})
-	sessions.Set("s2", session.Entry{WorkerID: "w2"})
+	ws.TryInc("w1", 100)
+	ws.TryInc("w2", 100)
 
 	maxWorkers := 2
 	// Both workers full (max_sessions = 1), at max_workers limit
-	wid, err := lb.Assign("app-1", workers, sessions, 1, &maxWorkers)
+	wid, err := lb.Assign("app-1", workers, ws, 1, &maxWorkers)
 	if err != errCapacityExhausted {
 		t.Fatalf("expected errCapacityExhausted, got %v", err)
 	}
@@ -123,13 +122,13 @@ func TestAssignCapacityExhausted(t *testing.T) {
 func TestAssignIgnoresOtherApps(t *testing.T) {
 	lb := LoadBalancer{}
 	workers := server.NewMemoryWorkerMap()
-	sessions := session.NewMemoryStore()
+	ws := server.NewWsConnCounter()
 
 	workers.Set("w1", server.ActiveWorker{AppID: "app-1"})
 	workers.Set("w2", server.ActiveWorker{AppID: "app-2"})
 
 	// app-2's worker should not be considered for app-1
-	wid, err := lb.Assign("app-1", workers, sessions, 5, nil)
+	wid, err := lb.Assign("app-1", workers, ws, 5, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -141,16 +140,16 @@ func TestAssignIgnoresOtherApps(t *testing.T) {
 func TestAssignWorkerAtExactCapacity(t *testing.T) {
 	lb := LoadBalancer{}
 	workers := server.NewMemoryWorkerMap()
-	sessions := session.NewMemoryStore()
+	ws := server.NewWsConnCounter()
 
 	workers.Set("w1", server.ActiveWorker{AppID: "app-1"})
-	sessions.Set("s1", session.Entry{WorkerID: "w1"})
-	sessions.Set("s2", session.Entry{WorkerID: "w1"})
-	sessions.Set("s3", session.Entry{WorkerID: "w1"})
+	for i := 0; i < 3; i++ {
+		ws.TryInc("w1", 100)
+	}
 
 	// Worker has exactly max sessions
 	maxWorkers := 1
-	wid, err := lb.Assign("app-1", workers, sessions, 3, &maxWorkers)
+	wid, err := lb.Assign("app-1", workers, ws, 3, &maxWorkers)
 	if err != errCapacityExhausted {
 		t.Fatalf("expected errCapacityExhausted, got err=%v, wid=%q", err, wid)
 	}

--- a/internal/proxy/metrics_integration_test.go
+++ b/internal/proxy/metrics_integration_test.go
@@ -138,16 +138,18 @@ func TestMetricsColdStartSpawn(t *testing.T) {
 	}
 }
 
-// TestMetricsSessionActive verifies that new proxy sessions increment
-// sessions_active and that eviction via ops.EvictWorker decrements it
-// along with incrementing workers_stopped_total.
+// TestMetricsSessionActive verifies that active WebSocket connections
+// drive sessions_active up, and that closing them brings it back down.
+// Sessions are now per-WebSocket, so HTTP requests alone don't move
+// the gauge — opening a WS does.
 func TestMetricsSessionActive(t *testing.T) {
 	srv, ts := testProxyServer(t)
+	srv.Backend.(*mock.MockBackend).SetWSHandler(wsEchoHandler())
 	createAndStartApp(t, ts, "sess-metrics")
 
 	beforeSessions := gaugeValue(srv.Metrics.SessionsActive)
 
-	// First request creates a new session
+	// Plain HTTP request does NOT create a session record for capacity.
 	resp, err := http.Get(ts.URL + "/app/sess-metrics/")
 	if err != nil {
 		t.Fatal(err)
@@ -155,27 +157,48 @@ func TestMetricsSessionActive(t *testing.T) {
 	if resp.StatusCode != 200 {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
-
-	afterSessions := gaugeValue(srv.Metrics.SessionsActive)
-	if delta := afterSessions - beforeSessions; delta != 1 {
-		t.Errorf("expected sessions_active +1 after new session, got %v", delta)
+	if delta := gaugeValue(srv.Metrics.SessionsActive) - beforeSessions; delta != 0 {
+		t.Errorf("expected sessions_active unchanged after HTTP-only request, got %v", delta)
 	}
 
-	// Second request without cookie creates another session
-	_, err = http.Get(ts.URL + "/app/sess-metrics/")
+	// Open a WebSocket — this is what counts as a session.
+	ctx := context.Background()
+	wsURL := strings.Replace(ts.URL, "http://", "ws://", 1) + "/app/sess-metrics/"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	afterSessions2 := gaugeValue(srv.Metrics.SessionsActive)
-	if delta := afterSessions2 - beforeSessions; delta != 2 {
-		t.Errorf("expected sessions_active +2 after two new sessions, got %v", delta)
+
+	// Allow the shuttle goroutine to Inc before we sample.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if gaugeValue(srv.Metrics.SessionsActive)-beforeSessions >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if delta := gaugeValue(srv.Metrics.SessionsActive) - beforeSessions; delta != 1 {
+		t.Errorf("expected sessions_active +1 after WS open, got %v", delta)
 	}
 
-	// Evict the worker directly — sessions_active should drop
-	beforeEvict := gaugeValue(srv.Metrics.SessionsActive)
+	// Close the client WS — the shuttle exits and decrements.
+	conn.Close(websocket.StatusNormalClosure, "done")
+
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if gaugeValue(srv.Metrics.SessionsActive) <= beforeSessions {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if after := gaugeValue(srv.Metrics.SessionsActive); after > beforeSessions {
+		t.Errorf("expected sessions_active to return to baseline after WS close, before=%v after=%v",
+			beforeSessions, after)
+	}
+
+	// Evict the worker — make sure eviction still increments stopped counter.
 	stoppedGraceful := srv.Metrics.WorkersStopped.WithLabelValues(telemetry.ReasonGraceful)
 	beforeStopped := counterValue(stoppedGraceful)
-
 	workerIDs := srv.Workers.All()
 	if len(workerIDs) == 0 {
 		t.Fatal("expected at least one worker to evict")
@@ -183,13 +206,6 @@ func TestMetricsSessionActive(t *testing.T) {
 	for _, wid := range workerIDs {
 		ops.EvictWorker(context.Background(), srv, wid, telemetry.ReasonGraceful)
 	}
-
-	afterEvict := gaugeValue(srv.Metrics.SessionsActive)
-	if afterEvict >= beforeEvict {
-		t.Errorf("expected sessions_active to decrease after eviction, before=%v after=%v",
-			beforeEvict, afterEvict)
-	}
-
 	afterStopped := counterValue(stoppedGraceful)
 	if delta := afterStopped - beforeStopped; delta < 1 {
 		t.Errorf("expected workers_stopped_total{reason=graceful} +1 after eviction, got %v", delta)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -235,7 +235,6 @@ func Handler(srv *server.Server) http.Handler {
 				UserSub:    callerSub,
 				LastAccess: time.Now(),
 			})
-			srv.Metrics.SessionsActive.Inc()
 
 			// Track session in the database for activity metrics.
 			if err := srv.DB.CreateSession(sessionID, app.ID, workerID, callerSub); err != nil {
@@ -291,7 +290,7 @@ func Handler(srv *server.Server) http.Handler {
 				http.Error(w, "too many WebSocket connections", http.StatusServiceUnavailable)
 				return
 			}
-			shuttleWS(w, r, addr, appName, sessionID, cache, srv)
+			shuttleWS(w, r, addr, appName, sessionID, workerID, app.MaxSessionsPerWorker, cache, srv)
 		} else {
 			forwardHTTP(w, r, addr, appName, srv.Config.Server.ExternalURL, transport, srv.Config.Proxy.HTTPForwardTimeout.Duration)
 		}

--- a/internal/proxy/ws.go
+++ b/internal/proxy/ws.go
@@ -145,10 +145,28 @@ func (br *backendReader) Close() {
 func shuttleWS(
 	w http.ResponseWriter,
 	r *http.Request,
-	addr, appName, sessionID string,
+	addr, appName, sessionID, workerID string,
+	maxSessionsPerWorker int,
 	cache *WsCache,
 	srv *server.Server,
 ) {
+	// Enforce max_sessions_per_worker at handshake time. A session in
+	// blockyard is one active WebSocket, so this is where the limit is
+	// checked. Reject before Accept so the browser sees a 503 rather
+	// than a successful Upgrade followed by an immediate close.
+	if !srv.WsConns.TryInc(workerID, maxSessionsPerWorker) {
+		slog.Info("ws rejected: worker at session capacity", //nolint:gosec // G706: slog structured logging handles this
+			"app", appName, "worker_id", workerID,
+			"max_sessions_per_worker", maxSessionsPerWorker)
+		http.Error(w, "app at capacity", http.StatusServiceUnavailable)
+		return
+	}
+	srv.Metrics.SessionsActive.Inc()
+	defer func() {
+		srv.WsConns.Dec(workerID)
+		srv.Metrics.SessionsActive.Dec()
+	}()
+
 	// Accept client WebSocket. Origin is restricted to the configured
 	// external_url host. Auth is enforced at the session/cookie layer.
 	clientConn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
@@ -333,10 +351,10 @@ done:
 					return
 				}
 				srv.Sessions.Delete(sessionID)
-				// If no other sessions reference this worker, mark idle.
+				// If no active WebSocket remains on this worker, mark idle.
 				// The idle worker reaper will evict it after idle_worker_timeout
 				// if no new sessions arrive (and it's not the last worker for the app).
-				if srv.Sessions.CountForWorker(entry.WorkerID) == 0 {
+				if srv.WsConns.Count(entry.WorkerID) == 0 {
 					srv.Workers.SetIdleSince(entry.WorkerID, time.Now())
 				}
 			})

--- a/internal/proxy/ws_idle_test.go
+++ b/internal/proxy/ws_idle_test.go
@@ -57,7 +57,7 @@ func TestWSIdleTimeout(t *testing.T) {
 
 	cache := NewWsCache()
 	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		shuttleWS(w, r, backend.Listener.Addr().String(), "test-app", sessionID, cache, srv)
+		shuttleWS(w, r, backend.Listener.Addr().String(), "test-app", sessionID, "w1", 100, cache, srv)
 	}))
 	t.Cleanup(proxy.Close)
 
@@ -90,7 +90,7 @@ func TestWSIdleTimeoutResetOnMessage(t *testing.T) {
 
 	cache := NewWsCache()
 	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		shuttleWS(w, r, backend.Listener.Addr().String(), "test-app", sessionID, cache, srv)
+		shuttleWS(w, r, backend.Listener.Addr().String(), "test-app", sessionID, "w1", 100, cache, srv)
 	}))
 	t.Cleanup(proxy.Close)
 
@@ -135,7 +135,7 @@ func TestWSIdleTimeoutDisabled(t *testing.T) {
 
 	cache := NewWsCache()
 	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		shuttleWS(w, r, backend.Listener.Addr().String(), "test-app", sessionID, cache, srv)
+		shuttleWS(w, r, backend.Listener.Addr().String(), "test-app", sessionID, "w1", 100, cache, srv)
 	}))
 	t.Cleanup(proxy.Close)
 
@@ -181,7 +181,7 @@ func TestWSTouchDuringMessages(t *testing.T) {
 
 	cache := NewWsCache()
 	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		shuttleWS(w, r, backend.Listener.Addr().String(), "test-app", sessionID, cache, srv)
+		shuttleWS(w, r, backend.Listener.Addr().String(), "test-app", sessionID, "w1", 100, cache, srv)
 	}))
 	t.Cleanup(proxy.Close)
 

--- a/internal/server/state.go
+++ b/internal/server/state.go
@@ -36,6 +36,7 @@ type Server struct {
 	DB       *db.DB
 	Workers  WorkerMap
 	Sessions session.Store
+	WsConns  *WsConnCounter
 	Registry registry.WorkerRegistry
 	Tasks    *task.Store
 	LogStore *logstore.Store
@@ -230,6 +231,7 @@ func NewServer(cfg *config.Config, be backend.Backend, database *db.DB) *Server 
 		DB:       database,
 		Workers:  NewMemoryWorkerMap(),
 		Sessions: session.NewMemoryStore(),
+		WsConns:  NewWsConnCounter(),
 		Registry: registry.NewMemoryRegistry(),
 		Tasks:    task.NewStore(),
 		LogStore: logstore.NewStore(),

--- a/internal/server/wsconns.go
+++ b/internal/server/wsconns.go
@@ -1,0 +1,72 @@
+package server
+
+import "sync"
+
+// WsConnCounter tracks active WebSocket connections per worker.
+//
+// Used to enforce max_sessions_per_worker at WebSocket handshake time
+// and to inform load-balancer assignment and idle detection. A session
+// in blockyard is one active Shiny WebSocket — one browser tab —
+// not one browser cookie, so this counter is what "max sessions" gates
+// against. The session.Store continues to track cookie-level worker
+// pinning for HTTP routing stickiness; it does not gate capacity.
+type WsConnCounter struct {
+	mu     sync.Mutex
+	counts map[string]int
+}
+
+func NewWsConnCounter() *WsConnCounter {
+	return &WsConnCounter{counts: make(map[string]int)}
+}
+
+// TryInc atomically increments the count for workerID if it is strictly
+// below max. Returns true on success, false if the worker is already at
+// capacity. A single mutex-protected check-and-increment avoids the race
+// where two concurrent handshakes both observe count < max.
+func (c *WsConnCounter) TryInc(workerID string, max int) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.counts[workerID] >= max {
+		return false
+	}
+	c.counts[workerID]++
+	return true
+}
+
+// Dec decrements the count for workerID. Idempotent at zero.
+func (c *WsConnCounter) Dec(workerID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.counts[workerID] > 0 {
+		c.counts[workerID]--
+	}
+	if c.counts[workerID] == 0 {
+		delete(c.counts, workerID)
+	}
+}
+
+// Count returns the current active WS count for workerID.
+func (c *WsConnCounter) Count(workerID string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.counts[workerID]
+}
+
+// CountForWorkers sums active WS counts across the given worker IDs.
+func (c *WsConnCounter) CountForWorkers(ids []string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for _, id := range ids {
+		n += c.counts[id]
+	}
+	return n
+}
+
+// DeleteWorker drops the entry for workerID. Called on eviction so
+// stale counts don't linger against a vanished worker.
+func (c *WsConnCounter) DeleteWorker(workerID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.counts, workerID)
+}

--- a/internal/server/wsconns_test.go
+++ b/internal/server/wsconns_test.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestWsConnCounterTryInc(t *testing.T) {
+	c := NewWsConnCounter()
+
+	if ok := c.TryInc("w1", 2); !ok {
+		t.Error("TryInc 1/2 should succeed")
+	}
+	if ok := c.TryInc("w1", 2); !ok {
+		t.Error("TryInc 2/2 should succeed")
+	}
+	if ok := c.TryInc("w1", 2); ok {
+		t.Error("TryInc 3/2 should fail (over capacity)")
+	}
+	if n := c.Count("w1"); n != 2 {
+		t.Errorf("Count = %d, want 2", n)
+	}
+}
+
+func TestWsConnCounterDec(t *testing.T) {
+	c := NewWsConnCounter()
+	c.TryInc("w1", 10)
+	c.TryInc("w1", 10)
+
+	c.Dec("w1")
+	if n := c.Count("w1"); n != 1 {
+		t.Errorf("Count after first Dec = %d, want 1", n)
+	}
+
+	c.Dec("w1")
+	if n := c.Count("w1"); n != 0 {
+		t.Errorf("Count after second Dec = %d, want 0", n)
+	}
+
+	// Idempotent at zero.
+	c.Dec("w1")
+	if n := c.Count("w1"); n != 0 {
+		t.Errorf("Count after third Dec = %d, want 0", n)
+	}
+}
+
+func TestWsConnCounterCountForWorkers(t *testing.T) {
+	c := NewWsConnCounter()
+	c.TryInc("w1", 10)
+	c.TryInc("w1", 10)
+	c.TryInc("w2", 10)
+	c.TryInc("w3", 10)
+
+	if n := c.CountForWorkers([]string{"w1", "w2"}); n != 3 {
+		t.Errorf("CountForWorkers([w1,w2]) = %d, want 3", n)
+	}
+	if n := c.CountForWorkers([]string{"w3"}); n != 1 {
+		t.Errorf("CountForWorkers([w3]) = %d, want 1", n)
+	}
+	if n := c.CountForWorkers(nil); n != 0 {
+		t.Errorf("CountForWorkers(nil) = %d, want 0", n)
+	}
+	if n := c.CountForWorkers([]string{"absent"}); n != 0 {
+		t.Errorf("CountForWorkers([absent]) = %d, want 0", n)
+	}
+}
+
+func TestWsConnCounterDeleteWorker(t *testing.T) {
+	c := NewWsConnCounter()
+	c.TryInc("w1", 10)
+	c.TryInc("w1", 10)
+	c.DeleteWorker("w1")
+	if n := c.Count("w1"); n != 0 {
+		t.Errorf("Count after DeleteWorker = %d, want 0", n)
+	}
+}
+
+// TestWsConnCounterConcurrentTryInc checks that concurrent TryInc
+// calls never exceed the configured maximum — the atomic
+// check-and-increment is what blocks the over-capacity case.
+func TestWsConnCounterConcurrentTryInc(t *testing.T) {
+	c := NewWsConnCounter()
+
+	const max = 5
+	const goroutines = 100
+
+	var wg sync.WaitGroup
+	var successes int64
+	var mu sync.Mutex
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if c.TryInc("w1", max) {
+				mu.Lock()
+				successes++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if successes != max {
+		t.Errorf("concurrent TryInc: got %d successes, want exactly %d", successes, max)
+	}
+	if got := c.Count("w1"); got != max {
+		t.Errorf("final Count = %d, want %d", got, max)
+	}
+}

--- a/internal/ui/sidebar.go
+++ b/internal/ui/sidebar.go
@@ -272,7 +272,7 @@ func (ui *UI) overviewTab(srv *server.Server) http.HandlerFunc {
 
 func (ui *UI) buildOverviewData(srv *server.Server, app *db.AppRow) overviewTabData {
 	workerIDs := srv.Workers.ForApp(app.ID)
-	activeSessionCount := srv.Sessions.CountForWorkers(workerIDs)
+	activeSessionCount := srv.WsConns.CountForWorkers(workerIDs)
 
 	since := time.Now().AddDate(0, 0, -7).UTC()
 	totalViews, _ := srv.DB.CountSessions(app.ID)
@@ -478,7 +478,7 @@ func (ui *UI) logsTab(srv *server.Server) http.HandlerFunc {
 				status = "draining"
 			}
 			startedAt := aw.StartedAt.UTC().Format(time.RFC3339)
-			sessionCount := srv.Sessions.CountForWorker(wid)
+			sessionCount := srv.WsConns.Count(wid)
 			workers = append(workers, logWorkerEntry{
 				ID:           wid,
 				Status:       status,

--- a/internal/ui/templates/tab_settings.html
+++ b/internal/ui/templates/tab_settings.html
@@ -99,6 +99,7 @@
     </div>
     <div class="field-group">
         <label for="max-workers">Max workers</label>
+        <p class="field-description">Upper bound on concurrent worker containers for this app. Leave empty for no per-app cap (still bounded by the server-wide limit).</p>
         <div class="field-row">
             <input type="number" id="max-workers" name="max_workers_per_app"
                    value="{{derefInt .App.MaxWorkersPerApp}}"
@@ -113,6 +114,7 @@
     </div>
     <div class="field-group">
         <label for="max-sessions">Max sessions per worker</label>
+        <p class="field-description">A session is one active browser tab (one Shiny WebSocket). <code>1</code> = isolated worker per tab; higher values = tabs share a worker process. New tabs beyond the limit are rejected with 503.</p>
         <div class="field-row">
             <input type="number" id="max-sessions" name="max_sessions_per_worker"
                    value="{{.App.MaxSessionsPerWorker}}"

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1898,6 +1898,9 @@ func TestOverviewTabWithActiveData(t *testing.T) {
 	srv.Sessions.Set("sess-1", session.Entry{WorkerID: "w-ov-1", UserSub: "owner", LastAccess: time.Now()})
 	srv.Sessions.Set("sess-2", session.Entry{WorkerID: "w-ov-2", UserSub: "owner", LastAccess: time.Now()})
 	srv.Sessions.Set("sess-3", session.Entry{WorkerID: "w-ov-2", UserSub: "other", LastAccess: time.Now()})
+	srv.WsConns.TryInc("w-ov-1", 1<<30)
+	srv.WsConns.TryInc("w-ov-2", 1<<30)
+	srv.WsConns.TryInc("w-ov-2", 1<<30)
 
 	// Seed DB sessions for view counts.
 	srv.DB.CreateSession("db-s1", app.ID, "w-ov-1", "owner")


### PR DESCRIPTION
## Summary
- Reframe "session" as one active Shiny WebSocket (one tab), not a browser cookie. `max_sessions_per_worker` now gates tabs, so a second tab in the same browser actually hits the limit instead of silently sharing the worker.
- Add `server.WsConnCounter` (atomic TryInc/Dec with compare-and-swap) and switch load balancer, autoscaler, idle detection, drain, and eviction to it.
- `shuttleWS` rejects the upgrade with 503 when the worker is at capacity and Inc/Dec's the counter for the lifetime of the connection; `sessions_active` follows the same lifecycle.
- Add regression test (`TestSecondWebSocketRejectedAtCapacity`) covering `max_workers_per_app=1` + `max_sessions_per_worker=1`, and unit tests for the counter including a concurrent-TryInc stress case.
- Clarify the settings UI help text for "Max workers" and "Max sessions per worker".

Fixes #268