### PR TITLE
fix(misc): use pak::scan_deps() for bare-script dependency discovery

### DIFF
--- a/internal/backend/docker/pak_integration_test.go
+++ b/internal/backend/docker/pak_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cynkra/blockyard/internal/bundle"
 	"github.com/cynkra/blockyard/internal/config"
 	"github.com/cynkra/blockyard/internal/db"
+	"github.com/cynkra/blockyard/internal/pakcache"
 	"github.com/cynkra/blockyard/internal/task"
 	"github.com/cynkra/blockyard/internal/testutil"
 )
@@ -82,6 +83,73 @@ func TestBuildE2E_PakBuild(t *testing.T) {
 	}
 	if !result.Success {
 		t.Fatalf("build failed with exit code %d\n--- build logs ---\n%s", result.ExitCode, result.Logs)
+	}
+}
+
+// TestBuildE2E_ScanDeps exercises pak::scan_deps() in the same R library
+// setup the bare-script build path uses. Regression test for #266 — calling
+// pkgdepends::scan_deps() directly via :: fails because pak loads its bundled
+// pkgdepends only inside subprocesses, so the build script must go through
+// pak's exported wrapper.
+func TestBuildE2E_ScanDeps(t *testing.T) {
+	image := testutil.TOMLDockerImage(t)
+
+	ctx := context.Background()
+	b, err := New(ctx, pakTestConfig(t), t.TempDir(), "test")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	bundleDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bundleDir, "app.R"),
+		[]byte("library(mime)\n"), 0o644); err != nil {
+		t.Fatalf("write app.R: %v", err)
+	}
+
+	pakCachePath := t.TempDir()
+	pakPath, err := pakcache.EnsureInstalled(ctx, b, image, "stable", pakCachePath)
+	if err != nil {
+		t.Fatalf("EnsureInstalled: %v", err)
+	}
+
+	// Mirrors the .libPaths() setup used by restore.go and preprocess.go.
+	// If someone changes the call from pak::scan_deps() back to
+	// pkgdepends::scan_deps(), this test fails with the #266 error.
+	rScript := `
+.libPaths(c("/pak", .libPaths()))
+library(pak)
+pak_lib <- system.file("library", package = "pak")
+if (nzchar(pak_lib) && dir.exists(pak_lib)) {
+  .libPaths(c(pak_lib, .libPaths()))
+}
+deps <- pak::scan_deps(path = "/app", root = "/app")
+pkgs <- unique(deps$package[deps$type == "prod"])
+if (!"mime" %in% pkgs) stop("mime not detected: ", paste(pkgs, collapse = ","))
+cat("OK:", pkgs, "\n")
+`
+
+	spec := backend.BuildSpec{
+		AppID:    "scan-deps-test",
+		BundleID: uuid.New().String()[:8],
+		Image:    image,
+		Cmd:      []string{"Rscript", "--vanilla", "-e", rScript},
+		Mounts: []backend.MountEntry{
+			{Source: bundleDir, Target: "/app", ReadOnly: true},
+			{Source: pakPath, Target: "/pak", ReadOnly: true},
+		},
+		Labels: map[string]string{},
+	}
+
+	result, err := b.Build(ctx, spec)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("scan_deps failed with exit code %d\n--- logs ---\n%s",
+			result.ExitCode, result.Logs)
+	}
+	if !strings.Contains(result.Logs, "OK: mime") {
+		t.Fatalf("expected 'OK: mime' in logs; got:\n%s", result.Logs)
 	}
 }
 

--- a/internal/backend/docker/pak_integration_test.go
+++ b/internal/backend/docker/pak_integration_test.go
@@ -105,6 +105,7 @@ func TestBuildE2E_ScanDeps(t *testing.T) {
 		[]byte("library(mime)\n"), 0o644); err != nil {
 		t.Fatalf("write app.R: %v", err)
 	}
+	cacheDir := t.TempDir()
 
 	pakCachePath := t.TempDir()
 	pakPath, err := pakcache.EnsureInstalled(ctx, b, image, "stable", pakCachePath)
@@ -112,10 +113,12 @@ func TestBuildE2E_ScanDeps(t *testing.T) {
 		t.Fatalf("EnsureInstalled: %v", err)
 	}
 
