### PR TITLE
test(misc): extend websocket dial retry window for httpuv race

### DIFF
--- a/tests/examples/helpers_test.go
+++ b/tests/examples/helpers_test.go
@@ -493,12 +493,21 @@ func dialAppWebSocket(t *testing.T, client *http.Client, baseURL, appName string
 		cookieStrs = append(cookieStrs, c.Name+"="+c.Value)
 	}
 
-	// Retry on transient errors (EOF, connection reset) common on CI.
+	// httpuv wires the WebSocket upgrade handler shortly after Shiny's
+	// TCP listener comes up, so an early attempt can get 101 from the
+	// proxy but EOF from the backend. Retry with exponential backoff
+	// over ~15s to absorb that window on contended CI runners.
 	var lastErr error
-	for attempt := 0; attempt < 3; attempt++ {
+	sleep := 500 * time.Millisecond
+	const maxSleep = 2 * time.Second
+	const maxAttempts = 10
+	for attempt := 0; attempt < maxAttempts; attempt++ {
 		if attempt > 0 {
 			t.Logf("websocket dial: retrying (attempt %d) after: %v", attempt+1, lastErr)
-			time.Sleep(2 * time.Second)
+			time.Sleep(sleep)
+			if sleep < maxSleep {
+				sleep = min(sleep*2, maxSleep)
+			}
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)


### PR DESCRIPTION
## Summary
- Bump `dialAppWebSocket` to 10 attempts with exponential backoff (~15s total) in place of 3 attempts at a fixed 2s interval.
- Absorbs the race where `httpuv` wires the WebSocket upgrade handler shortly after Shiny's TCP listener comes up: proxy returns 101 but backend EOFs before the handshake completes.
- Scope limited to the test helper; the backend readiness probe is unchanged since blockyard also runs non-Shiny workers where a WS-upgrade probe would be inappropriate.

Fixes #277