### PR TITLE
feat(process): postgres-primary worker registry + metadata with redis cache

### DIFF
--- a/cmd/blockyard/main.go
+++ b/cmd/blockyard/main.go
@@ -293,46 +293,59 @@ func main() {
 	hostname, _ := os.Hostname()
 	serverID := hostname + "-" + randomNonceHex(8)
 
-	// Wire Redis-backed shared state into the server if Redis is
-	// configured. The rc client was constructed above, before the
-	// backend, so the process backend's allocators share it.
-	if rc != nil {
-		srv.RedisClient = rc
-		registryTTL := 3 * cfg.Proxy.HealthInterval.Duration
+	// Shared-state backend selection — see #287, #286, parent #262.
+	// Postgres is the source of truth; Redis is an optional read-through
+	// cache so restarts don't cause session / worker loss. The same mode
+	// drives all three stores (registry, worker map, session store)
+	// because their durability requirements are identical — operators
+	// rarely want asymmetric modes.
+	mode := resolveSessionStore(cfg)
+	registryTTL := 3 * cfg.Proxy.HealthInterval.Duration
+	idleTTL := cfg.Proxy.SessionIdleTTL.Duration
+	var pgSessions *session.PostgresStore
+	switch mode {
+	case config.SessionStoreMemory:
+		srv.Registry = registry.NewMemoryRegistry()
+		srv.Workers = server.NewMemoryWorkerMap()
+		srv.Sessions = session.NewMemoryStore()
+	case config.SessionStoreRedis:
 		srv.Registry = registry.NewRedisRegistry(rc, registryTTL)
 		srv.Workers = server.NewRedisWorkerMap(rc, serverID)
+		srv.Sessions = session.NewRedisStore(rc, idleTTL)
+	case config.SessionStorePostgres:
+		srv.Registry = registry.NewPostgresRegistry(database.DB, registryTTL)
+		srv.Workers = server.NewPostgresWorkerMap(database.DB, serverID)
+		pgSessions = session.NewPostgresStore(database.DB, idleTTL)
+		srv.Sessions = pgSessions
+	case config.SessionStoreLayered:
+		srv.Registry = registry.NewLayeredRegistry(
+			registry.NewPostgresRegistry(database.DB, registryTTL),
+			registry.NewRedisRegistry(rc, registryTTL),
+		)
+		srv.Workers = server.NewLayeredWorkerMap(
+			server.NewPostgresWorkerMap(database.DB, serverID),
+			server.NewRedisWorkerMap(rc, serverID),
+		)
+		pgSessions = session.NewPostgresStore(database.DB, idleTTL)
+		srv.Sessions = session.NewLayeredStore(
+			pgSessions, session.NewRedisStore(rc, idleTTL),
+		)
+	}
+	if rc != nil {
+		srv.RedisClient = rc
 		slog.Info("using redis for shared state",
 			"url", maskRedisPassword(cfg.Redis.URL),
 			"prefix", cfg.Redis.KeyPrefix,
 			"server_id", serverID)
 	}
-
-	// Session store selection — see #286, parent #262. Postgres is the
-	// source of truth; Redis is an optional read-through cache so that
-	// Redis restarts don't cause session loss.
-	mode := resolveSessionStore(cfg)
-	idleTTL := cfg.Proxy.SessionIdleTTL.Duration
-	var pg *session.PostgresStore
-	switch mode {
-	case config.SessionStoreMemory:
-		srv.Sessions = session.NewMemoryStore()
-	case config.SessionStoreRedis:
-		srv.Sessions = session.NewRedisStore(rc, idleTTL)
-	case config.SessionStorePostgres:
-		pg = session.NewPostgresStore(database.DB, idleTTL)
-		srv.Sessions = pg
-	case config.SessionStoreLayered:
-		pg = session.NewPostgresStore(database.DB, idleTTL)
-		srv.Sessions = session.NewLayeredStore(pg, session.NewRedisStore(rc, idleTTL))
-	}
-	if pg != nil {
+	if pgSessions != nil {
 		bgWg.Add(1)
 		go func() {
 			defer bgWg.Done()
-			pg.RunExpiry(bgCtx, time.Minute)
+			pgSessions.RunExpiry(bgCtx, time.Minute)
 		}()
 	}
-	slog.Info("session store selected", "mode", mode)
+	slog.Info("shared state store selected", "mode", mode)
 
 	// Deferred validation: session_secret must be present if OIDC is configured.
 	if cfg.OIDC != nil {

--- a/internal/db/migrations/postgres/004_blockyard_workers.down.sql
+++ b/internal/db/migrations/postgres/004_blockyard_workers.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS blockyard_workers;

--- a/internal/db/migrations/postgres/004_blockyard_workers.up.sql
+++ b/internal/db/migrations/postgres/004_blockyard_workers.up.sql
@@ -1,0 +1,29 @@
+-- phase: expand
+--
+-- Postgres-primary worker registry + metadata (see #287, parent #262).
+-- Unifies the previously separate Redis stores (`registry:{id}` string
+-- and `worker:{id}` hash) into one row-per-worker table. Postgres becomes
+-- source of truth; Redis drops to an optional read-through cache so that
+-- a Redis restart does not drop workers.
+--
+-- Defaults on the *-required* columns let PostgresRegistry.Set (which
+-- only knows id+address) and PostgresWorkerMap.Set (which only knows the
+-- metadata) each do standalone upserts. In production both Set calls
+-- happen together during spawn, and the row converges to the full shape;
+-- the defaults only cover the "one side ran alone" case (tests, or a
+-- future caller that doesn't mirror both).
+CREATE TABLE blockyard_workers (
+    id             TEXT PRIMARY KEY,
+    address        TEXT NOT NULL DEFAULT '',
+    app_id         TEXT NOT NULL DEFAULT '',
+    bundle_id      TEXT NOT NULL DEFAULT '',
+    server_id      TEXT NOT NULL DEFAULT '',
+    draining       BOOLEAN NOT NULL DEFAULT false,
+    idle_since     TIMESTAMPTZ,
+    started_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_heartbeat TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_blockyard_workers_app_id         ON blockyard_workers(app_id);
+CREATE INDEX idx_blockyard_workers_server_id      ON blockyard_workers(server_id);
+CREATE INDEX idx_blockyard_workers_last_heartbeat ON blockyard_workers(last_heartbeat);

--- a/internal/db/migrations/sqlite/004_blockyard_workers.down.sql
+++ b/internal/db/migrations/sqlite/004_blockyard_workers.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS blockyard_workers;

--- a/internal/db/migrations/sqlite/004_blockyard_workers.up.sql
+++ b/internal/db/migrations/sqlite/004_blockyard_workers.up.sql
@@ -1,0 +1,23 @@
+-- phase: expand
+--
+-- Mirror of the Postgres blockyard_workers table (see #287). The
+-- Postgres-primary worker stores are only wired up when [redis] +
+-- database.driver = "postgres"; SQLite deployments keep the in-memory
+-- stores. The table is created here so migration numbering stays in
+-- lockstep across dialects and so future dialect-agnostic stores have
+-- somewhere to land.
+CREATE TABLE blockyard_workers (
+    id             TEXT PRIMARY KEY,
+    address        TEXT NOT NULL DEFAULT '',
+    app_id         TEXT NOT NULL DEFAULT '',
+    bundle_id      TEXT NOT NULL DEFAULT '',
+    server_id      TEXT NOT NULL DEFAULT '',
+    draining       INTEGER NOT NULL DEFAULT 0,
+    idle_since     TEXT,
+    started_at     TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_heartbeat TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_blockyard_workers_app_id         ON blockyard_workers(app_id);
+CREATE INDEX idx_blockyard_workers_server_id      ON blockyard_workers(server_id);
+CREATE INDEX idx_blockyard_workers_last_heartbeat ON blockyard_workers(last_heartbeat);

--- a/internal/registry/layered.go
+++ b/internal/registry/layered.go
@@ -1,0 +1,43 @@
+package registry
+
+// LayeredRegistry layers a cache WorkerRegistry over a primary (see
+// #287, parent #262). The primary is the source of truth (Postgres
+// in production); the cache is an optional optimization (Redis).
+//
+// Reads: cache first; on miss, fall back to primary and populate the
+// cache on the way out.
+//
+// Writes: primary first; cache mirrored best-effort. Cache errors are
+// swallowed inside the concrete stores, so LayeredRegistry just calls
+// both — the primary operation's outcome is the one surfaced.
+type LayeredRegistry struct {
+	primary WorkerRegistry
+	cache   WorkerRegistry
+}
+
+func NewLayeredRegistry(primary, cache WorkerRegistry) *LayeredRegistry {
+	return &LayeredRegistry{primary: primary, cache: cache}
+}
+
+func (r *LayeredRegistry) Get(workerID string) (string, bool) {
+	if addr, ok := r.cache.Get(workerID); ok {
+		return addr, true
+	}
+	addr, ok := r.primary.Get(workerID)
+	if ok {
+		r.cache.Set(workerID, addr)
+	}
+	return addr, ok
+}
+
+func (r *LayeredRegistry) Set(workerID, addr string) {
+	r.primary.Set(workerID, addr)
+	r.cache.Set(workerID, addr)
+}
+
+func (r *LayeredRegistry) Delete(workerID string) {
+	r.primary.Delete(workerID)
+	r.cache.Delete(workerID)
+}
+
+var _ WorkerRegistry = (*LayeredRegistry)(nil)

--- a/internal/registry/layered_test.go
+++ b/internal/registry/layered_test.go
@@ -1,0 +1,95 @@
+package registry
+
+import "testing"
+
+// TestLayeredRegistryCacheMissPopulates verifies the read-through
+// semantic: a cache miss reads from primary and warms the cache.
+func TestLayeredRegistryCacheMissPopulates(t *testing.T) {
+	primary := NewMemoryRegistry()
+	cache := NewMemoryRegistry()
+	r := NewLayeredRegistry(primary, cache)
+
+	// Seed only the primary. Cache has nothing — simulates post-restart.
+	primary.Set("w1", "127.0.0.1:3838")
+
+	if _, ok := cache.Get("w1"); ok {
+		t.Fatal("precondition: cache should be empty")
+	}
+
+	addr, ok := r.Get("w1")
+	if !ok || addr != "127.0.0.1:3838" {
+		t.Fatalf("expected primary-backed hit, got ok=%v addr=%q", ok, addr)
+	}
+
+	// Cache should now contain the entry (backfill).
+	if _, ok := cache.Get("w1"); !ok {
+		t.Error("cache should be populated after miss-through-read")
+	}
+}
+
+// TestLayeredRegistryCacheHitShortCircuits confirms reads don't touch
+// the primary when the cache has the entry — the whole point of the
+// cache layer.
+func TestLayeredRegistryCacheHitShortCircuits(t *testing.T) {
+	primary := NewMemoryRegistry()
+	cache := NewMemoryRegistry()
+	r := NewLayeredRegistry(primary, cache)
+
+	// Cache holds one address, primary another. Get must return cache value.
+	cache.Set("w1", "10.0.0.1:3838")
+	primary.Set("w1", "127.0.0.1:3838")
+
+	addr, ok := r.Get("w1")
+	if !ok {
+		t.Fatal("expected hit")
+	}
+	if addr != "10.0.0.1:3838" {
+		t.Errorf("addr = %q, want %q (cache must win)", addr, "10.0.0.1:3838")
+	}
+}
+
+// TestLayeredRegistryWriteThrough verifies Set writes to both layers.
+func TestLayeredRegistryWriteThrough(t *testing.T) {
+	primary := NewMemoryRegistry()
+	cache := NewMemoryRegistry()
+	r := NewLayeredRegistry(primary, cache)
+
+	r.Set("w1", "127.0.0.1:3838")
+
+	if _, ok := primary.Get("w1"); !ok {
+		t.Error("primary should have the entry")
+	}
+	if _, ok := cache.Get("w1"); !ok {
+		t.Error("cache should have the entry")
+	}
+}
+
+// TestLayeredRegistryDeletePropagates verifies Delete clears both
+// layers — otherwise a cache hit could resurrect a deleted entry.
+func TestLayeredRegistryDeletePropagates(t *testing.T) {
+	primary := NewMemoryRegistry()
+	cache := NewMemoryRegistry()
+	r := NewLayeredRegistry(primary, cache)
+
+	r.Set("w1", "127.0.0.1:3838")
+	r.Delete("w1")
+
+	if _, ok := primary.Get("w1"); ok {
+		t.Error("primary should be empty after Delete")
+	}
+	if _, ok := cache.Get("w1"); ok {
+		t.Error("cache should be empty after Delete")
+	}
+}
+
+// TestLayeredRegistryGetMissBothLayers confirms Get returns false
+// cleanly when neither layer has the entry.
+func TestLayeredRegistryGetMissBothLayers(t *testing.T) {
+	primary := NewMemoryRegistry()
+	cache := NewMemoryRegistry()
+	r := NewLayeredRegistry(primary, cache)
+
+	if _, ok := r.Get("nonexistent"); ok {
+		t.Error("Get should return false when both layers miss")
+	}
+}

--- a/internal/registry/postgres.go
+++ b/internal/registry/postgres.go
@@ -1,0 +1,85 @@
+package registry
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// PostgresRegistry implements WorkerRegistry against the blockyard_workers
+// table, making Postgres the source of truth for the worker address
+// lookup (see #287, parent #262). The same table also backs
+// server.PostgresWorkerMap; each store updates its own column set via
+// upserts, so a production spawn that calls Workers.Set before
+// Registry.Set converges to a full row.
+//
+// registryTTL mirrors the Redis TTL semantic: a worker whose last_heartbeat
+// is older than registryTTL is treated as gone (Get returns not-found).
+// The health poller calls Set on every successful probe, which bumps
+// last_heartbeat back to now().
+type PostgresRegistry struct {
+	db          *sqlx.DB
+	registryTTL time.Duration
+}
+
+func NewPostgresRegistry(db *sqlx.DB, registryTTL time.Duration) *PostgresRegistry {
+	return &PostgresRegistry{db: db, registryTTL: registryTTL}
+}
+
+func (r *PostgresRegistry) Get(workerID string) (string, bool) {
+	ctx := context.Background()
+	var addr string
+	var lastHeartbeat time.Time
+	err := r.db.QueryRowxContext(ctx,
+		`SELECT address, last_heartbeat
+		 FROM blockyard_workers WHERE id = $1`,
+		workerID,
+	).Scan(&addr, &lastHeartbeat)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false
+	}
+	if err != nil {
+		slog.Error("postgres registry get", "worker_id", workerID, "error", err)
+		return "", false
+	}
+	// Empty address means the row was created by PostgresWorkerMap alone
+	// (no Registry.Set yet). Treat that as "no address known" rather
+	// than handing out the empty string.
+	if addr == "" {
+		return "", false
+	}
+	if r.registryTTL > 0 && time.Since(lastHeartbeat) > r.registryTTL {
+		return "", false
+	}
+	return addr, true
+}
+
+func (r *PostgresRegistry) Set(workerID, addr string) {
+	ctx := context.Background()
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO blockyard_workers (id, address, last_heartbeat)
+		 VALUES ($1, $2, now())
+		 ON CONFLICT (id) DO UPDATE SET
+		     address        = EXCLUDED.address,
+		     last_heartbeat = EXCLUDED.last_heartbeat`,
+		workerID, addr,
+	)
+	if err != nil {
+		slog.Error("postgres registry set", "worker_id", workerID, "error", err)
+	}
+}
+
+func (r *PostgresRegistry) Delete(workerID string) {
+	ctx := context.Background()
+	if _, err := r.db.ExecContext(ctx,
+		`DELETE FROM blockyard_workers WHERE id = $1`, workerID,
+	); err != nil {
+		slog.Error("postgres registry delete", "worker_id", workerID, "error", err)
+	}
+}
+
+var _ WorkerRegistry = (*PostgresRegistry)(nil)

--- a/internal/registry/postgres_test.go
+++ b/internal/registry/postgres_test.go
@@ -1,0 +1,246 @@
+package registry
+
+import (
+	"database/sql"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/cynkra/blockyard/internal/config"
+	"github.com/cynkra/blockyard/internal/db"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// pgTestBaseURL is the admin URL for the Postgres instance hosting the
+// per-test databases. Empty when tests should skip.
+var pgTestBaseURL string
+
+// pgRegistryTemplate is the migrated template database. Per-test
+// databases clone from it (CREATE DATABASE … TEMPLATE), which is
+// orders of magnitude faster than re-running migrations. Own name
+// (not reused from internal/db or internal/session) so the test
+// binaries don't collide when CI runs them concurrently.
+const pgRegistryTemplate = "blockyard_registry_test_template"
+
+func TestMain(m *testing.M) {
+	pgTestBaseURL = os.Getenv("BLOCKYARD_TEST_POSTGRES_URL")
+	if pgTestBaseURL != "" {
+		if err := setupRegistryTemplate(pgTestBaseURL); err != nil {
+			fmt.Fprintf(os.Stderr, "registry: template bootstrap: %v\n", err)
+			os.Exit(1)
+		}
+		defer teardownRegistryTemplate(pgTestBaseURL)
+	}
+	os.Exit(m.Run())
+}
+
+func setupRegistryTemplate(base string) error {
+	admin, err := sql.Open("pgx", base)
+	if err != nil {
+		return err
+	}
+	defer admin.Close()
+
+	admin.Exec("DROP DATABASE IF EXISTS " + pgRegistryTemplate)
+	if _, err := admin.Exec("CREATE DATABASE " + pgRegistryTemplate); err != nil {
+		return fmt.Errorf("create template: %w", err)
+	}
+
+	tplURL := replacePGName(base, pgRegistryTemplate)
+	tpl, err := db.Open(config.DatabaseConfig{Driver: "postgres", URL: tplURL})
+	if err != nil {
+		return fmt.Errorf("migrate template: %w", err)
+	}
+	tpl.Close()
+
+	admin.Exec("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '" + pgRegistryTemplate + "'")
+	admin.Exec("ALTER DATABASE " + pgRegistryTemplate + " WITH ALLOW_CONNECTIONS = false")
+	return nil
+}
+
+func teardownRegistryTemplate(base string) {
+	admin, err := sql.Open("pgx", base)
+	if err != nil {
+		return
+	}
+	defer admin.Close()
+	admin.Exec("ALTER DATABASE " + pgRegistryTemplate + " WITH ALLOW_CONNECTIONS = true")
+	admin.Exec("DROP DATABASE IF EXISTS " + pgRegistryTemplate)
+}
+
+// testPGDB clones the pre-migrated template and returns a fresh
+// *sqlx.DB pointing at it. Registers a t.Cleanup that drops the clone
+// when the test exits.
+func testPGDB(t *testing.T) *sqlx.DB {
+	t.Helper()
+	if pgTestBaseURL == "" {
+		t.Skip("BLOCKYARD_TEST_POSTGRES_URL not set; skipping Postgres registry tests")
+	}
+
+	dbName := "reg_" + strings.ReplaceAll(uuid.New().String(), "-", "")[:20]
+
+	admin, err := sql.Open("pgx", pgTestBaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admin.Exec("CREATE DATABASE " + dbName + " TEMPLATE " + pgRegistryTemplate); err != nil {
+		admin.Close()
+		t.Fatal(err)
+	}
+	admin.Close()
+
+	testURL := replacePGName(pgTestBaseURL, dbName)
+	rawDB, err := sqlx.Open("pgx", testURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawDB.SetMaxOpenConns(5)
+
+	t.Cleanup(func() {
+		rawDB.Close()
+		cleanup, cErr := sql.Open("pgx", pgTestBaseURL)
+		if cErr == nil {
+			cleanup.Exec("DROP DATABASE IF EXISTS " + dbName)
+			cleanup.Close()
+		}
+	})
+	return rawDB
+}
+
+func replacePGName(raw, name string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	u.Path = "/" + name
+	return u.String()
+}
+
+func TestPostgresRegistryGetSetDelete(t *testing.T) {
+	r := NewPostgresRegistry(testPGDB(t), time.Hour)
+
+	r.Set("worker-1", "127.0.0.1:3838")
+
+	addr, ok := r.Get("worker-1")
+	if !ok {
+		t.Fatal("expected worker to exist")
+	}
+	if addr != "127.0.0.1:3838" {
+		t.Errorf("expected 127.0.0.1:3838, got %q", addr)
+	}
+
+	r.Delete("worker-1")
+	if _, ok := r.Get("worker-1"); ok {
+		t.Error("expected worker to be deleted")
+	}
+}
+
+func TestPostgresRegistryGetMissing(t *testing.T) {
+	r := NewPostgresRegistry(testPGDB(t), time.Hour)
+	if _, ok := r.Get("nonexistent"); ok {
+		t.Error("expected false for missing worker")
+	}
+}
+
+// TestPostgresRegistrySetOverwrite confirms Set is idempotent — a
+// second Set with a new address replaces the first. The Redis variant
+// does the same via a straight SET; the Postgres path needs ON
+// CONFLICT DO UPDATE, which this test pins.
+func TestPostgresRegistrySetOverwrite(t *testing.T) {
+	r := NewPostgresRegistry(testPGDB(t), time.Hour)
+
+	r.Set("worker-1", "127.0.0.1:3838")
+	r.Set("worker-1", "10.0.0.1:3838")
+
+	addr, ok := r.Get("worker-1")
+	if !ok {
+		t.Fatal("expected worker to exist")
+	}
+	if addr != "10.0.0.1:3838" {
+		t.Errorf("expected 10.0.0.1:3838 after overwrite, got %q", addr)
+	}
+}
+
+// TestPostgresRegistryDeleteNonexistent confirms Delete is a no-op for
+// a missing id (matches Redis DEL which returns 0 with no error).
+func TestPostgresRegistryDeleteNonexistent(t *testing.T) {
+	r := NewPostgresRegistry(testPGDB(t), time.Hour)
+	// Should not panic or error.
+	r.Delete("nonexistent")
+}
+
+// TestPostgresRegistryTTLExpiry confirms Get treats a stale heartbeat
+// as "gone", matching the Redis TTL semantic. The health poller bumps
+// last_heartbeat on every successful probe — here we starve that and
+// push the clock forward via a direct UPDATE.
+func TestPostgresRegistryTTLExpiry(t *testing.T) {
+	db := testPGDB(t)
+	r := NewPostgresRegistry(db, 10*time.Second)
+
+	r.Set("worker-1", "127.0.0.1:3838")
+	// Simulate 11 seconds without a heartbeat refresh.
+	if _, err := db.Exec(
+		`UPDATE blockyard_workers SET last_heartbeat = now() - interval '11 seconds' WHERE id = $1`,
+		"worker-1",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := r.Get("worker-1"); ok {
+		t.Error("expected registry entry to be stale and reported as gone")
+	}
+}
+
+// TestPostgresRegistryTTLRefresh confirms Set bumps last_heartbeat —
+// the mechanism the health poller uses to keep a worker alive in the
+// registry.
+func TestPostgresRegistryTTLRefresh(t *testing.T) {
+	db := testPGDB(t)
+	r := NewPostgresRegistry(db, 10*time.Second)
+
+	r.Set("worker-1", "127.0.0.1:3838")
+	if _, err := db.Exec(
+		`UPDATE blockyard_workers SET last_heartbeat = now() - interval '6 seconds' WHERE id = $1`,
+		"worker-1",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-Set refreshes the heartbeat (simulates health poller behaviour).
+	r.Set("worker-1", "127.0.0.1:3838")
+
+	addr, ok := r.Get("worker-1")
+	if !ok {
+		t.Error("expected worker to still exist after heartbeat refresh")
+	}
+	if addr != "127.0.0.1:3838" {
+		t.Errorf("expected 127.0.0.1:3838, got %q", addr)
+	}
+}
+
+// TestPostgresRegistryZeroTTLNeverExpires pins the "registryTTL == 0"
+// contract: Get does not filter by heartbeat age. Matches the
+// registry.WorkerRegistry callers in tests that don't care about TTL.
+func TestPostgresRegistryZeroTTLNeverExpires(t *testing.T) {
+	db := testPGDB(t)
+	r := NewPostgresRegistry(db, 0)
+
+	r.Set("worker-1", "127.0.0.1:3838")
+	if _, err := db.Exec(
+		`UPDATE blockyard_workers SET last_heartbeat = now() - interval '1 hour' WHERE id = $1`,
+		"worker-1",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := r.Get("worker-1"); !ok {
+		t.Error("expected worker to still exist with TTL=0")
+	}
+}

--- a/internal/server/workermap_conformance_test.go
+++ b/internal/server/workermap_conformance_test.go
@@ -26,6 +26,19 @@ func workerMapImplementations(t *testing.T) map[string]workerMapFactory {
 			client := redisstate.TestClient(t, mr.Addr())
 			return NewRedisWorkerMap(client, "test-host")
 		},
+		"Postgres": func(t *testing.T) WorkerMap {
+			t.Helper()
+			return NewPostgresWorkerMap(testPGDB(t), "test-host")
+		},
+		"Layered": func(t *testing.T) WorkerMap {
+			t.Helper()
+			// Matches production wiring: Postgres primary + Redis cache.
+			mr := miniredis.RunT(t)
+			client := redisstate.TestClient(t, mr.Addr())
+			cache := NewRedisWorkerMap(client, "test-host")
+			primary := NewPostgresWorkerMap(testPGDB(t), "test-host")
+			return NewLayeredWorkerMap(primary, cache)
+		},
 	}
 }
 

--- a/internal/server/workermap_layered.go
+++ b/internal/server/workermap_layered.go
@@ -1,0 +1,112 @@
+package server
+
+import "time"
+
+// LayeredWorkerMap layers a cache WorkerMap over a primary (see #287,
+// parent #262). The primary is the source of truth (Postgres in
+// production); the cache is an optional optimization (Redis).
+//
+// Reads: cache first; on miss, fall back to primary and populate the
+// cache on the way out.
+//
+// Writes: primary first; cache mirrored best-effort. Cache errors are
+// swallowed inside the concrete stores, so LayeredWorkerMap just calls
+// both — the primary operation's outcome is the one surfaced.
+//
+// Aggregate queries (Count, CountForApp, ForApp, MarkDraining, …)
+// always go to the primary: the cache may hold a subset and can't
+// answer accurately.
+type LayeredWorkerMap struct {
+	primary WorkerMap
+	cache   WorkerMap
+}
+
+func NewLayeredWorkerMap(primary, cache WorkerMap) *LayeredWorkerMap {
+	return &LayeredWorkerMap{primary: primary, cache: cache}
+}
+
+func (m *LayeredWorkerMap) Get(id string) (ActiveWorker, bool) {
+	if w, ok := m.cache.Get(id); ok {
+		return w, true
+	}
+	w, ok := m.primary.Get(id)
+	if ok {
+		m.cache.Set(id, w)
+	}
+	return w, ok
+}
+
+func (m *LayeredWorkerMap) Set(id string, w ActiveWorker) {
+	m.primary.Set(id, w)
+	m.cache.Set(id, w)
+}
+
+func (m *LayeredWorkerMap) Delete(id string) {
+	m.primary.Delete(id)
+	m.cache.Delete(id)
+}
+
+func (m *LayeredWorkerMap) Count() int                 { return m.primary.Count() }
+func (m *LayeredWorkerMap) CountForApp(appID string) int { return m.primary.CountForApp(appID) }
+func (m *LayeredWorkerMap) All() []string              { return m.primary.All() }
+func (m *LayeredWorkerMap) ForApp(appID string) []string {
+	return m.primary.ForApp(appID)
+}
+func (m *LayeredWorkerMap) ForAppAvailable(appID string) []string {
+	return m.primary.ForAppAvailable(appID)
+}
+
+// MarkDraining writes the drain flag to the primary, then mirrors the
+// state to the cache for each affected worker so a subsequent cache
+// hit returns the new draining flag.
+func (m *LayeredWorkerMap) MarkDraining(appID string) []string {
+	ids := m.primary.MarkDraining(appID)
+	for _, id := range ids {
+		m.cache.SetDraining(id)
+	}
+	return ids
+}
+
+func (m *LayeredWorkerMap) SetDraining(workerID string) {
+	m.primary.SetDraining(workerID)
+	m.cache.SetDraining(workerID)
+}
+
+func (m *LayeredWorkerMap) ClearDraining(workerID string) {
+	m.primary.ClearDraining(workerID)
+	m.cache.ClearDraining(workerID)
+}
+
+func (m *LayeredWorkerMap) SetIdleSince(workerID string, t time.Time) {
+	m.primary.SetIdleSince(workerID, t)
+	m.cache.SetIdleSince(workerID, t)
+}
+
+func (m *LayeredWorkerMap) SetIdleSinceIfZero(workerID string, t time.Time) {
+	m.primary.SetIdleSinceIfZero(workerID, t)
+	m.cache.SetIdleSinceIfZero(workerID, t)
+}
+
+func (m *LayeredWorkerMap) ClearIdleSince(workerID string) bool {
+	ok := m.primary.ClearIdleSince(workerID)
+	if ok {
+		m.cache.ClearIdleSince(workerID)
+	}
+	return ok
+}
+
+func (m *LayeredWorkerMap) IdleWorkers(timeout time.Duration) []string {
+	return m.primary.IdleWorkers(timeout)
+}
+
+func (m *LayeredWorkerMap) AppIDs() []string { return m.primary.AppIDs() }
+
+func (m *LayeredWorkerMap) IsDraining(appID string) bool {
+	return m.primary.IsDraining(appID)
+}
+
+func (m *LayeredWorkerMap) WorkersForServer(serverID string) []string {
+	return m.primary.WorkersForServer(serverID)
+}
+
+var _ WorkerMap = (*LayeredWorkerMap)(nil)

--- a/internal/server/workermap_layered_test.go
+++ b/internal/server/workermap_layered_test.go
@@ -1,0 +1,148 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+// TestLayeredWorkerMapCacheMissPopulates verifies the read-through
+// semantic: a cache miss reads from primary and warms the cache.
+func TestLayeredWorkerMapCacheMissPopulates(t *testing.T) {
+	primary := NewMemoryWorkerMap()
+	cache := NewMemoryWorkerMap()
+	m := NewLayeredWorkerMap(primary, cache)
+
+	// Seed only the primary. Cache has nothing — simulates post-restart.
+	primary.Set("w1", ActiveWorker{AppID: "app1", BundleID: "b1", StartedAt: time.Now()})
+
+	if _, ok := cache.Get("w1"); ok {
+		t.Fatal("precondition: cache should be empty")
+	}
+
+	w, ok := m.Get("w1")
+	if !ok || w.AppID != "app1" {
+		t.Fatalf("expected primary-backed hit, got ok=%v worker=%+v", ok, w)
+	}
+
+	// Cache should now contain the entry (backfill).
+	if _, ok := cache.Get("w1"); !ok {
+		t.Error("cache should be populated after miss-through-read")
+	}
+}
+
+// TestLayeredWorkerMapCacheHitShortCircuits verifies reads don't touch
+// the primary when the cache has the entry.
+func TestLayeredWorkerMapCacheHitShortCircuits(t *testing.T) {
+	primary := NewMemoryWorkerMap()
+	cache := NewMemoryWorkerMap()
+	m := NewLayeredWorkerMap(primary, cache)
+
+	// Cache holds app1, primary holds app2. Get must return cache value.
+	cache.Set("w1", ActiveWorker{AppID: "app1"})
+	primary.Set("w1", ActiveWorker{AppID: "app2"})
+
+	w, ok := m.Get("w1")
+	if !ok {
+		t.Fatal("expected hit")
+	}
+	if w.AppID != "app1" {
+		t.Errorf("AppID = %q, want %q (cache must win)", w.AppID, "app1")
+	}
+}
+
+// TestLayeredWorkerMapWriteThrough verifies Set writes to both layers.
+func TestLayeredWorkerMapWriteThrough(t *testing.T) {
+	primary := NewMemoryWorkerMap()
+	cache := NewMemoryWorkerMap()
+	m := NewLayeredWorkerMap(primary, cache)
+
+	m.Set("w1", ActiveWorker{AppID: "app1"})
+
+	if _, ok := primary.Get("w1"); !ok {
+		t.Error("primary should have the entry")
+	}
+	if _, ok := cache.Get("w1"); !ok {
+		t.Error("cache should have the entry")
+	}
+}
+
+// TestLayeredWorkerMapDeletePropagates verifies Delete clears both
+// layers — otherwise a cache hit could resurrect a deleted entry.
+func TestLayeredWorkerMapDeletePropagates(t *testing.T) {
+	primary := NewMemoryWorkerMap()
+	cache := NewMemoryWorkerMap()
+	m := NewLayeredWorkerMap(primary, cache)
+
+	m.Set("w1", ActiveWorker{AppID: "app1"})
+	m.Delete("w1")
+
+	if _, ok := primary.Get("w1"); ok {
+		t.Error("primary should be empty after Delete")
+	}
+	if _, ok := cache.Get("w1"); ok {
+		t.Error("cache should be empty after Delete")
+	}
+}
+
+// TestLayeredWorkerMapAggregatesFromPrimary verifies aggregate queries
+// bypass the cache and go straight to the primary. The cache may hold
+// a subset and would under-report.
+func TestLayeredWorkerMapAggregatesFromPrimary(t *testing.T) {
+	primary := NewMemoryWorkerMap()
+	cache := NewMemoryWorkerMap()
+	m := NewLayeredWorkerMap(primary, cache)
+
+	// Primary has 3, cache has 1 (partial warmup).
+	primary.Set("a", ActiveWorker{AppID: "app1"})
+	primary.Set("b", ActiveWorker{AppID: "app1"})
+	primary.Set("c", ActiveWorker{AppID: "app2"})
+	cache.Set("a", ActiveWorker{AppID: "app1"})
+
+	if n := m.Count(); n != 3 {
+		t.Errorf("Count = %d, want 3 (primary is source of truth)", n)
+	}
+	if n := m.CountForApp("app1"); n != 2 {
+		t.Errorf("CountForApp(app1) = %d, want 2", n)
+	}
+}
+
+// TestLayeredWorkerMapMarkDrainingMirrorsCache verifies MarkDraining
+// on the primary also flips the cache entry so a subsequent cache hit
+// sees the new draining flag. Otherwise a draining worker could still
+// be routed to by a handler that reads through the cache.
+func TestLayeredWorkerMapMarkDrainingMirrorsCache(t *testing.T) {
+	primary := NewMemoryWorkerMap()
+	cache := NewMemoryWorkerMap()
+	m := NewLayeredWorkerMap(primary, cache)
+
+	// Seed both layers with a non-draining worker.
+	m.Set("w1", ActiveWorker{AppID: "app1"})
+
+	ids := m.MarkDraining("app1")
+	if len(ids) != 1 || ids[0] != "w1" {
+		t.Fatalf("MarkDraining returned %v, want [w1]", ids)
+	}
+
+	// Cache must reflect the new draining state.
+	w, ok := cache.Get("w1")
+	if !ok || !w.Draining {
+		t.Errorf("cache entry Draining = %v, want true", w.Draining)
+	}
+}
+
+// TestLayeredWorkerMapClearIdleSinceReportsPrimary verifies the return
+// value of ClearIdleSince reflects the primary's state — the
+// authoritative "was this worker actually idle" answer.
+func TestLayeredWorkerMapClearIdleSinceReportsPrimary(t *testing.T) {
+	primary := NewMemoryWorkerMap()
+	cache := NewMemoryWorkerMap()
+	m := NewLayeredWorkerMap(primary, cache)
+
+	primary.Set("w1", ActiveWorker{AppID: "app1"})
+	primary.SetIdleSince("w1", time.Now().Add(-time.Minute))
+	cache.Set("w1", ActiveWorker{AppID: "app1"}) // cache has no idle state
+
+	if !m.ClearIdleSince("w1") {
+		t.Error("ClearIdleSince should report true (primary was idle)")
+	}
+}

--- a/internal/server/workermap_postgres.go
+++ b/internal/server/workermap_postgres.go
@@ -1,0 +1,285 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// PostgresWorkerMap implements WorkerMap against the blockyard_workers
+// table, making Postgres the source of truth for worker metadata (see
+// #287, parent #262). The same table also backs registry.PostgresRegistry
+// — each store upserts its own column subset so a production spawn
+// that calls Workers.Set before Registry.Set converges to a full row.
+//
+// idle_since is stored as NULL when the worker is not idle (mapped to
+// Go's zero-value time.Time), mirroring the MemoryWorkerMap semantic
+// used throughout the codebase.
+type PostgresWorkerMap struct {
+	db       *sqlx.DB
+	serverID string
+}
+
+func NewPostgresWorkerMap(db *sqlx.DB, serverID string) *PostgresWorkerMap {
+	return &PostgresWorkerMap{db: db, serverID: serverID}
+}
+
+func (m *PostgresWorkerMap) Get(id string) (ActiveWorker, bool) {
+	ctx := context.Background()
+	var w ActiveWorker
+	var idleSince sql.NullTime
+	err := m.db.QueryRowxContext(ctx,
+		`SELECT app_id, bundle_id, draining, idle_since, started_at
+		 FROM blockyard_workers WHERE id = $1`,
+		id,
+	).Scan(&w.AppID, &w.BundleID, &w.Draining, &idleSince, &w.StartedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ActiveWorker{}, false
+	}
+	if err != nil {
+		slog.Error("postgres worker get", "worker_id", id, "error", err)
+		return ActiveWorker{}, false
+	}
+	if idleSince.Valid {
+		w.IdleSince = idleSince.Time
+	}
+	return w, true
+}
+
+func (m *PostgresWorkerMap) Set(id string, w ActiveWorker) {
+	ctx := context.Background()
+	var idleSince sql.NullTime
+	if !w.IdleSince.IsZero() {
+		idleSince = sql.NullTime{Time: w.IdleSince, Valid: true}
+	}
+	startedAt := w.StartedAt
+	if startedAt.IsZero() {
+		startedAt = time.Now()
+	}
+	_, err := m.db.ExecContext(ctx,
+		`INSERT INTO blockyard_workers
+		     (id, app_id, bundle_id, server_id, draining, idle_since, started_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)
+		 ON CONFLICT (id) DO UPDATE SET
+		     app_id     = EXCLUDED.app_id,
+		     bundle_id  = EXCLUDED.bundle_id,
+		     server_id  = EXCLUDED.server_id,
+		     draining   = EXCLUDED.draining,
+		     idle_since = EXCLUDED.idle_since,
+		     started_at = EXCLUDED.started_at`,
+		id, w.AppID, w.BundleID, m.serverID, w.Draining, idleSince, startedAt,
+	)
+	if err != nil {
+		slog.Error("postgres worker set", "worker_id", id, "error", err)
+	}
+}
+
+func (m *PostgresWorkerMap) Delete(id string) {
+	ctx := context.Background()
+	if _, err := m.db.ExecContext(ctx,
+		`DELETE FROM blockyard_workers WHERE id = $1`, id,
+	); err != nil {
+		slog.Error("postgres worker delete", "worker_id", id, "error", err)
+	}
+}
+
+// Count returns the total number of tracked workers. Rows created by
+// registry.PostgresRegistry alone (no Workers.Set ever called) still
+// count — a registered address is a tracked worker.
+func (m *PostgresWorkerMap) Count() int {
+	ctx := context.Background()
+	var n int
+	if err := m.db.QueryRowxContext(ctx,
+		`SELECT COUNT(*) FROM blockyard_workers`,
+	).Scan(&n); err != nil {
+		slog.Error("postgres worker count", "error", err)
+		return 0
+	}
+	return n
+}
+
+func (m *PostgresWorkerMap) CountForApp(appID string) int {
+	ctx := context.Background()
+	var n int
+	if err := m.db.QueryRowxContext(ctx,
+		`SELECT COUNT(*) FROM blockyard_workers WHERE app_id = $1`, appID,
+	).Scan(&n); err != nil {
+		slog.Error("postgres worker count for app",
+			"app_id", appID, "error", err)
+		return 0
+	}
+	return n
+}
+
+func (m *PostgresWorkerMap) All() []string {
+	return m.selectIDs(`SELECT id FROM blockyard_workers`)
+}
+
+func (m *PostgresWorkerMap) ForApp(appID string) []string {
+	return m.selectIDs(
+		`SELECT id FROM blockyard_workers WHERE app_id = $1`, appID,
+	)
+}
+
+func (m *PostgresWorkerMap) ForAppAvailable(appID string) []string {
+	return m.selectIDs(
+		`SELECT id FROM blockyard_workers
+		 WHERE app_id = $1 AND draining = false`, appID,
+	)
+}
+
+// MarkDraining sets draining on every worker for the given app and
+// returns the affected worker IDs. Implemented as a single UPDATE ...
+// RETURNING so the read-modify-write stays atomic.
+func (m *PostgresWorkerMap) MarkDraining(appID string) []string {
+	ctx := context.Background()
+	rows, err := m.db.QueryxContext(ctx,
+		`UPDATE blockyard_workers SET draining = true
+		 WHERE app_id = $1 RETURNING id`, appID,
+	)
+	if err != nil {
+		slog.Error("postgres worker mark draining",
+			"app_id", appID, "error", err)
+		return nil
+	}
+	defer rows.Close()
+	return collectIDs(rows, "mark draining")
+}
+
+// SetDraining flips draining on a single worker. The WHERE guard
+// matches the "must not create ghost entry" conformance test — if the
+// row doesn't exist, nothing is inserted.
+func (m *PostgresWorkerMap) SetDraining(workerID string) {
+	m.execUpdate(
+		`UPDATE blockyard_workers SET draining = true WHERE id = $1`,
+		"set draining", workerID,
+	)
+}
+
+func (m *PostgresWorkerMap) ClearDraining(workerID string) {
+	m.execUpdate(
+		`UPDATE blockyard_workers SET draining = false WHERE id = $1`,
+		"clear draining", workerID,
+	)
+}
+
+func (m *PostgresWorkerMap) SetIdleSince(workerID string, t time.Time) {
+	m.execUpdate(
+		`UPDATE blockyard_workers SET idle_since = $2 WHERE id = $1`,
+		"set idle since", workerID, t,
+	)
+}
+
+// SetIdleSinceIfZero sets idle_since only when it's currently NULL
+// (the zero-value representation). Matches the MemoryWorkerMap
+// semantic used to avoid resetting the timer on repeated ticks.
+func (m *PostgresWorkerMap) SetIdleSinceIfZero(workerID string, t time.Time) {
+	m.execUpdate(
+		`UPDATE blockyard_workers SET idle_since = $2
+		 WHERE id = $1 AND idle_since IS NULL`,
+		"set idle since if zero", workerID, t,
+	)
+}
+
+// ClearIdleSince resets idle_since to NULL and reports whether the
+// worker was previously idle. Done in a single UPDATE so the
+// read-modify-write is race-free.
+func (m *PostgresWorkerMap) ClearIdleSince(workerID string) bool {
+	ctx := context.Background()
+	res, err := m.db.ExecContext(ctx,
+		`UPDATE blockyard_workers SET idle_since = NULL
+		 WHERE id = $1 AND idle_since IS NOT NULL`, workerID,
+	)
+	if err != nil {
+		slog.Error("postgres worker clear idle since",
+			"worker_id", workerID, "error", err)
+		return false
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		slog.Error("postgres worker clear idle since rows",
+			"worker_id", workerID, "error", err)
+		return false
+	}
+	return n > 0
+}
+
+// IdleWorkers returns workers idle longer than timeout, excluding
+// draining workers (they're on their own lifecycle).
+func (m *PostgresWorkerMap) IdleWorkers(timeout time.Duration) []string {
+	cutoff := time.Now().Add(-timeout)
+	return m.selectIDs(
+		`SELECT id FROM blockyard_workers
+		 WHERE idle_since IS NOT NULL
+		   AND idle_since <= $1
+		   AND draining = false`, cutoff,
+	)
+}
+
+// AppIDs returns the deduplicated set of app_ids with at least one
+// tracked worker. Filters out the empty-string default so rows created
+// by registry.PostgresRegistry alone don't leak a bogus "" entry.
+func (m *PostgresWorkerMap) AppIDs() []string {
+	return m.selectIDs(
+		`SELECT DISTINCT app_id FROM blockyard_workers WHERE app_id <> ''`,
+	)
+}
+
+func (m *PostgresWorkerMap) IsDraining(appID string) bool {
+	ctx := context.Background()
+	var exists bool
+	if err := m.db.QueryRowxContext(ctx,
+		`SELECT EXISTS (
+		     SELECT 1 FROM blockyard_workers
+		     WHERE app_id = $1 AND draining = true
+		 )`, appID,
+	).Scan(&exists); err != nil {
+		slog.Error("postgres worker is draining",
+			"app_id", appID, "error", err)
+		return false
+	}
+	return exists
+}
+
+func (m *PostgresWorkerMap) WorkersForServer(serverID string) []string {
+	return m.selectIDs(
+		`SELECT id FROM blockyard_workers WHERE server_id = $1`, serverID,
+	)
+}
+
+func (m *PostgresWorkerMap) selectIDs(query string, args ...any) []string {
+	ctx := context.Background()
+	rows, err := m.db.QueryxContext(ctx, query, args...)
+	if err != nil {
+		slog.Error("postgres worker select", "error", err)
+		return nil
+	}
+	defer rows.Close()
+	return collectIDs(rows, "select")
+}
+
+func collectIDs(rows *sqlx.Rows, op string) []string {
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			slog.Error("postgres worker scan", "op", op, "error", err)
+			continue
+		}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func (m *PostgresWorkerMap) execUpdate(query, op string, args ...any) {
+	ctx := context.Background()
+	if _, err := m.db.ExecContext(ctx, query, args...); err != nil {
+		slog.Error("postgres worker "+op, "args", args, "error", err)
+	}
+}
+
+var _ WorkerMap = (*PostgresWorkerMap)(nil)

--- a/internal/server/workermap_postgres_test.go
+++ b/internal/server/workermap_postgres_test.go
@@ -1,0 +1,184 @@
+package server
+
+import (
+	"database/sql"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/cynkra/blockyard/internal/config"
+	"github.com/cynkra/blockyard/internal/db"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// pgTestBaseURL is the admin URL for the Postgres instance hosting
+// the per-test databases. Empty when tests should skip.
+var pgTestBaseURL string
+
+// pgWorkersTemplate is the migrated template database. Per-test
+// databases clone from it (CREATE DATABASE … TEMPLATE) — orders of
+// magnitude faster than re-running migrations. Own name so the test
+// binaries don't collide when CI runs them concurrently.
+const pgWorkersTemplate = "blockyard_workers_test_template"
+
+func TestMain(m *testing.M) {
+	pgTestBaseURL = os.Getenv("BLOCKYARD_TEST_POSTGRES_URL")
+	if pgTestBaseURL != "" {
+		if err := setupWorkersTemplate(pgTestBaseURL); err != nil {
+			fmt.Fprintf(os.Stderr, "server: workers template bootstrap: %v\n", err)
+			os.Exit(1)
+		}
+		defer teardownWorkersTemplate(pgTestBaseURL)
+	}
+	os.Exit(m.Run())
+}
+
+func setupWorkersTemplate(base string) error {
+	admin, err := sql.Open("pgx", base)
+	if err != nil {
+		return err
+	}
+	defer admin.Close()
+
+	admin.Exec("DROP DATABASE IF EXISTS " + pgWorkersTemplate)
+	if _, err := admin.Exec("CREATE DATABASE " + pgWorkersTemplate); err != nil {
+		return fmt.Errorf("create template: %w", err)
+	}
+
+	tplURL := replacePGName(base, pgWorkersTemplate)
+	tpl, err := db.Open(config.DatabaseConfig{Driver: "postgres", URL: tplURL})
+	if err != nil {
+		return fmt.Errorf("migrate template: %w", err)
+	}
+	tpl.Close()
+
+	admin.Exec("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '" + pgWorkersTemplate + "'")
+	admin.Exec("ALTER DATABASE " + pgWorkersTemplate + " WITH ALLOW_CONNECTIONS = false")
+	return nil
+}
+
+func teardownWorkersTemplate(base string) {
+	admin, err := sql.Open("pgx", base)
+	if err != nil {
+		return
+	}
+	defer admin.Close()
+	admin.Exec("ALTER DATABASE " + pgWorkersTemplate + " WITH ALLOW_CONNECTIONS = true")
+	admin.Exec("DROP DATABASE IF EXISTS " + pgWorkersTemplate)
+}
+
+func testPGDB(t *testing.T) *sqlx.DB {
+	t.Helper()
+	if pgTestBaseURL == "" {
+		t.Skip("BLOCKYARD_TEST_POSTGRES_URL not set; skipping Postgres worker map tests")
+	}
+
+	dbName := "wm_" + strings.ReplaceAll(uuid.New().String(), "-", "")[:20]
+
+	admin, err := sql.Open("pgx", pgTestBaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admin.Exec("CREATE DATABASE " + dbName + " TEMPLATE " + pgWorkersTemplate); err != nil {
+		admin.Close()
+		t.Fatal(err)
+	}
+	admin.Close()
+
+	testURL := replacePGName(pgTestBaseURL, dbName)
+	rawDB, err := sqlx.Open("pgx", testURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawDB.SetMaxOpenConns(5)
+
+	t.Cleanup(func() {
+		rawDB.Close()
+		cleanup, cErr := sql.Open("pgx", pgTestBaseURL)
+		if cErr == nil {
+			cleanup.Exec("DROP DATABASE IF EXISTS " + dbName)
+			cleanup.Close()
+		}
+	})
+	return rawDB
+}
+
+func replacePGName(raw, name string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	u.Path = "/" + name
+	return u.String()
+}
+
+// TestPostgresWorkerMapServerIDHardcoded pins that Set always stamps
+// the serverID given at construction time — not whatever ActiveWorker
+// field might carry. This matches RedisWorkerMap behavior: WorkersForServer
+// filters by the construction-time serverID.
+func TestPostgresWorkerMapServerIDHardcoded(t *testing.T) {
+	m := NewPostgresWorkerMap(testPGDB(t), "host-A")
+	m.Set("w1", ActiveWorker{AppID: "app1"})
+
+	if ids := m.WorkersForServer("host-A"); len(ids) != 1 {
+		t.Errorf("WorkersForServer(host-A) = %v, want [w1]", ids)
+	}
+	if ids := m.WorkersForServer("host-B"); len(ids) != 0 {
+		t.Errorf("WorkersForServer(host-B) = %v, want empty", ids)
+	}
+}
+
+// TestPostgresWorkerMapIdleSinceNullRoundTrip pins the Go-to-SQL
+// mapping for idle_since: Go time.Time{} (zero) ↔ SQL NULL. The Get
+// path must hand back a zero-valued IdleSince (not sql.NullTime with
+// Valid=false) so callers that check w.IdleSince.IsZero() keep working.
+func TestPostgresWorkerMapIdleSinceNullRoundTrip(t *testing.T) {
+	m := NewPostgresWorkerMap(testPGDB(t), "test-host")
+	m.Set("w1", ActiveWorker{AppID: "app1"})
+
+	w, ok := m.Get("w1")
+	if !ok {
+		t.Fatal("expected worker to exist")
+	}
+	if !w.IdleSince.IsZero() {
+		t.Errorf("IdleSince = %v, want zero value", w.IdleSince)
+	}
+}
+
+// TestPostgresWorkerMapSetUpsertPreservesAddress verifies that
+// PostgresWorkerMap.Set does not clobber the address column that
+// registry.PostgresRegistry.Set writes to the same row. The two stores
+// share the table and each must update only its own columns.
+func TestPostgresWorkerMapSetUpsertPreservesAddress(t *testing.T) {
+	db := testPGDB(t)
+	m := NewPostgresWorkerMap(db, "test-host")
+
+	// Simulate a prior Registry.Set that populated the address column.
+	if _, err := db.Exec(
+		`INSERT INTO blockyard_workers (id, address, last_heartbeat)
+		 VALUES ($1, $2, now())`,
+		"w1", "127.0.0.1:3838",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	m.Set("w1", ActiveWorker{AppID: "app1", BundleID: "b1", StartedAt: time.Now()})
+
+	// Address must still be there.
+	var addr string
+	if err := db.QueryRow(
+		`SELECT address FROM blockyard_workers WHERE id = $1`, "w1",
+	).Scan(&addr); err != nil {
+		t.Fatal(err)
+	}
+	if addr != "127.0.0.1:3838" {
+		t.Errorf("address = %q, want %q (WorkerMap.Set must not touch address)", addr, "127.0.0.1:3838")
+	}
+}


### PR DESCRIPTION
## Summary

- New `blockyard_workers` table backs both the worker registry
  (`id`→`address`) and the worker metadata map (`app_id`, `bundle_id`,
  `server_id`, `draining`, `idle_since`, `started_at`), unifying the
  two previously separate Redis stores.
- Adds `registry.PostgresRegistry` + `registry.LayeredRegistry` and
  `server.PostgresWorkerMap` + `server.LayeredWorkerMap`, following
  the same read-through / write-primary pattern as #286.
- `main.go` collapses registry/worker/session wiring into one mode
  switch — operators get a single `proxy.session_store` knob that
  drives the whole shared-state stack.
- Existing Redis-based tests keep running; the Postgres + Layered
  variants join the worker-map conformance suite and share the
  template-clone test infra that sessions introduced.
- Registry TTL semantic is preserved in Postgres via a
  `last_heartbeat` column; the existing health poller's Set-on-probe
  bump keeps a live worker fresh, stale rows are reported as gone.

Fixes #287