-	// Mirrors the .libPaths() setup used by restore.go and preprocess.go.
-	// If someone changes the call from pak::scan_deps() back to
-	// pkgdepends::scan_deps(), this test fails with the #266 error.
+	// Mirrors the .libPaths() + R_USER_CACHE_DIR setup used by
+	// restore.go and preprocess.go. If someone changes the call from
+	// pak::scan_deps() back to pkgdepends::scan_deps(), this test fails
+	// with the #266 error ("not an exported object from namespace:pkgdepends").
 	rScript := `
+Sys.setenv(R_USER_CACHE_DIR = "/cache")
 .libPaths(c("/pak", .libPaths()))
 library(pak)
 pak_lib <- system.file("library", package = "pak")
@@ -136,6 +139,7 @@ cat("OK:", pkgs, "\n")
 		Mounts: []backend.MountEntry{
 			{Source: bundleDir, Target: "/app", ReadOnly: true},
 			{Source: pakPath, Target: "/pak", ReadOnly: true},
+			{Source: cacheDir, Target: "/cache", ReadOnly: false},
 		},
 		Labels: map[string]string{},
 	}

--- a/internal/bundle/preprocess.go
+++ b/internal/bundle/preprocess.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cynkra/blockyard/internal/backend"
 )
 
-// preProcess runs pkgdepends::scan_deps() in a container to discover
+// preProcess runs pak::scan_deps() in a container to discover
 // dependencies from bare scripts and generates a synthetic DESCRIPTION.
 func preProcess(ctx context.Context, be backend.Backend,
 	pakPath string, p RestoreParams) error {
@@ -25,12 +25,12 @@ func preProcess(ctx context.Context, be backend.Backend,
 		Sys.setenv(R_USER_CACHE_DIR = "/output")
 		.libPaths(c("/pak", .libPaths()))
 		library(pak)
-		# Make pak's bundled dependencies (pkgdepends, desc) available.
+		# Make pak's bundled dependencies (desc) available.
 		pak_lib <- system.file("library", package = "pak")
 		if (nzchar(pak_lib) && dir.exists(pak_lib)) {
 		  .libPaths(c(pak_lib, .libPaths()))
 		}
-		deps <- pkgdepends::scan_deps("/app")
+		deps <- pak::scan_deps("/app")
 		pkgs <- unique(deps$package[deps$type == "prod"])
 		dsc <- desc::desc("!new")
 		dsc$set(Package = "app", Version = "0.0.1")

--- a/internal/bundle/restore.go
+++ b/internal/bundle/restore.go
@@ -192,7 +192,7 @@ func runRestore(p RestoreParams) error {
 	// 4. Handle manifest / bare scripts.
 	if p.Store != nil {
 		// Store-aware: bare scripts handled directly by R build script
-		// (scan_deps). Manifest written if generated server-side.
+		// (pak::scan_deps). Manifest written if generated server-side.
 		if m != nil {
 			manifestPath := filepath.Join(p.Paths.Unpacked, "manifest.json")
 			if !fileExists(manifestPath) {
@@ -474,7 +474,7 @@ if (!is.null(manifest) && !is.null(manifest$packages)) {
 } else {
   # Bare scripts: scan for library()/require()/:: calls directly.
   message("No manifest or DESCRIPTION found -- scanning scripts")
-  deps <- pkgdepends::scan_deps(path = "/app", root = "/app")
+  deps <- pak::scan_deps(path = "/app", root = "/app")
   refs <- unique(deps$package[deps$type == "prod"])
   if (length(refs) == 0) stop("No package dependencies found in scripts")
 }


### PR DESCRIPTION
## Summary
- `pkgdepends::scan_deps()` fails with `not an exported object` when called via `::` inside the build container — pak loads its bundled pkgdepends only in subprocesses, so direct namespace access hits the wrong copy (or none at all).
- Switch both call sites (`restore.go` build script, legacy `preprocess.go`) to `pak::scan_deps()`, which has been exported since pak 0.9.0 and wraps pkgdepends via the subprocess mechanism.
- Add `TestBuildE2E_ScanDeps` regression test that exercises the same `.libPaths()` + `R_USER_CACHE_DIR` setup the build script uses — reverting to `pkgdepends::scan_deps()` would fail this test.

Fixes #266