### PR TITLE
feat(telemetry): pass env and W3C trace context into worker apps

### DIFF
--- a/blockyard.toml
+++ b/blockyard.toml
@@ -7,6 +7,7 @@ shutdown_timeout = "30s"
 # management_bind = "127.0.0.1:9100"  # separate listener for /healthz, /readyz, /metrics
 # log_level      = "info"             # trace, debug, info, warn, error
 # trusted_proxies = ["10.0.0.0/8", "172.16.0.0/12"]  # CIDRs whose X-Forwarded-For to trust for rate limiting
+# worker_env = { OTEL_EXPORTER_OTLP_ENDPOINT = "http://alloy:4317" }  # env vars injected into every worker
 
 [docker]
 socket     = "/var/run/docker.sock"

--- a/docs/content/docs/guides/observability.md
+++ b/docs/content/docs/guides/observability.md
@@ -134,16 +134,60 @@ the management listener, no authentication is required.
 
 ## OpenTelemetry tracing
 
+This section covers tracing of **blockyard itself** — the HTTP handlers,
+proxy, and API. Tracing for hosted Shiny apps is an app-level concern,
+covered under [Tracing hosted Shiny apps](#tracing-hosted-shiny-apps).
+
 Send distributed traces to an OpenTelemetry collector:
 
 ```toml
 [telemetry]
-otlp_endpoint = "http://otel-collector:4317"
+otlp_endpoint = "otel-collector:4317"
 ```
 
 The service name is `blockyard`. Spans include `http.method`, `http.route`,
-and `http.status_code` attributes. Endpoints using `http://`, `localhost`,
-or `127.0.0.1` connect without TLS; all others use TLS.
+and `http.status_code` attributes.
+
+The exporter speaks **OTLP/gRPC only** (default collector port `4317`);
+OTLP/HTTP (port `4318`) is not supported. Transport security is picked
+automatically from the endpoint string: plaintext for `http://`,
+`localhost`, or `127.0.0.1`, TLS for everything else. The endpoint
+itself can point anywhere reachable from the blockyard process — for
+example `host.docker.internal:4317` when blockyard runs in a container
+and the collector runs on the host.
+
+### Tracing hosted Shiny apps
+
+Blockyard forwards W3C `traceparent` into each worker — on HTTP
+requests and on the initial WebSocket upgrade. If a hosted Shiny app
+is instrumented with [`{otel}` / `{otelsdk}`](https://shiny.posit.co/r/articles/improve/opentelemetry/),
+its spans attach to the blockyard trace automatically, giving a single
+end-to-end view from inbound request to reactive computation.
+
+Point the worker at a collector via `server.worker_env`:
+
+```toml
+[server]
+worker_env = { OTEL_EXPORTER_OTLP_ENDPOINT = "http://alloy:4317" }
+```
+
+Blockyard does not care what sits at that address — an OpenTelemetry
+Collector, Grafana Alloy, or a vendor endpoint all work. Reachability
+is your responsibility: for the Docker backend, the collector must be
+reachable on the worker's network (see `docker.service_network`); for
+the process backend, it must be reachable from `localhost`.
+
+When `OTEL_EXPORTER_OTLP_ENDPOINT` is set in `worker_env`, blockyard
+auto-populates identity attributes so signals from different apps and
+workers are distinguishable in the backend:
+
+| Variable | Value |
+|---|---|
+| `OTEL_SERVICE_NAME` | the app name |
+| `OTEL_RESOURCE_ATTRIBUTES` | `blockyard.app=<name>,blockyard.worker_id=<id>`, merged with any user-supplied attributes |
+
+User-set values in `worker_env` win, so you can override either for a
+specific deployment.
 
 ## Security headers
 

--- a/docs/content/docs/reference/config.md
+++ b/docs/content/docs/reference/config.md
@@ -57,6 +57,7 @@ shutdown_timeout = "30s"
 | `external_url` | `string` | — | No | Public-facing URL of the server (used for OIDC redirect URIs) |
 | `trusted_proxies` | `string[]` | — | No | CIDRs whose `X-Forwarded-For` headers to trust (e.g. `["10.0.0.0/8"]`). Each entry must be a valid CIDR. Set via env as comma-separated: `BLOCKYARD_SERVER_TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12`. |
 | `bootstrap_token` | `string` | — | No | One-time token that can be exchanged for a real PAT via `POST /api/v1/bootstrap`. Requires `oidc.initial_admin` to be set. Intended for dev/CI bootstrapping — do not use in production. See [Bootstrap tokens](/docs/reference/api/#post-apiv1bootstrap). |
+| `worker_env` | `map[string]string` | — | No | Extra environment variables injected into every worker. Common use: point workers at an OTLP collector (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`) for hosted-app tracing. Blockyard-managed keys (`BLOCKYARD_API_URL`, `SHINY_HOST`, `VAULT_ADDR`, …) cannot be overridden. See [Tracing hosted Shiny apps](/docs/guides/observability/#tracing-hosted-shiny-apps). |
 
 > [!NOTE]
 > `server.skip_docker_preflight` is deprecated and has been renamed to

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,6 +96,7 @@ type ServerConfig struct {
 	DefaultMemoryLimit   string   `toml:"default_memory_limit"`   // fallback memory limit for workers (e.g. "2g")
 	DefaultCPULimit      float64  `toml:"default_cpu_limit"`      // fallback CPU limit for workers (fractional vCPUs)
 	BootstrapToken       string   `toml:"bootstrap_token"`        // dev only: one-time token exchanged for a real PAT via POST /api/v1/bootstrap
+	WorkerEnv            map[string]string `toml:"worker_env"`  // extra env vars injected into every worker (e.g. OTEL_EXPORTER_OTLP_ENDPOINT)
 
 	// Deprecated; copied into SkipPreflight by migrateDeprecatedFields and
 	// removed in the next release.

--- a/internal/proxy/coldstart.go
+++ b/internal/proxy/coldstart.go
@@ -180,8 +180,6 @@ func spawnWorker(ctx context.Context, srv *server.Server, app *db.AppRow) (strin
 		"dev.blockyard/role":      "worker",
 	}
 
-	extraEnv := server.WorkerEnv(srv)
-
 	// Assemble per-worker library from the package store.
 	var libDir string
 	if srv.PkgStore != nil {
@@ -254,7 +252,6 @@ func spawnWorker(ctx context.Context, srv *server.Server, app *db.AppRow) (strin
 	spec.MemoryLimit = ptrOr(app.MemoryLimit, "")
 	spec.CPULimit = ptrOr(app.CPULimit, 0.0)
 	spec.Labels = labels
-	spec.Env = extraEnv
 
 	// Resolve per-app data mounts.
 	appMounts, err := srv.DB.ListAppDataMounts(app.ID)

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -9,6 +9,9 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 // forwardHTTP proxies an HTTP request to the worker at addr. The
@@ -50,6 +53,9 @@ func forwardHTTP(w http.ResponseWriter, r *http.Request, addr, appName, external
 				proto = "https"
 			}
 			pr.Out.Header.Set("X-Forwarded-Proto", proto)
+
+			otel.GetTextMapPropagator().Inject(pr.Out.Context(),
+				propagation.HeaderCarrier(pr.Out.Header))
 		},
 		Transport: transport,
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -1,0 +1,55 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// TestForwardHTTPInjectsTraceparent verifies that forwardHTTP injects
+// W3C trace context into upstream requests so instrumented Shiny apps
+// can continue blockyard's trace.
+func TestForwardHTTPInjectsTraceparent(t *testing.T) {
+	// Install the W3C propagator and a real tracer provider so spans
+	// have a valid trace/span ID to inject.
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+	tp := sdktrace.NewTracerProvider()
+	defer tp.Shutdown(context.Background())
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	defer otel.SetTracerProvider(prev)
+
+	var gotTraceparent string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTraceparent = r.Header.Get("Traceparent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	addr := strings.TrimPrefix(backend.URL, "http://")
+
+	ctx, span := tp.Tracer("test").Start(context.Background(), "parent")
+	defer span.End()
+	req := httptest.NewRequest("GET", "/app/myapp/", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	forwardHTTP(rec, req, addr, "myapp", "", http.DefaultTransport, 5*time.Second)
+
+	if gotTraceparent == "" {
+		t.Fatal("backend did not receive a Traceparent header")
+	}
+	// A valid W3C traceparent starts with version "00-".
+	if !strings.HasPrefix(gotTraceparent, "00-") {
+		t.Errorf("unexpected traceparent format: %q", gotTraceparent)
+	}
+}

--- a/internal/proxy/ws.go
+++ b/internal/proxy/ws.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 
 	"github.com/cynkra/blockyard/internal/config"
 	"github.com/cynkra/blockyard/internal/server"
@@ -194,8 +196,13 @@ func shuttleWS(
 		backendURL := "ws://" + addr + backendPath
 		dialCtx, dialCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer dialCancel()
+		dialHeaders := forwardClientHeaders(r)
+		// Trace context rides only on the initial upgrade; individual WS
+		// frames are not traced.
+		otel.GetTextMapPropagator().Inject(r.Context(),
+			propagation.HeaderCarrier(dialHeaders))
 		backendConn, _, dialErr := websocket.Dial(dialCtx, backendURL, &websocket.DialOptions{
-			HTTPHeader: forwardClientHeaders(r),
+			HTTPHeader: dialHeaders,
 		})
 		if dialErr != nil {
 			slog.Warn("ws backend dial failed", //nolint:gosec // G706: slog structured logging handles this

--- a/internal/server/state_test.go
+++ b/internal/server/state_test.go
@@ -584,6 +584,96 @@ func TestWorkerEnv_ShinyHostDefault(t *testing.T) {
 	}
 }
 
+func TestWorkerEnv_UserWorkerEnvPassthrough(t *testing.T) {
+	srv := &Server{
+		Config: &config.Config{
+			Server: config.ServerConfig{
+				Bind: ":8080",
+				WorkerEnv: map[string]string{
+					"OTEL_EXPORTER_OTLP_ENDPOINT": "http://alloy:4317",
+					"TEAM":                        "data",
+				},
+			},
+		},
+	}
+	env := WorkerEnv(srv)
+	if env["OTEL_EXPORTER_OTLP_ENDPOINT"] != "http://alloy:4317" {
+		t.Errorf("OTEL_EXPORTER_OTLP_ENDPOINT = %q", env["OTEL_EXPORTER_OTLP_ENDPOINT"])
+	}
+	if env["TEAM"] != "data" {
+		t.Errorf("TEAM = %q", env["TEAM"])
+	}
+}
+
+func TestWorkerEnv_BlockyardKeysWinOverWorkerEnv(t *testing.T) {
+	srv := &Server{
+		Config: &config.Config{
+			Server: config.ServerConfig{
+				Bind: ":8080",
+				WorkerEnv: map[string]string{
+					"BLOCKYARD_API_URL": "http://evil",
+					"SHINY_HOST":        "1.2.3.4",
+				},
+			},
+		},
+	}
+	env := WorkerEnv(srv)
+	if env["BLOCKYARD_API_URL"] == "http://evil" {
+		t.Error("user worker_env must not override BLOCKYARD_API_URL")
+	}
+	if env["SHINY_HOST"] == "1.2.3.4" {
+		t.Error("user worker_env must not override SHINY_HOST")
+	}
+}
+
+func TestInjectOTELIdentity_NoEndpoint(t *testing.T) {
+	env := map[string]string{"FOO": "bar"}
+	injectOTELIdentity(env, "myapp", "w-123")
+	if _, ok := env["OTEL_SERVICE_NAME"]; ok {
+		t.Error("should not inject OTEL_SERVICE_NAME when endpoint is unset")
+	}
+	if _, ok := env["OTEL_RESOURCE_ATTRIBUTES"]; ok {
+		t.Error("should not inject OTEL_RESOURCE_ATTRIBUTES when endpoint is unset")
+	}
+}
+
+func TestInjectOTELIdentity_WithEndpoint(t *testing.T) {
+	env := map[string]string{
+		"OTEL_EXPORTER_OTLP_ENDPOINT": "http://alloy:4317",
+	}
+	injectOTELIdentity(env, "myapp", "w-123")
+	if env["OTEL_SERVICE_NAME"] != "myapp" {
+		t.Errorf("OTEL_SERVICE_NAME = %q, want %q", env["OTEL_SERVICE_NAME"], "myapp")
+	}
+	want := "blockyard.app=myapp,blockyard.worker_id=w-123"
+	if env["OTEL_RESOURCE_ATTRIBUTES"] != want {
+		t.Errorf("OTEL_RESOURCE_ATTRIBUTES = %q, want %q", env["OTEL_RESOURCE_ATTRIBUTES"], want)
+	}
+}
+
+func TestInjectOTELIdentity_MergesUserResourceAttrs(t *testing.T) {
+	env := map[string]string{
+		"OTEL_EXPORTER_OTLP_ENDPOINT": "http://alloy:4317",
+		"OTEL_RESOURCE_ATTRIBUTES":    "team=data,env=prod",
+	}
+	injectOTELIdentity(env, "myapp", "w-123")
+	want := "team=data,env=prod,blockyard.app=myapp,blockyard.worker_id=w-123"
+	if env["OTEL_RESOURCE_ATTRIBUTES"] != want {
+		t.Errorf("OTEL_RESOURCE_ATTRIBUTES = %q, want %q", env["OTEL_RESOURCE_ATTRIBUTES"], want)
+	}
+}
+
+func TestInjectOTELIdentity_UserServiceNameWins(t *testing.T) {
+	env := map[string]string{
+		"OTEL_EXPORTER_OTLP_ENDPOINT": "http://alloy:4317",
+		"OTEL_SERVICE_NAME":           "custom-name",
+	}
+	injectOTELIdentity(env, "myapp", "w-123")
+	if env["OTEL_SERVICE_NAME"] != "custom-name" {
+		t.Errorf("user-set OTEL_SERVICE_NAME overwritten: %q", env["OTEL_SERVICE_NAME"])
+	}
+}
+
 func TestMarkDraining(t *testing.T) {
 	m := NewMemoryWorkerMap()
 	m.Set("w1", ActiveWorker{AppID: "app-a"})

--- a/internal/server/workerenv.go
+++ b/internal/server/workerenv.go
@@ -9,20 +9,24 @@ import (
 	"github.com/cynkra/blockyard/internal/manifest"
 )
 
-// WorkerEnv builds the environment variable map for worker containers.
-// Always sets BLOCKYARD_API_URL (needed for runtime package installs).
-// Includes Vault/OpenBao integration vars when configured.
-// Sets SHINY_HOST per backend so bundles don't have to.
+// WorkerEnv builds the backend-agnostic environment variable map for
+// worker containers. Always sets BLOCKYARD_API_URL (needed for runtime
+// package installs). Includes Vault/OpenBao integration vars when
+// configured. Sets SHINY_HOST per backend so bundles don't have to.
+// Values from server.worker_env are merged in last; blockyard-managed
+// keys win on collision, everything else (e.g. OTEL_*) is passed through.
 func WorkerEnv(srv *Server) map[string]string {
+	env := make(map[string]string)
+	for k, v := range srv.Config.Server.WorkerEnv {
+		env[k] = v
+	}
+
 	shinyHost := "0.0.0.0"
 	if srv.Config.Server.Backend == "process" {
 		shinyHost = "127.0.0.1"
 	}
-
-	env := map[string]string{
-		"BLOCKYARD_API_URL": srv.InternalAPIURL(),
-		"SHINY_HOST":        shinyHost,
-	}
+	env["BLOCKYARD_API_URL"] = srv.InternalAPIURL()
+	env["SHINY_HOST"] = shinyHost
 
 	if srv.Config.Openbao != nil {
 		env["VAULT_ADDR"] = srv.Config.Openbao.Address
@@ -44,6 +48,26 @@ func WorkerEnv(srv *Server) map[string]string {
 	return env
 }
 
+// injectOTELIdentity adds per-app OpenTelemetry identity attributes
+// so signals from different apps/workers are distinguishable in the
+// backend. A no-op unless OTEL_EXPORTER_OTLP_ENDPOINT is already in
+// env. A user-set OTEL_SERVICE_NAME wins; blockyard resource attrs
+// are appended to any user-supplied OTEL_RESOURCE_ATTRIBUTES.
+func injectOTELIdentity(env map[string]string, appName, workerID string) {
+	if env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "" {
+		return
+	}
+	if _, set := env["OTEL_SERVICE_NAME"]; !set {
+		env["OTEL_SERVICE_NAME"] = appName
+	}
+	blockyardAttrs := "blockyard.app=" + appName + ",blockyard.worker_id=" + workerID
+	if existing := env["OTEL_RESOURCE_ATTRIBUTES"]; existing != "" {
+		env["OTEL_RESOURCE_ATTRIBUTES"] = existing + "," + blockyardAttrs
+	} else {
+		env["OTEL_RESOURCE_ATTRIBUTES"] = blockyardAttrs
+	}
+}
+
 // BaseWorkerSpec returns a WorkerSpec with all fields that are common
 // across spawn sites (coldstart, transfer, API scale-up). Callers
 // fill in site-specific fields like LibDir, TransferDir, TokenDir,
@@ -56,6 +80,9 @@ func BaseWorkerSpec(srv *Server, app *db.AppRow, workerID, bundleID string) back
 	if m, err := manifest.Read(filepath.Join(hostPaths.Unpacked, "manifest.json")); err == nil {
 		rVersion = m.RVersion
 	}
+
+	env := WorkerEnv(srv)
+	injectOTELIdentity(env, app.Name, workerID)
 
 	return backend.WorkerSpec{
 		AppID:        app.ID,
@@ -74,7 +101,7 @@ func BaseWorkerSpec(srv *Server, app *db.AppRow, workerID, bundleID string) back
 			"dev.blockyard/worker-id": workerID,
 			"dev.blockyard/role":      "worker",
 		},
-		Env:     WorkerEnv(srv),
+		Env:     env,
 		Runtime: AppRuntime(app, srv.Config.Docker),
 	}
 }

--- a/internal/telemetry/tracing.go
+++ b/internal/telemetry/tracing.go
@@ -13,15 +13,23 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 )
 
-// InitTracing sets up the OpenTelemetry trace provider. Returns a
-// shutdown function that flushes pending spans. If endpoint is empty,
-// tracing is not initialized (no-op provider is used).
+// InitTracing sets up the OpenTelemetry trace provider and installs
+// the W3C trace-context + baggage propagator as the global default.
+// Returns a shutdown function that flushes pending spans. If endpoint
+// is empty, no exporter is installed but the propagator is still set
+// so the proxy can forward inbound trace context to workers.
 func InitTracing(ctx context.Context, endpoint string) (func(context.Context) error, error) {
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
 	if endpoint == "" {
 		return func(context.Context) error { return nil }, nil
 	}

--- a/internal/telemetry/tracing_test.go
+++ b/internal/telemetry/tracing_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/coder/websocket"
 	"github.com/go-chi/chi/v5"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/propagation"
 )
 
 func TestInitTracingEmpty(t *testing.T) {
@@ -67,11 +66,6 @@ func TestInitTracingSetsPropagator(t *testing.T) {
 	}
 	if !sawTraceparent {
 		t.Errorf("expected propagator to handle traceparent, fields=%v", fields)
-	}
-	// Ensure the installed propagator is actually a composite including
-	// the W3C trace-context propagator (not just a no-op).
-	if _, ok := otel.GetTextMapPropagator().(propagation.TextMapPropagator); !ok {
-		t.Error("expected a TextMapPropagator to be installed")
 	}
 }
 

--- a/internal/telemetry/tracing_test.go
+++ b/internal/telemetry/tracing_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/coder/websocket"
 	"github.com/go-chi/chi/v5"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 func TestInitTracingEmpty(t *testing.T) {
@@ -43,6 +45,33 @@ func TestInitTracingWithEndpoint(t *testing.T) {
 	// Shutdown should succeed (flushes empty batch).
 	if err := shutdown(context.Background()); err != nil {
 		t.Fatalf("shutdown error: %v", err)
+	}
+}
+
+func TestInitTracingSetsPropagator(t *testing.T) {
+	// Propagator must be set even with no endpoint, so the proxy can
+	// still forward inbound traceparent to workers in deployments
+	// where blockyard itself is not exporting traces.
+	shutdown, err := InitTracing(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer shutdown(context.Background())
+
+	fields := otel.GetTextMapPropagator().Fields()
+	var sawTraceparent bool
+	for _, f := range fields {
+		if f == "traceparent" {
+			sawTraceparent = true
+		}
+	}
+	if !sawTraceparent {
+		t.Errorf("expected propagator to handle traceparent, fields=%v", fields)
+	}
+	// Ensure the installed propagator is actually a composite including
+	// the W3C trace-context propagator (not just a no-op).
+	if _, ok := otel.GetTextMapPropagator().(propagation.TextMapPropagator); !ok {
+		t.Error("expected a TextMapPropagator to be installed")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `[server].worker_env` for injecting arbitrary env vars into every worker — most common use is pointing an OTLP collector at hosted Shiny apps (`OTEL_EXPORTER_OTLP_ENDPOINT=…`). Blockyard-managed keys still win on collision.
- Auto-populates `OTEL_SERVICE_NAME` (app name) and `OTEL_RESOURCE_ATTRIBUTES` (`blockyard.app=…,blockyard.worker_id=…`) per worker when an OTLP endpoint is set, so per-app signals are distinguishable in the backend.
- Installs the W3C trace-context + baggage propagator globally and forwards `traceparent` on HTTP requests and on the initial WebSocket upgrade, so an instrumented Shiny app can stitch its spans onto the blockyard trace.
- Docs: new "Tracing hosted Shiny apps" section, rewrote the TLS-detection sentence that was being misread as a reachability constraint, and noted explicitly that the exporter speaks OTLP/gRPC only (port 4317, not the 4318 HTTP port).

Fixes #274