### PR TITLE
fix(telemetry): walk Unwrap chain in statusWriter Hijack

### DIFF
--- a/internal/telemetry/tracing.go
+++ b/internal/telemetry/tracing.go
@@ -3,7 +3,6 @@ package telemetry
 import (
 	"bufio"
 	"context"
-	"errors"
 	"log/slog"
 	"net"
 	"net/http"
@@ -106,25 +105,29 @@ func (w *statusWriter) WriteHeader(code int) {
 }
 
 // Hijack forwards to the underlying ResponseWriter so WebSocket
-// upgrades work when this middleware is in the chain. Without this,
-// wrapping ResponseWriter hides the Hijacker interface and upgrades
-// fail.
+// upgrades work when this middleware is in the chain. A direct
+// type assertion is not enough because the request logger wraps
+// with responseCapture, which exposes Unwrap but not Hijack —
+// http.NewResponseController walks the Unwrap chain and finds the
+// net/http Hijacker underneath.
 func (w *statusWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	h, ok := w.ResponseWriter.(http.Hijacker)
-	if !ok {
-		return nil, nil, errors.New("telemetry: underlying ResponseWriter does not implement http.Hijacker")
-	}
 	if !w.wroteHeader {
 		w.status = http.StatusSwitchingProtocols
 		w.wroteHeader = true
 	}
-	return h.Hijack()
+	return http.NewResponseController(w.ResponseWriter).Hijack()
 }
 
 // Flush forwards to the underlying ResponseWriter so streaming
-// responses are not held up by the wrapper.
+// responses are not held up by the wrapper. Same unwrap-walking
+// reasoning as Hijack.
 func (w *statusWriter) Flush() {
-	if f, ok := w.ResponseWriter.(http.Flusher); ok {
-		f.Flush()
-	}
+	_ = http.NewResponseController(w.ResponseWriter).Flush()
+}
+
+// Unwrap exposes the wrapped ResponseWriter so outer callers (e.g.
+// http.NewResponseController, coder/websocket's hijacker walk) can
+// descend past this middleware.
+func (w *statusWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
 }

--- a/internal/telemetry/tracing_test.go
+++ b/internal/telemetry/tracing_test.go
@@ -172,6 +172,63 @@ func TestTracingMiddlewarePreservesWebSocketUpgrade(t *testing.T) {
 	c.Close(websocket.StatusNormalClosure, "")
 }
 
+// unwrapOnlyWriter is a ResponseWriter wrapper that exposes Unwrap but
+// deliberately does not implement http.Hijacker. It mirrors the shape
+// of the requestLogger's responseCapture: present outermost in the
+// chain, it forces a Hijack implementation that walks Unwrap instead
+// of doing a one-shot type assertion.
+type unwrapOnlyWriter struct {
+	http.ResponseWriter
+}
+
+func (u *unwrapOnlyWriter) Unwrap() http.ResponseWriter { return u.ResponseWriter }
+
+func TestTracingMiddlewareWebSocketUpgradeThroughUnwrapOnlyWrapper(t *testing.T) {
+	// Regression test for #263: when an outer middleware wraps the
+	// ResponseWriter with an Unwrap-only shim (e.g. requestLogger's
+	// responseCapture), the tracing middleware's Hijack must still
+	// find the real Hijacker by walking Unwrap. Before the fix, a
+	// direct type assertion failed and coder/websocket's Accept
+	// wrote an HTTP 500 body after the 101 upgrade, corrupting the
+	// frame stream and producing "Invalid frame header" on the client.
+	shutdown, _ := InitTracing(context.Background(), "")
+	defer shutdown(context.Background())
+
+	mw := TracingMiddleware()
+	inner := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("websocket.Accept: %v", err)
+			return
+		}
+		if err := c.Write(r.Context(), websocket.MessageText, []byte("hello")); err != nil {
+			t.Errorf("Write: %v", err)
+		}
+		c.Close(websocket.StatusNormalClosure, "")
+	}))
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		inner.ServeHTTP(&unwrapOnlyWriter{ResponseWriter: w}, r)
+	})
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	wsURL := "ws" + srv.URL[len("http"):]
+	c, _, err := websocket.Dial(context.Background(), wsURL, nil)
+	if err != nil {
+		t.Fatalf("websocket.Dial: %v", err)
+	}
+	defer c.Close(websocket.StatusNormalClosure, "")
+
+	typ, data, err := c.Read(context.Background())
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if typ != websocket.MessageText || string(data) != "hello" {
+		t.Fatalf("unexpected message: typ=%v data=%q", typ, data)
+	}
+}
+
 func TestTracingMiddlewareWithoutRouteContext(t *testing.T) {
 	// Test that the middleware works even without chi's RouteContext
 	// (i.e., when used with a plain http.ServeMux).


### PR DESCRIPTION
## Summary
- WS upgrades with OTEL enabled were corrupting frames — browser saw "Invalid frame header" after the 101.
- `statusWriter.Hijack` did a one-shot type assertion on its inner writer, which is `responseCapture` (Unwrap only, no Hijack). The assertion failed, coder/websocket called `http.Error`, and the 500 body was written after the 101, poisoning the WebSocket stream.
- Use `http.NewResponseController` so `Hijack` and `Flush` walk the Unwrap chain. Add `Unwrap()` on `statusWriter` so outer walkers can descend past it too.
- Regression test wraps the tracing middleware in an Unwrap-only shim (mirroring `responseCapture`) and asserts a round-trip message — fails on main, passes here.

Fixes #263