### PR TITLE
feat(process): postgres-primary port / uid allocators with redis cache

### DIFF
--- a/cmd/blockyard/backend_docker.go
+++ b/cmd/blockyard/backend_docker.go
@@ -5,6 +5,8 @@ package main
 import (
 	"context"
 
+	"github.com/jmoiron/sqlx"
+
 	"github.com/cynkra/blockyard/internal/backend"
 	"github.com/cynkra/blockyard/internal/backend/docker"
 	"github.com/cynkra/blockyard/internal/config"
@@ -12,7 +14,7 @@ import (
 )
 
 func init() {
-	backendFactories["docker"] = func(ctx context.Context, cfg *config.Config, _ *redisstate.Client, version string) (backend.Backend, error) {
+	backendFactories["docker"] = func(ctx context.Context, cfg *config.Config, _ *redisstate.Client, _ *sqlx.DB, version string) (backend.Backend, error) {
 		return docker.New(ctx, cfg, cfg.Storage.BundleServerPath, version)
 	}
 }

--- a/cmd/blockyard/backend_factory.go
+++ b/cmd/blockyard/backend_factory.go
@@ -4,21 +4,24 @@ import (
 	"context"
 	"sort"
 
+	"github.com/jmoiron/sqlx"
+
 	"github.com/cynkra/blockyard/internal/backend"
 	"github.com/cynkra/blockyard/internal/config"
 	"github.com/cynkra/blockyard/internal/redisstate"
 )
 
-// backendFactory constructs a Backend from the already-parsed config
-// and a (possibly nil) shared Redis client. The process backend uses
-// rc for Redis-backed allocators when non-nil and falls back to
-// in-memory allocators otherwise. The Docker backend ignores rc —
-// its Redis awareness is limited to reading the URL string from
-// cfg.Redis.URL for its preflight check.
+// backendFactory constructs a Backend from the already-parsed config,
+// a (possibly nil) shared Redis client, and the open database handle.
+// The process backend uses rc for Redis-backed allocators and database
+// for Postgres-backed allocators (#288), picking based on the
+// resolved SessionStore mode. The Docker backend ignores both rc and
+// database — its Redis awareness is limited to reading the URL string
+// from cfg.Redis.URL for its preflight check.
 //
 // version is threaded through because docker.New needs it for the
 // orchestrator's version-comparison path.
-type backendFactory func(ctx context.Context, cfg *config.Config, rc *redisstate.Client, version string) (backend.Backend, error)
+type backendFactory func(ctx context.Context, cfg *config.Config, rc *redisstate.Client, db *sqlx.DB, version string) (backend.Backend, error)
 
 // backendFactories maps [server] backend = "..." values to factories.
 // Populated by init() in the tag-gated backend_docker.go /

--- a/cmd/blockyard/backend_process.go
+++ b/cmd/blockyard/backend_process.go
@@ -5,6 +5,8 @@ package main
 import (
 	"context"
 
+	"github.com/jmoiron/sqlx"
+
 	"github.com/cynkra/blockyard/internal/backend"
 	"github.com/cynkra/blockyard/internal/backend/process"
 	"github.com/cynkra/blockyard/internal/config"
@@ -12,7 +14,7 @@ import (
 )
 
 func init() {
-	backendFactories["process"] = func(_ context.Context, cfg *config.Config, rc *redisstate.Client, _ string) (backend.Backend, error) {
-		return process.New(cfg, rc)
+	backendFactories["process"] = func(_ context.Context, cfg *config.Config, rc *redisstate.Client, db *sqlx.DB, _ string) (backend.Backend, error) {
+		return process.New(cfg, rc, db)
 	}
 }

--- a/cmd/blockyard/main.go
+++ b/cmd/blockyard/main.go
@@ -147,6 +147,16 @@ func main() {
 		defer rc.Close()
 	}
 
+	// Database init happens BEFORE backend construction for the same
+	// reason as Redis above: the process backend's Postgres-primary
+	// port / UID allocators (#288) need the *sqlx.DB at construction
+	// time. The Docker backend factory ignores the database argument.
+	database, err := db.Open(cfg.Database)
+	if err != nil {
+		slog.Error("failed to open database", "error", err)
+		os.Exit(1)
+	}
+
 	// Initialize backend via the tag-gated factory map.
 	factory, ok := backendFactories[cfg.Server.Backend]
 	if !ok {
@@ -155,17 +165,10 @@ func main() {
 			"available", availableBackends())
 		os.Exit(1)
 	}
-	be, err := factory(context.Background(), cfg, rc, version)
+	be, err := factory(context.Background(), cfg, rc, database.DB, version)
 	if err != nil {
 		slog.Error("failed to create backend",
 			"backend", cfg.Server.Backend, "error", err)
-		os.Exit(1)
-	}
-
-	// Initialize database
-	database, err := db.Open(cfg.Database)
-	if err != nil {
-		slog.Error("failed to open database", "error", err)
 		os.Exit(1)
 	}
 	// Build shared state and router. Use NewServerWithDefaultMetrics so
@@ -299,7 +302,7 @@ func main() {
 	// drives all three stores (registry, worker map, session store)
 	// because their durability requirements are identical — operators
 	// rarely want asymmetric modes.
-	mode := resolveSessionStore(cfg)
+	mode := config.ResolveSessionStoreMode(cfg)
 	registryTTL := 3 * cfg.Proxy.HealthInterval.Duration
 	idleTTL := cfg.Proxy.SessionIdleTTL.Duration
 	var pgSessions *session.PostgresStore
@@ -712,32 +715,6 @@ func randomNonceHex(n int) string {
 		return "fallback"
 	}
 	return hex.EncodeToString(b)
-}
-
-// resolveSessionStore picks the sticky-session backend. Honours an
-// explicit cfg.Proxy.SessionStore value; otherwise defaults to the
-// "best" available mode given which backends are configured.
-//
-//   - [redis] + postgres  → layered (PG primary, Redis cache). #286 target.
-//   - [redis] only        → redis. Legacy behavior.
-//   - postgres only       → postgres.
-//   - neither             → memory. Single-process only.
-func resolveSessionStore(cfg *config.Config) config.SessionStoreMode {
-	if cfg.Proxy.SessionStore != config.SessionStoreAuto {
-		return cfg.Proxy.SessionStore
-	}
-	hasRedis := cfg.Redis != nil
-	hasPG := cfg.Database.Driver == "postgres"
-	switch {
-	case hasRedis && hasPG:
-		return config.SessionStoreLayered
-	case hasRedis:
-		return config.SessionStoreRedis
-	case hasPG:
-		return config.SessionStorePostgres
-	default:
-		return config.SessionStoreMemory
-	}
 }
 
 // maskRedisPassword replaces the password in a Redis URL with "***".

--- a/internal/backend/process/allocators_conformance_test.go
+++ b/internal/backend/process/allocators_conformance_test.go
@@ -1,0 +1,514 @@
+package process
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/cynkra/blockyard/internal/redisstate"
+)
+
+// portAllocatorFactory builds a port allocator for the given hostname
+// and range. Implementations that share backing storage across hostnames
+// (Redis, Postgres, Layered) take an *allocatorBackend that pins the
+// shared resources (miniredis, *sqlx.DB) for the duration of the test.
+type portAllocatorFactory func(t *testing.T, b *allocatorBackend, hostname string, first, last int) portAllocator
+
+type uidAllocatorFactory func(t *testing.T, b *allocatorBackend, hostname string, first, last int) uidAllocator
+
+// allocatorBackend lazily holds the shared backing resources for a
+// test (one miniredis + one Postgres clone) so two allocators with
+// different hostnames coordinate via the same storage. Each subtest
+// only pays the bootstrap cost for the variants it actually uses —
+// the Memory variant touches neither, Redis-only variants skip the
+// PG clone, etc.
+type allocatorBackend struct {
+	t   *testing.T
+	rc  *redisstate.Client
+	rcM sync.Once
+	pg  *sqlx.DB
+	pgM sync.Once
+}
+
+func newAllocatorBackend(t *testing.T) *allocatorBackend {
+	t.Helper()
+	return &allocatorBackend{t: t}
+}
+
+func (b *allocatorBackend) redisClient() *redisstate.Client {
+	b.rcM.Do(func() {
+		mr := miniredis.RunT(b.t)
+		b.rc = redisstate.TestClient(b.t, mr.Addr())
+	})
+	return b.rc
+}
+
+func (b *allocatorBackend) pgDB() *sqlx.DB {
+	b.pgM.Do(func() {
+		b.pg = testPGDB(b.t)
+	})
+	return b.pg
+}
+
+// portAllocatorImplementations lists every port-allocator backend.
+// Memory-only callers can pick by name to skip peer-coexistence tests.
+func portAllocatorImplementations() map[string]portAllocatorFactory {
+	return map[string]portAllocatorFactory{
+		"Memory": func(_ *testing.T, _ *allocatorBackend, _ string, first, last int) portAllocator {
+			return newMemoryPortAllocator(first, last)
+		},
+		"Redis": func(t *testing.T, b *allocatorBackend, hostname string, first, last int) portAllocator {
+			t.Helper()
+			return newRedisPortAllocator(b.redisClient(), first, last, hostname)
+		},
+		"Postgres": func(t *testing.T, b *allocatorBackend, hostname string, first, last int) portAllocator {
+			t.Helper()
+			return newPostgresPortAllocator(b.pgDB(), first, last, hostname)
+		},
+		"Layered": func(t *testing.T, b *allocatorBackend, hostname string, first, last int) portAllocator {
+			t.Helper()
+			pg := newPostgresPortAllocator(b.pgDB(), first, last, hostname)
+			rd := newRedisPortAllocator(b.redisClient(), first, last, hostname)
+			return newLayeredPortAllocator(pg, rd)
+		},
+	}
+}
+
+func uidAllocatorImplementations() map[string]uidAllocatorFactory {
+	return map[string]uidAllocatorFactory{
+		"Memory": func(_ *testing.T, _ *allocatorBackend, _ string, first, last int) uidAllocator {
+			return newMemoryUIDAllocator(first, last)
+		},
+		"Redis": func(t *testing.T, b *allocatorBackend, hostname string, first, last int) uidAllocator {
+			t.Helper()
+			return newRedisUIDAllocator(b.redisClient(), first, last, hostname)
+		},
+		"Postgres": func(t *testing.T, b *allocatorBackend, hostname string, first, last int) uidAllocator {
+			t.Helper()
+			return newPostgresUIDAllocator(b.pgDB(), first, last, hostname)
+		},
+		"Layered": func(t *testing.T, b *allocatorBackend, hostname string, first, last int) uidAllocator {
+			t.Helper()
+			pg := newPostgresUIDAllocator(b.pgDB(), first, last, hostname)
+			rd := newRedisUIDAllocator(b.redisClient(), first, last, hostname)
+			return newLayeredUIDAllocator(pg, rd)
+		},
+	}
+}
+
+// peerCoexistenceFactories returns only the implementations that share
+// backing storage across hostnames. Memory has independent in-process
+// bitsets per allocator instance and cannot coordinate.
+func peerCoexistenceFactories[F any](impls map[string]F) map[string]F {
+	out := make(map[string]F, len(impls))
+	for name, f := range impls {
+		if name == "Memory" {
+			continue
+		}
+		out[name] = f
+	}
+	return out
+}
+
+// ── Port allocator conformance ──
+
+func TestPortAllocatorConformance_BasicReserveRelease(t *testing.T) {
+	for name, factory := range portAllocatorImplementations() {
+		t.Run(name, func(t *testing.T) {
+			b := newAllocatorBackend(t)
+			base := findFreePortRange(t, 3)
+			a := factory(t, b, "host-a", base, base+2)
+
+			p1, ln1, err := a.Reserve()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer ln1.Close()
+			p2, ln2, err := a.Reserve()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer ln2.Close()
+			p3, ln3, err := a.Reserve()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer ln3.Close()
+
+			if p1 == p2 || p2 == p3 || p1 == p3 {
+				t.Errorf("duplicate ports: %d, %d, %d", p1, p2, p3)
+			}
+			for _, p := range []int{p1, p2, p3} {
+				if p < base || p > base+2 {
+					t.Errorf("port %d out of range [%d..%d]", p, base, base+2)
+				}
+			}
+
+			if _, _, err := a.Reserve(); err == nil {
+				t.Error("expected error on exhausted range")
+			}
+
+			ln2.Close()
+			a.Release(p2)
+			got, ln, err := a.Reserve()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer ln.Close()
+			if got != p2 {
+				t.Errorf("re-alloc got %d, want %d", got, p2)
+			}
+		})
+	}
+}
+
+func TestPortAllocatorConformance_ConcurrentDistinct(t *testing.T) {
+	for name, factory := range portAllocatorImplementations() {
+		t.Run(name, func(t *testing.T) {
+			b := newAllocatorBackend(t)
+			base := findFreePortRange(t, 50)
+			a := factory(t, b, "host-a", base, base+49)
+
+			var wg sync.WaitGroup
+			type result struct {
+				port int
+				ln   net.Listener
+			}
+			results := make(chan result, 50)
+			for range 50 {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					p, ln, err := a.Reserve()
+					if err == nil {
+						results <- result{p, ln}
+					}
+				}()
+			}
+			wg.Wait()
+			close(results)
+
+			seen := make(map[int]bool)
+			for r := range results {
+				if seen[r.port] {
+					t.Errorf("duplicate port: %d", r.port)
+				}
+				seen[r.port] = true
+				r.ln.Close()
+			}
+			if len(seen) == 0 {
+				t.Error("expected at least some successful reservations")
+			}
+		})
+	}
+}
+
+func TestPortAllocatorConformance_KernelProbeSkipsExternallyBound(t *testing.T) {
+	for name, factory := range portAllocatorImplementations() {
+		t.Run(name, func(t *testing.T) {
+			pre, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer pre.Close()
+			boundPort := pre.Addr().(*net.TCPAddr).Port
+
+			b := newAllocatorBackend(t)
+			a := factory(t, b, "host-a", boundPort, boundPort+2)
+
+			got, ln, err := a.Reserve()
+			if err != nil {
+				t.Fatalf("Reserve: %v", err)
+			}
+			defer ln.Close()
+			if got == boundPort {
+				t.Errorf("Reserve returned the externally-bound port %d", got)
+			}
+			if got < boundPort || got > boundPort+2 {
+				t.Errorf("Reserve returned %d, outside range", got)
+			}
+		})
+	}
+}
+
+func TestPortAllocatorConformance_PeerCoexistence(t *testing.T) {
+	for name, factory := range peerCoexistenceFactories(portAllocatorImplementations()) {
+		t.Run(name, func(t *testing.T) {
+			b := newAllocatorBackend(t)
+			base := findFreePortRange(t, 10)
+			host1 := factory(t, b, "host-1", base, base+9)
+			host2 := factory(t, b, "host-2", base, base+9)
+
+			var held []net.Listener
+			t.Cleanup(func() {
+				for _, ln := range held {
+					if ln != nil {
+						ln.Close()
+					}
+				}
+			})
+
+			for range 5 {
+				_, ln, err := host1.Reserve()
+				if err != nil {
+					t.Fatal(err)
+				}
+				held = append(held, ln)
+			}
+			for range 5 {
+				_, ln, err := host2.Reserve()
+				if err != nil {
+					t.Fatal(err)
+				}
+				held = append(held, ln)
+			}
+			if _, _, err := host1.Reserve(); err == nil {
+				t.Error("expected exhaustion after 10 allocs across peers")
+			}
+		})
+	}
+}
+
+func TestPortAllocatorConformance_CleanupOwnedOrphans(t *testing.T) {
+	for name, factory := range peerCoexistenceFactories(portAllocatorImplementations()) {
+		t.Run(name, func(t *testing.T) {
+			b := newAllocatorBackend(t)
+			base := findFreePortRange(t, 6)
+			host1 := factory(t, b, "host-1", base, base+5)
+			host2 := factory(t, b, "host-2", base, base+5)
+
+			cleaner1, ok1 := host1.(interface {
+				CleanupOwnedOrphans(ctx context.Context) error
+			})
+			if !ok1 {
+				t.Skip("backend does not support CleanupOwnedOrphans")
+			}
+
+			var held []net.Listener
+			t.Cleanup(func() {
+				for _, ln := range held {
+					if ln != nil {
+						ln.Close()
+					}
+				}
+			})
+
+			for range 3 {
+				_, ln, err := host1.Reserve()
+				if err != nil {
+					t.Fatal(err)
+				}
+				held = append(held, ln)
+			}
+			for range 3 {
+				_, ln, err := host2.Reserve()
+				if err != nil {
+					t.Fatal(err)
+				}
+				held = append(held, ln)
+			}
+
+			// Release host1's listeners so the kernel frees them; cleanup
+			// then drops host1's claims from the shared store.
+			for i, ln := range held[:3] {
+				ln.Close()
+				held[i] = nil
+			}
+			if err := cleaner1.CleanupOwnedOrphans(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+
+			fresh := factory(t, b, "host-1", base, base+5)
+			for range 3 {
+				_, ln, err := fresh.Reserve()
+				if err != nil {
+					t.Fatal(err)
+				}
+				held = append(held, ln)
+			}
+			if _, _, err := fresh.Reserve(); err == nil {
+				t.Error("expected exhaustion — host2's 3 entries should still be held")
+			}
+		})
+	}
+}
+
+// ── UID allocator conformance ──
+
+func TestUIDAllocatorConformance_BasicAllocRelease(t *testing.T) {
+	for name, factory := range uidAllocatorImplementations() {
+		t.Run(name, func(t *testing.T) {
+			b := newAllocatorBackend(t)
+			a := factory(t, b, "host-a", 60000, 60002)
+
+			u1, err := a.Alloc()
+			if err != nil {
+				t.Fatal(err)
+			}
+			u2, err := a.Alloc()
+			if err != nil {
+				t.Fatal(err)
+			}
+			u3, err := a.Alloc()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if u1 != 60000 || u2 != 60001 || u3 != 60002 {
+				t.Errorf("allocated UIDs = %d, %d, %d; want 60000, 60001, 60002", u1, u2, u3)
+			}
+			if _, err := a.Alloc(); err == nil {
+				t.Error("expected exhaustion error")
+			}
+			a.Release(60001)
+			next, err := a.Alloc()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if next != 60001 {
+				t.Errorf("re-allocated UID = %d, want 60001", next)
+			}
+		})
+	}
+}
+
+func TestUIDAllocatorConformance_ConcurrentDistinct(t *testing.T) {
+	for name, factory := range uidAllocatorImplementations() {
+		t.Run(name, func(t *testing.T) {
+			b := newAllocatorBackend(t)
+			a := factory(t, b, "host-a", 60000, 60049)
+
+			var wg sync.WaitGroup
+			results := make(chan int, 50)
+			for range 50 {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					uid, err := a.Alloc()
+					if err == nil {
+						results <- uid
+					}
+				}()
+			}
+			wg.Wait()
+			close(results)
+
+			seen := make(map[int]bool)
+			for uid := range results {
+				if seen[uid] {
+					t.Errorf("duplicate UID: %d", uid)
+				}
+				seen[uid] = true
+			}
+			if len(seen) != 50 {
+				t.Errorf("expected 50 unique UIDs, got %d", len(seen))
+			}
+		})
+	}
+}
+
+func TestUIDAllocatorConformance_PeerCoexistence(t *testing.T) {
+	for name, factory := range peerCoexistenceFactories(uidAllocatorImplementations()) {
+		t.Run(name, func(t *testing.T) {
+			b := newAllocatorBackend(t)
+			host1 := factory(t, b, "host-1", 60000, 60009)
+			host2 := factory(t, b, "host-2", 60000, 60009)
+
+			var allocated []int
+			for range 5 {
+				u, err := host1.Alloc()
+				if err != nil {
+					t.Fatal(err)
+				}
+				allocated = append(allocated, u)
+			}
+			for range 5 {
+				u, err := host2.Alloc()
+				if err != nil {
+					t.Fatal(err)
+				}
+				allocated = append(allocated, u)
+			}
+			if _, err := host1.Alloc(); err == nil {
+				t.Error("expected exhaustion after 10 allocs across peers")
+			}
+			seen := make(map[int]bool)
+			for _, u := range allocated {
+				if seen[u] {
+					t.Errorf("duplicate UID %d across peers", u)
+				}
+				seen[u] = true
+			}
+		})
+	}
+}
+
+func TestUIDAllocatorConformance_ReleaseOwnership(t *testing.T) {
+	for name, factory := range peerCoexistenceFactories(uidAllocatorImplementations()) {
+		t.Run(name, func(t *testing.T) {
+			b := newAllocatorBackend(t)
+			host1 := factory(t, b, "host-1", 60000, 60002)
+			host2 := factory(t, b, "host-2", 60000, 60002)
+
+			u1, err := host1.Alloc()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// host2 must not be able to release host1's UID.
+			host2.Release(u1)
+			u2, err := host1.Alloc()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if u2 == u1 {
+				t.Errorf("host2's release stole host1's UID %d", u1)
+			}
+		})
+	}
+}
+
+func TestUIDAllocatorConformance_CleanupOwnedOrphans(t *testing.T) {
+	for name, factory := range peerCoexistenceFactories(uidAllocatorImplementations()) {
+		t.Run(name, func(t *testing.T) {
+			b := newAllocatorBackend(t)
+			host1 := factory(t, b, "host-1", 60000, 60005)
+			host2 := factory(t, b, "host-2", 60000, 60005)
+
+			cleaner1, ok1 := host1.(interface {
+				CleanupOwnedOrphans(ctx context.Context) error
+			})
+			if !ok1 {
+				t.Skip("backend does not support CleanupOwnedOrphans")
+			}
+
+			for range 3 {
+				if _, err := host1.Alloc(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			for range 3 {
+				if _, err := host2.Alloc(); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if err := cleaner1.CleanupOwnedOrphans(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+
+			fresh := factory(t, b, "host-1", 60000, 60005)
+			for range 3 {
+				if _, err := fresh.Alloc(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if _, err := fresh.Alloc(); err == nil {
+				t.Error("expected exhaustion — host2's 3 entries should still be held")
+			}
+		})
+	}
+}

--- a/internal/backend/process/ports.go
+++ b/internal/backend/process/ports.go
@@ -8,11 +8,13 @@ import (
 )
 
 // portAllocator manages a fixed range of localhost ports for workers.
-// Two implementations exist: memoryPortAllocator (used when Redis is
-// not configured; single-node only) and redisPortAllocator (used when
-// Redis is configured; coordinates across blockyard peers during
-// rolling-update overlap). Both share the same interface so the rest
-// of the backend does not care which is live.
+// Four implementations exist, picked by config.ResolveSessionStoreMode:
+// memoryPortAllocator (single-node, no shared state), redisPortAllocator
+// (peer coordination via SETNX, fails open on Redis blip),
+// postgresPortAllocator (peer coordination via INSERT … ON CONFLICT,
+// the new source-of-truth path from #288), and layeredPortAllocator
+// (PG primary + Redis mirror for cheaper InUse reads). All share the
+// same interface so the rest of the backend does not care which is live.
 type portAllocator interface {
 	// Reserve picks a free port, holds a listener on it, and returns
 	// (port, listener, nil). The caller MUST close the listener

--- a/internal/backend/process/ports_layered.go
+++ b/internal/backend/process/ports_layered.go
@@ -1,0 +1,60 @@
+package process
+
+import (
+	"context"
+	"fmt"
+	"net"
+)
+
+// layeredPortAllocator pairs a Postgres-primary allocator with a Redis
+// mirror (see #288, parent #262). Postgres is the cross-peer mutex —
+// the unique constraint on blockyard_ports is what prevents two peers
+// from claiming the same slot. Redis is a best-effort mirror so that
+// peers querying InUse hit the cache instead of doing a Postgres scan.
+type layeredPortAllocator struct {
+	primary *postgresPortAllocator
+	cache   *redisPortAllocator
+}
+
+func newLayeredPortAllocator(primary *postgresPortAllocator, cache *redisPortAllocator) *layeredPortAllocator {
+	return &layeredPortAllocator{primary: primary, cache: cache}
+}
+
+// Reserve claims via Postgres (the mutex), then mirrors the claim to
+// Redis. On a kernel-bound retry inside the primary's Reserve loop,
+// the primary handles the DB cleanup itself — the cache only ever
+// sees successfully-bound ports.
+func (p *layeredPortAllocator) Reserve() (int, net.Listener, error) {
+	port, ln, err := p.primary.Reserve()
+	if err != nil {
+		return 0, nil, err
+	}
+	p.cache.mirrorClaim(port)
+	return port, ln, nil
+}
+
+func (p *layeredPortAllocator) Release(port int) {
+	p.primary.Release(port)
+	p.cache.Release(port)
+}
+
+// InUse reports the cache's count. Both layers report counts owned by
+// the local hostname; in steady state they agree, and InUse is a
+// diagnostic rather than load-bearing for correctness, so a transient
+// cache miss surfaces honestly as 0 rather than masquerading as a
+// primary read.
+func (p *layeredPortAllocator) InUse() int {
+	return p.cache.InUse()
+}
+
+// CleanupOwnedOrphans cleans both layers — primary first (correctness),
+// then cache (mirror).
+func (p *layeredPortAllocator) CleanupOwnedOrphans(ctx context.Context) error {
+	if err := p.primary.CleanupOwnedOrphans(ctx); err != nil {
+		return fmt.Errorf("primary: %w", err)
+	}
+	if err := p.cache.CleanupOwnedOrphans(ctx); err != nil {
+		return fmt.Errorf("cache: %w", err)
+	}
+	return nil
+}

--- a/internal/backend/process/ports_postgres.go
+++ b/internal/backend/process/ports_postgres.go
@@ -1,0 +1,179 @@
+package process
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// postgresPortAllocator coordinates port allocation across blockyard
+// peers via the blockyard_ports table (see #288, parent #262).
+//
+// The Redis variant fails open on a Redis blip — a transient outage
+// during allocation can hand out a port already claimed by another
+// peer, or falsely report exhaustion. Moving the source of truth into
+// Postgres makes allocation correct under Redis restart.
+//
+// Each row is (port, owner). Owner is the hostname (matching the Redis
+// SETNX value), so CleanupOwnedOrphans at startup can reclaim slots a
+// previous crashed instance on the same host left behind.
+type postgresPortAllocator struct {
+	db       *sqlx.DB
+	first    int
+	last     int
+	hostname string
+}
+
+func newPostgresPortAllocator(db *sqlx.DB, first, last int, hostname string) *postgresPortAllocator {
+	return &postgresPortAllocator{
+		db:       db,
+		first:    first,
+		last:     last,
+		hostname: hostname,
+	}
+}
+
+// Reserve picks a free port by inserting it into blockyard_ports, then
+// attempts to bind a listener. On bind failure (a non-blockyard host
+// process holds the port), the row is deleted and the scan advances
+// past the failed index — matching the Redis variant's kernel-probe
+// retry loop.
+//
+// The CTE INSERT is atomic: if two peers race for the same lowest free
+// port, only one row inserts; the other returns no rows. The race
+// branch re-probes for the next free slot rather than treating the
+// no-row return as exhaustion.
+func (p *postgresPortAllocator) Reserve() (int, net.Listener, error) {
+	skipFrom := p.first
+	for {
+		if skipFrom > p.last {
+			return 0, nil, errors.New("process backend: no free ports in range")
+		}
+		port, err := p.tryClaim(skipFrom)
+		if err != nil {
+			return 0, nil, fmt.Errorf("postgres port alloc: %w", err)
+		}
+		if port < 0 {
+			next, err := p.findNextFree(skipFrom)
+			if err != nil {
+				return 0, nil, fmt.Errorf("postgres port probe: %w", err)
+			}
+			if next < 0 {
+				return 0, nil, errors.New("process backend: no free ports in range")
+			}
+			skipFrom = next
+			continue
+		}
+		ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		if err == nil {
+			return port, ln, nil
+		}
+		// Kernel says this port is externally busy. Drop the DB claim so
+		// it can be re-used after the external holder releases, and
+		// advance skip_from so the same index isn't re-probed.
+		p.deleteRow(port)
+		skipFrom = port + 1
+	}
+}
+
+// Release returns a port to the pool via an ownership-checked DELETE.
+// The owner guard prevents accidentally deleting a peer's row.
+func (p *postgresPortAllocator) Release(port int) {
+	if port < p.first || port > p.last {
+		return
+	}
+	p.deleteRow(port)
+}
+
+// InUse counts entries owned by this host. Used by tests and diagnostic
+// endpoints; not load-bearing for correctness.
+func (p *postgresPortAllocator) InUse() int {
+	ctx := context.Background()
+	var n int
+	if err := p.db.QueryRowxContext(ctx,
+		`SELECT COUNT(*) FROM blockyard_ports WHERE owner = $1`,
+		p.hostname,
+	).Scan(&n); err != nil {
+		slog.Error("postgres port in-use", "error", err)
+		return 0
+	}
+	return n
+}
+
+// CleanupOwnedOrphans deletes every blockyard_ports row owned by this
+// hostname. Called at startup to reclaim slots a previous crashed
+// instance on the same host left behind. Workers from the previous run
+// are dead (Pdeathsig killed them with the server), so the deletion is
+// unconditional for owned rows.
+func (p *postgresPortAllocator) CleanupOwnedOrphans(ctx context.Context) error {
+	if _, err := p.db.ExecContext(ctx,
+		`DELETE FROM blockyard_ports WHERE owner = $1`, p.hostname,
+	); err != nil {
+		return fmt.Errorf("postgres port cleanup: %w", err)
+	}
+	return nil
+}
+
+// tryClaim attempts to insert the lowest free port in [skipFrom, last].
+// Returns the claimed port, or -1 if no row was inserted (either
+// exhaustion or a race lost to a concurrent INSERT).
+func (p *postgresPortAllocator) tryClaim(skipFrom int) (int, error) {
+	ctx := context.Background()
+	var port int
+	err := p.db.QueryRowxContext(ctx, `
+		INSERT INTO blockyard_ports (port, owner)
+		SELECT p, $3
+		FROM generate_series($1::int, $2::int) AS p
+		WHERE NOT EXISTS (SELECT 1 FROM blockyard_ports b WHERE b.port = p)
+		ORDER BY p
+		LIMIT 1
+		ON CONFLICT (port) DO NOTHING
+		RETURNING port`,
+		skipFrom, p.last, p.hostname,
+	).Scan(&port)
+	if errors.Is(err, sql.ErrNoRows) {
+		return -1, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return port, nil
+}
+
+// findNextFree returns the lowest unclaimed port in [from, last], or -1
+// if the range has no free slots. Used to distinguish "no rows" =
+// exhaustion from "no rows" = race after tryClaim returns -1.
+func (p *postgresPortAllocator) findNextFree(from int) (int, error) {
+	ctx := context.Background()
+	var port int
+	err := p.db.QueryRowxContext(ctx, `
+		SELECT p
+		FROM generate_series($1::int, $2::int) AS p
+		WHERE NOT EXISTS (SELECT 1 FROM blockyard_ports b WHERE b.port = p)
+		ORDER BY p
+		LIMIT 1`,
+		from, p.last,
+	).Scan(&port)
+	if errors.Is(err, sql.ErrNoRows) {
+		return -1, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return port, nil
+}
+
+func (p *postgresPortAllocator) deleteRow(port int) {
+	ctx := context.Background()
+	if _, err := p.db.ExecContext(ctx,
+		`DELETE FROM blockyard_ports WHERE port = $1 AND owner = $2`,
+		port, p.hostname,
+	); err != nil {
+		slog.Error("postgres port delete", "port", port, "error", err)
+	}
+}

--- a/internal/backend/process/ports_redis.go
+++ b/internal/backend/process/ports_redis.go
@@ -158,6 +158,20 @@ func (p *redisPortAllocator) luaAlloc(skipFrom int) (int, error) {
 	return res, nil
 }
 
+// mirrorClaim writes the claim key unconditionally for a specific
+// port. Used by the layered allocator after Postgres has already
+// arbitrated ownership — no SETNX needed because the primary mutex
+// guarantees only one peer reaches this point with this port. Errors
+// are logged here (matching the rest of this store's best-effort
+// pattern) so callers don't have to repeat the slog dance.
+func (p *redisPortAllocator) mirrorClaim(port int) {
+	ctx := context.Background()
+	key := p.client.Prefix() + "port:" + strconv.Itoa(port)
+	if err := p.client.Redis().Set(ctx, key, p.hostname, 0).Err(); err != nil {
+		slog.Warn("redis port mirror", "port", port, "error", err)
+	}
+}
+
 func (p *redisPortAllocator) luaRelease(port int) error {
 	ctx := context.Background()
 	key := p.client.Prefix() + "port:" + strconv.Itoa(port)

--- a/internal/backend/process/postgres_test.go
+++ b/internal/backend/process/postgres_test.go
@@ -1,0 +1,123 @@
+package process
+
+import (
+	"database/sql"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/cynkra/blockyard/internal/config"
+	"github.com/cynkra/blockyard/internal/db"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// pgTestBaseURL is the admin URL for the Postgres instance hosting the
+// per-test databases. Empty when tests should skip.
+var pgTestBaseURL string
+
+// pgAllocatorsTemplate is the migrated template database. Per-test
+// databases clone from it (CREATE DATABASE … TEMPLATE) — orders of
+// magnitude faster than re-running migrations. Own name (not reused
+// from internal/db, internal/session, internal/registry, internal/server)
+// so the test binaries don't collide when CI runs them concurrently.
+const pgAllocatorsTemplate = "blockyard_allocators_test_template"
+
+func TestMain(m *testing.M) {
+	pgTestBaseURL = os.Getenv("BLOCKYARD_TEST_POSTGRES_URL")
+	if pgTestBaseURL != "" {
+		if err := setupAllocatorsTemplate(pgTestBaseURL); err != nil {
+			fmt.Fprintf(os.Stderr, "process: allocators template bootstrap: %v\n", err)
+			os.Exit(1)
+		}
+		defer teardownAllocatorsTemplate(pgTestBaseURL)
+	}
+	os.Exit(m.Run())
+}
+
+func setupAllocatorsTemplate(base string) error {
+	admin, err := sql.Open("pgx", base)
+	if err != nil {
+		return err
+	}
+	defer admin.Close()
+
+	admin.Exec("DROP DATABASE IF EXISTS " + pgAllocatorsTemplate)
+	if _, err := admin.Exec("CREATE DATABASE " + pgAllocatorsTemplate); err != nil {
+		return fmt.Errorf("create template: %w", err)
+	}
+
+	tplURL := replacePGName(base, pgAllocatorsTemplate)
+	tpl, err := db.Open(config.DatabaseConfig{Driver: "postgres", URL: tplURL})
+	if err != nil {
+		return fmt.Errorf("migrate template: %w", err)
+	}
+	tpl.Close()
+
+	admin.Exec("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '" + pgAllocatorsTemplate + "'")
+	admin.Exec("ALTER DATABASE " + pgAllocatorsTemplate + " WITH ALLOW_CONNECTIONS = false")
+	return nil
+}
+
+func teardownAllocatorsTemplate(base string) {
+	admin, err := sql.Open("pgx", base)
+	if err != nil {
+		return
+	}
+	defer admin.Close()
+	admin.Exec("ALTER DATABASE " + pgAllocatorsTemplate + " WITH ALLOW_CONNECTIONS = true")
+	admin.Exec("DROP DATABASE IF EXISTS " + pgAllocatorsTemplate)
+}
+
+// testPGDB clones the pre-migrated template and returns a fresh
+// *sqlx.DB pointing at it. Registers a t.Cleanup that drops the clone
+// when the test exits.
+func testPGDB(t *testing.T) *sqlx.DB {
+	t.Helper()
+	if pgTestBaseURL == "" {
+		t.Skip("BLOCKYARD_TEST_POSTGRES_URL not set; skipping Postgres allocator tests")
+	}
+
+	dbName := "alloc_" + strings.ReplaceAll(uuid.New().String(), "-", "")[:20]
+
+	admin, err := sql.Open("pgx", pgTestBaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admin.Exec("CREATE DATABASE " + dbName + " TEMPLATE " + pgAllocatorsTemplate); err != nil {
+		admin.Close()
+		t.Fatal(err)
+	}
+	admin.Close()
+
+	testURL := replacePGName(pgTestBaseURL, dbName)
+	rawDB, err := sqlx.Open("pgx", testURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawDB.SetMaxOpenConns(5)
+
+	t.Cleanup(func() {
+		rawDB.Close()
+		cleanup, cErr := sql.Open("pgx", pgTestBaseURL)
+		if cErr == nil {
+			cleanup.Exec("DROP DATABASE IF EXISTS " + dbName)
+			cleanup.Close()
+		}
+	})
+	return rawDB
+}
+
+func replacePGName(raw, name string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	u.Path = "/" + name
+	return u.String()
+}

--- a/internal/backend/process/process.go
+++ b/internal/backend/process/process.go
@@ -18,6 +18,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/jmoiron/sqlx"
+
 	"github.com/cynkra/blockyard/internal/backend"
 	"github.com/cynkra/blockyard/internal/config"
 	"github.com/cynkra/blockyard/internal/preflight"
@@ -63,13 +65,15 @@ type ProcessBackend struct {
 // the egress probe and the server-level resource-limit fields for
 // the warning check.
 //
-// When rc is non-nil the backend uses Redis-backed port and UID
-// allocators to coordinate with concurrent peers during rolling-
-// update overlap. When rc is nil (single-node deployment without
-// [redis]) it falls back to in-memory bitset allocators, which are
-// correct because without the cutover window there are no cross-
-// server collisions.
-func New(fullCfg *config.Config, rc *redisstate.Client) (*ProcessBackend, error) {
+// rc and db are the shared connection pools opened by main.go before
+// the backend factory runs. The allocator implementation is picked by
+// config.ResolveSessionStoreMode(cfg) — the same selector that drives
+// session, registry, and worker-map storage — so a deployment that
+// asks for Postgres-primary sessions also gets Postgres-primary
+// allocators. The allocator path is the only place this backend touches
+// rc/db; both can be nil in test/single-process configurations and the
+// memory allocators take over.
+func New(fullCfg *config.Config, rc *redisstate.Client, db *sqlx.DB) (*ProcessBackend, error) {
 	cfg := fullCfg.Process
 	if cfg == nil {
 		return nil, fmt.Errorf("process backend: [process] config section is required")
@@ -82,18 +86,7 @@ func New(fullCfg *config.Config, rc *redisstate.Client) (*ProcessBackend, error)
 		return nil, err
 	}
 
-	var (
-		ports portAllocator
-		uids  uidAllocator
-	)
-	if rc != nil {
-		hostname, _ := os.Hostname()
-		ports = newRedisPortAllocator(rc, cfg.PortRangeStart, cfg.PortRangeEnd, hostname)
-		uids = newRedisUIDAllocator(rc, cfg.WorkerUIDStart, cfg.WorkerUIDEnd, hostname)
-	} else {
-		ports = newMemoryPortAllocator(cfg.PortRangeStart, cfg.PortRangeEnd)
-		uids = newMemoryUIDAllocator(cfg.WorkerUIDStart, cfg.WorkerUIDEnd)
-	}
+	ports, uids := selectAllocators(fullCfg, rc, db)
 
 	return &ProcessBackend{
 		cfg:     cfg,
@@ -102,6 +95,39 @@ func New(fullCfg *config.Config, rc *redisstate.Client) (*ProcessBackend, error)
 		uids:    uids,
 		workers: make(map[string]*workerProc),
 	}, nil
+}
+
+// selectAllocators returns the allocator pair appropriate for the
+// resolved SessionStore mode (#288, parent #262). Postgres is the new
+// source-of-truth path; Redis stays available as a standalone or as a
+// best-effort cache layer in front of Postgres. The Memory fallback
+// covers tests and single-process deployments without [redis] or
+// postgres.
+func selectAllocators(fullCfg *config.Config, rc *redisstate.Client, db *sqlx.DB) (portAllocator, uidAllocator) {
+	pCfg := fullCfg.Process
+	portFirst, portLast := pCfg.PortRangeStart, pCfg.PortRangeEnd
+	uidFirst, uidLast := pCfg.WorkerUIDStart, pCfg.WorkerUIDEnd
+	hostname, _ := os.Hostname()
+	switch config.ResolveSessionStoreMode(fullCfg) {
+	case config.SessionStoreRedis:
+		return newRedisPortAllocator(rc, portFirst, portLast, hostname),
+			newRedisUIDAllocator(rc, uidFirst, uidLast, hostname)
+	case config.SessionStorePostgres:
+		return newPostgresPortAllocator(db, portFirst, portLast, hostname),
+			newPostgresUIDAllocator(db, uidFirst, uidLast, hostname)
+	case config.SessionStoreLayered:
+		return newLayeredPortAllocator(
+				newPostgresPortAllocator(db, portFirst, portLast, hostname),
+				newRedisPortAllocator(rc, portFirst, portLast, hostname),
+			),
+			newLayeredUIDAllocator(
+				newPostgresUIDAllocator(db, uidFirst, uidLast, hostname),
+				newRedisUIDAllocator(rc, uidFirst, uidLast, hostname),
+			)
+	default:
+		return newMemoryPortAllocator(portFirst, portLast),
+			newMemoryUIDAllocator(uidFirst, uidLast)
+	}
 }
 
 // ensureBundleMountPoint guarantees that bwrap will be able to bind

--- a/internal/backend/process/process_integration_test.go
+++ b/internal/backend/process/process_integration_test.go
@@ -174,7 +174,7 @@ func TestSpawnAndStop(t *testing.T) {
 			WorkerGID:      65534,
 		},
 	}
-	be, err := process.New(cfg, nil)
+	be, err := process.New(cfg, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,7 +230,7 @@ func TestWorkerResourceUsageUnknownWorker(t *testing.T) {
 			WorkerGID:      65534,
 		},
 	}
-	be, err := process.New(cfg, nil)
+	be, err := process.New(cfg, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -260,7 +260,7 @@ func TestWorkerResourceUsageLiveWorker(t *testing.T) {
 			WorkerGID:      65534,
 		},
 	}
-	be, err := process.New(cfg, nil)
+	be, err := process.New(cfg, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,7 +310,7 @@ func TestUpdateResourcesNotSupported(t *testing.T) {
 			WorkerGID:      65534,
 		},
 	}
-	be, err := process.New(cfg, nil)
+	be, err := process.New(cfg, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -352,7 +352,7 @@ func TestRSmokeBoot(t *testing.T) {
 			WorkerGID:      65534,
 		},
 	}
-	be, err := process.New(cfg, nil)
+	be, err := process.New(cfg, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/process/process_unit_test.go
+++ b/internal/backend/process/process_unit_test.go
@@ -42,7 +42,7 @@ func newFakeBackend(t *testing.T) *ProcessBackend {
 }
 
 func TestNewRequiresProcessSection(t *testing.T) {
-	_, err := New(&config.Config{}, nil)
+	_, err := New(&config.Config{}, nil, nil)
 	if err == nil {
 		t.Fatal("expected error when Process config is nil")
 	}
@@ -63,7 +63,7 @@ func TestNewRejectsMissingBwrap(t *testing.T) {
 			WorkerGID:      65534,
 		},
 	}
-	_, err := New(cfg, nil)
+	_, err := New(cfg, nil, nil)
 	if err == nil {
 		t.Fatal("expected error when bwrap path does not exist")
 	}
@@ -87,7 +87,7 @@ func TestNewSuccessPath(t *testing.T) {
 			WorkerGID:      65534,
 		},
 	}
-	b, err := New(cfg, nil)
+	b, err := New(cfg, nil, nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestNewRejectsUnreachableBundleMountPoint(t *testing.T) {
 			WorkerGID:      65534,
 		},
 	}
-	if _, err := New(cfg, nil); err == nil {
+	if _, err := New(cfg, nil, nil); err == nil {
 		t.Fatal("expected error from unreachable bundle mount point")
 	}
 }

--- a/internal/backend/process/uids.go
+++ b/internal/backend/process/uids.go
@@ -6,10 +6,11 @@ import (
 	"sync"
 )
 
-// uidAllocator manages a fixed range of host UIDs for workers. Two
-// implementations exist: memoryUIDAllocator (used when Redis is not
-// configured; single-node only) and redisUIDAllocator (used when
-// Redis is configured; coordinates across blockyard peers). Both
+// uidAllocator manages a fixed range of host UIDs for workers. Four
+// implementations exist, picked by config.ResolveSessionStoreMode:
+// memoryUIDAllocator (single-node), redisUIDAllocator (SETNX),
+// postgresUIDAllocator (INSERT … ON CONFLICT, source of truth from
+// #288), and layeredUIDAllocator (PG primary + Redis mirror). All
 // share the same interface so the rest of the backend does not care
 // which is live.
 type uidAllocator interface {

--- a/internal/backend/process/uids_layered.go
+++ b/internal/backend/process/uids_layered.go
@@ -1,0 +1,47 @@
+package process
+
+import (
+	"context"
+	"fmt"
+)
+
+// layeredUIDAllocator pairs a Postgres-primary allocator with a Redis
+// mirror (see #288, parent #262). See ports_layered.go for the
+// reasoning — the structure is identical, just simpler because UIDs
+// have no kernel-probe analog.
+type layeredUIDAllocator struct {
+	primary *postgresUIDAllocator
+	cache   *redisUIDAllocator
+}
+
+func newLayeredUIDAllocator(primary *postgresUIDAllocator, cache *redisUIDAllocator) *layeredUIDAllocator {
+	return &layeredUIDAllocator{primary: primary, cache: cache}
+}
+
+func (u *layeredUIDAllocator) Alloc() (int, error) {
+	uid, err := u.primary.Alloc()
+	if err != nil {
+		return 0, err
+	}
+	u.cache.mirrorClaim(uid)
+	return uid, nil
+}
+
+func (u *layeredUIDAllocator) Release(uid int) {
+	u.primary.Release(uid)
+	u.cache.Release(uid)
+}
+
+func (u *layeredUIDAllocator) InUse() int {
+	return u.cache.InUse()
+}
+
+func (u *layeredUIDAllocator) CleanupOwnedOrphans(ctx context.Context) error {
+	if err := u.primary.CleanupOwnedOrphans(ctx); err != nil {
+		return fmt.Errorf("primary: %w", err)
+	}
+	if err := u.cache.CleanupOwnedOrphans(ctx); err != nil {
+		return fmt.Errorf("cache: %w", err)
+	}
+	return nil
+}

--- a/internal/backend/process/uids_postgres.go
+++ b/internal/backend/process/uids_postgres.go
@@ -1,0 +1,146 @@
+package process
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// postgresUIDAllocator coordinates UID allocation across blockyard
+// peers via the blockyard_uids table (see #288, parent #262). Same
+// pattern as postgresPortAllocator but simpler: UIDs have no kernel-
+// side probe analogous to net.Listen, so the Alloc path is straight-
+// line — no kernel-bound retry, no tryClaim/probe distinction needed
+// because a no-row return from the INSERT is always either exhaustion
+// or a race (re-probed via findNextFree).
+type postgresUIDAllocator struct {
+	db       *sqlx.DB
+	first    int
+	last     int
+	hostname string
+}
+
+func newPostgresUIDAllocator(db *sqlx.DB, first, last int, hostname string) *postgresUIDAllocator {
+	return &postgresUIDAllocator{
+		db:       db,
+		first:    first,
+		last:     last,
+		hostname: hostname,
+	}
+}
+
+// Alloc claims the lowest free UID via INSERT ... ON CONFLICT DO
+// NOTHING RETURNING. On race (two peers picking the same lowest free
+// UID), the loser returns no rows and re-probes for the next free slot
+// rather than reporting exhaustion.
+func (u *postgresUIDAllocator) Alloc() (int, error) {
+	skipFrom := u.first
+	for {
+		if skipFrom > u.last {
+			return 0, errors.New("process backend: no free UIDs in range")
+		}
+		uid, err := u.tryClaim(skipFrom)
+		if err != nil {
+			return 0, fmt.Errorf("postgres uid alloc: %w", err)
+		}
+		if uid >= 0 {
+			return uid, nil
+		}
+		next, err := u.findNextFree(skipFrom)
+		if err != nil {
+			return 0, fmt.Errorf("postgres uid probe: %w", err)
+		}
+		if next < 0 {
+			return 0, errors.New("process backend: no free UIDs in range")
+		}
+		skipFrom = next
+	}
+}
+
+// Release deletes the row owned by this hostname. The owner guard
+// prevents accidentally deleting a peer's UID.
+func (u *postgresUIDAllocator) Release(uid int) {
+	if uid < u.first || uid > u.last {
+		return
+	}
+	ctx := context.Background()
+	if _, err := u.db.ExecContext(ctx,
+		`DELETE FROM blockyard_uids WHERE uid = $1 AND owner = $2`,
+		uid, u.hostname,
+	); err != nil {
+		slog.Error("postgres uid release", "uid", uid, "error", err)
+	}
+}
+
+// InUse counts entries owned by this host.
+func (u *postgresUIDAllocator) InUse() int {
+	ctx := context.Background()
+	var n int
+	if err := u.db.QueryRowxContext(ctx,
+		`SELECT COUNT(*) FROM blockyard_uids WHERE owner = $1`,
+		u.hostname,
+	).Scan(&n); err != nil {
+		slog.Error("postgres uid in-use", "error", err)
+		return 0
+	}
+	return n
+}
+
+// CleanupOwnedOrphans deletes every blockyard_uids row owned by this
+// hostname. Workers from a previous run are dead (Pdeathsig), so all
+// owned rows at startup are stale.
+func (u *postgresUIDAllocator) CleanupOwnedOrphans(ctx context.Context) error {
+	if _, err := u.db.ExecContext(ctx,
+		`DELETE FROM blockyard_uids WHERE owner = $1`, u.hostname,
+	); err != nil {
+		return fmt.Errorf("postgres uid cleanup: %w", err)
+	}
+	return nil
+}
+
+func (u *postgresUIDAllocator) tryClaim(skipFrom int) (int, error) {
+	ctx := context.Background()
+	var uid int
+	err := u.db.QueryRowxContext(ctx, `
+		INSERT INTO blockyard_uids (uid, owner)
+		SELECT u, $3
+		FROM generate_series($1::int, $2::int) AS u
+		WHERE NOT EXISTS (SELECT 1 FROM blockyard_uids b WHERE b.uid = u)
+		ORDER BY u
+		LIMIT 1
+		ON CONFLICT (uid) DO NOTHING
+		RETURNING uid`,
+		skipFrom, u.last, u.hostname,
+	).Scan(&uid)
+	if errors.Is(err, sql.ErrNoRows) {
+		return -1, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return uid, nil
+}
+
+func (u *postgresUIDAllocator) findNextFree(from int) (int, error) {
+	ctx := context.Background()
+	var uid int
+	err := u.db.QueryRowxContext(ctx, `
+		SELECT u
+		FROM generate_series($1::int, $2::int) AS u
+		WHERE NOT EXISTS (SELECT 1 FROM blockyard_uids b WHERE b.uid = u)
+		ORDER BY u
+		LIMIT 1`,
+		from, u.last,
+	).Scan(&uid)
+	if errors.Is(err, sql.ErrNoRows) {
+		return -1, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return uid, nil
+}

--- a/internal/backend/process/uids_redis.go
+++ b/internal/backend/process/uids_redis.go
@@ -116,6 +116,17 @@ func (u *redisUIDAllocator) InUse() int {
 	return n
 }
 
+// mirrorClaim writes the claim key unconditionally for a specific
+// UID. Used by the layered allocator after Postgres has already
+// arbitrated ownership. Errors are logged here (best-effort).
+func (u *redisUIDAllocator) mirrorClaim(uid int) {
+	ctx := context.Background()
+	key := u.client.Prefix() + "uid:" + strconv.Itoa(uid)
+	if err := u.client.Redis().Set(ctx, key, u.hostname, 0).Err(); err != nil {
+		slog.Warn("redis uid mirror", "uid", uid, "error", err)
+	}
+}
+
 // CleanupOwnedOrphans scans the UID key namespace and deletes entries
 // owned by this hostname. The process backend's workers from a
 // previous run are dead (Pdeathsig), so all owned keys at startup

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -173,7 +173,12 @@ type ProxyConfig struct {
 	SessionStore SessionStoreMode `toml:"session_store"`
 }
 
-// SessionStoreMode is the selector for proxy.session_store.
+// SessionStoreMode is the selector for proxy.session_store. Despite
+// the "Session" name, the same value also drives the worker registry,
+// worker map, and process-backend port/UID allocators (see #286, #287,
+// #288, parent #262) — operators rarely want asymmetric durability
+// across these stores, so the resolver below picks one mode for all of
+// them.
 type SessionStoreMode string
 
 const (
@@ -183,6 +188,36 @@ const (
 	SessionStorePostgres SessionStoreMode = "postgres"
 	SessionStoreLayered  SessionStoreMode = "layered"
 )
+
+// ResolveSessionStoreMode picks the shared-state backend. Honours an
+// explicit cfg.Proxy.SessionStore value; otherwise defaults to the
+// "best" available mode given which backends are configured.
+//
+//   - [redis] + postgres  → layered (PG primary, Redis cache)
+//   - [redis] only        → redis
+//   - postgres only       → postgres
+//   - neither             → memory (single-process only)
+//
+// Lives in the config package so both cmd/blockyard/main.go and the
+// process backend's allocator selection can reach it without importing
+// each other.
+func ResolveSessionStoreMode(cfg *Config) SessionStoreMode {
+	if cfg.Proxy.SessionStore != SessionStoreAuto {
+		return cfg.Proxy.SessionStore
+	}
+	hasRedis := cfg.Redis != nil
+	hasPG := cfg.Database.Driver == "postgres"
+	switch {
+	case hasRedis && hasPG:
+		return SessionStoreLayered
+	case hasRedis:
+		return SessionStoreRedis
+	case hasPG:
+		return SessionStorePostgres
+	default:
+		return SessionStoreMemory
+	}
+}
 
 type OidcConfig struct {
 	IssuerURL         string   `toml:"issuer_url"`

--- a/internal/db/migrations/postgres/005_blockyard_allocators.down.sql
+++ b/internal/db/migrations/postgres/005_blockyard_allocators.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS blockyard_uids;
+DROP TABLE IF EXISTS blockyard_ports;

--- a/internal/db/migrations/postgres/005_blockyard_allocators.up.sql
+++ b/internal/db/migrations/postgres/005_blockyard_allocators.up.sql
@@ -1,0 +1,30 @@
+-- phase: expand
+--
+-- Postgres-primary port / UID allocators for the process backend
+-- (see #288, parent #262). The Redis variants in
+-- internal/backend/process/{ports,uids}_redis.go fail open on a Redis
+-- blip — a transient outage during allocation can hand out a slot
+-- already claimed by another peer, or falsely report exhaustion. Moving
+-- the source of truth into Postgres makes allocation correct under
+-- Redis restart; Redis stays as an optional read-through cache for the
+-- diagnostic InUse() path.
+--
+-- The owner column carries the hostname (the same identifier the Redis
+-- variants use as the SETNX value). It is NOT the per-process serverID
+-- — these allocators care about "which host's crashed state should be
+-- reclaimed at startup" rather than "which concurrent peer holds this
+-- slot," and hostname is the right granularity for the former.
+-- No secondary index on `owner`. The only owner-keyed queries are
+-- InUse() (a diagnostic) and CleanupOwnedOrphans() (once per startup),
+-- both fully tolerant of a seq scan over the small (< ~1000-row)
+-- range. An index would add maintenance cost on every Reserve / Release
+-- without paying back on any hot path.
+CREATE TABLE blockyard_ports (
+    port  INT  PRIMARY KEY,
+    owner TEXT NOT NULL
+);
+
+CREATE TABLE blockyard_uids (
+    uid   INT  PRIMARY KEY,
+    owner TEXT NOT NULL
+);

--- a/internal/db/migrations/sqlite/005_blockyard_allocators.down.sql
+++ b/internal/db/migrations/sqlite/005_blockyard_allocators.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS blockyard_uids;
+DROP TABLE IF EXISTS blockyard_ports;

--- a/internal/db/migrations/sqlite/005_blockyard_allocators.up.sql
+++ b/internal/db/migrations/sqlite/005_blockyard_allocators.up.sql
@@ -1,0 +1,16 @@
+-- phase: expand
+--
+-- Mirror of the Postgres blockyard_ports / blockyard_uids tables (see
+-- #288). The Postgres-primary allocators are only wired up when [redis]
+-- + database.driver = "postgres"; SQLite deployments keep the in-memory
+-- allocators. The tables are created here so migration numbering stays
+-- in lockstep across dialects.
+CREATE TABLE blockyard_ports (
+    port  INTEGER PRIMARY KEY,
+    owner TEXT    NOT NULL
+);
+
+CREATE TABLE blockyard_uids (
+    uid   INTEGER PRIMARY KEY,
+    owner TEXT    NOT NULL
+);


### PR DESCRIPTION
## Summary

- Adds `postgresPortAllocator` / `postgresUIDAllocator` backed by `INSERT ... ON CONFLICT DO NOTHING RETURNING` over `generate_series` ranges, plus `layered{Port,UID}Allocator` mirroring writes to a Redis cache.
- Wires selection through `config.ResolveSessionStoreMode` (extracted from `cmd/blockyard/main.go` into the config package) so allocator durability matches the session/registry/worker-map durability — no asymmetric configuration.
- New migration `005_blockyard_allocators` creates `blockyard_ports` / `blockyard_uids` in both Postgres and SQLite (the SQLite copy is unused but keeps numbering aligned).
- Conformance tests run all four backends (Memory, Redis, Postgres, Layered) through the same scenarios, including peer-coexistence and orphan-cleanup; PG bootstrap helper follows the per-test template-clone pattern from #286 / #287.

Fixes #288