### PR TITLE
test(misc): cover redis-down paths for postgres-primary stores

### DIFF
--- a/cmd/blockyard/main.go
+++ b/cmd/blockyard/main.go
@@ -295,6 +295,7 @@ func main() {
 	// "recover my own crashed state" need different identifiers.
 	hostname, _ := os.Hostname()
 	serverID := hostname + "-" + randomNonceHex(8)
+	srv.ServerID = serverID
 
 	// Shared-state backend selection — see #287, #286, parent #262.
 	// Postgres is the source of truth; Redis is an optional read-through

--- a/cmd/blockyard/main.go
+++ b/cmd/blockyard/main.go
@@ -307,6 +307,7 @@ func main() {
 	registryTTL := 3 * cfg.Proxy.HealthInterval.Duration
 	idleTTL := cfg.Proxy.SessionIdleTTL.Duration
 	var pgSessions *session.PostgresStore
+	var pgWorkers *server.PostgresWorkerMap
 	switch mode {
 	case config.SessionStoreMemory:
 		srv.Registry = registry.NewMemoryRegistry()
@@ -318,7 +319,8 @@ func main() {
 		srv.Sessions = session.NewRedisStore(rc, idleTTL)
 	case config.SessionStorePostgres:
 		srv.Registry = registry.NewPostgresRegistry(database.DB, registryTTL)
-		srv.Workers = server.NewPostgresWorkerMap(database.DB, serverID)
+		pgWorkers = server.NewPostgresWorkerMap(database.DB, serverID)
+		srv.Workers = pgWorkers
 		pgSessions = session.NewPostgresStore(database.DB, idleTTL)
 		srv.Sessions = pgSessions
 	case config.SessionStoreLayered:
@@ -326,8 +328,9 @@ func main() {
 			registry.NewPostgresRegistry(database.DB, registryTTL),
 			registry.NewRedisRegistry(rc, registryTTL),
 		)
+		pgWorkers = server.NewPostgresWorkerMap(database.DB, serverID)
 		srv.Workers = server.NewLayeredWorkerMap(
-			server.NewPostgresWorkerMap(database.DB, serverID),
+			pgWorkers,
 			server.NewRedisWorkerMap(rc, serverID),
 		)
 		pgSessions = session.NewPostgresStore(database.DB, idleTTL)
@@ -347,6 +350,19 @@ func main() {
 		go func() {
 			defer bgWg.Done()
 			pgSessions.RunExpiry(bgCtx, time.Minute)
+		}()
+	}
+	if pgWorkers != nil {
+		// Reap rows whose last_heartbeat has been stale for 5× the
+		// registry TTL. Registry.Get already filters stale rows at
+		// registryTTL, so reaping a bit later keeps the WorkerMap /
+		// Registry views converged without racing a transient
+		// heartbeat blip. Sweeps once a minute — low volume, bounded
+		// blast radius per sweep.
+		bgWg.Add(1)
+		go func() {
+			defer bgWg.Done()
+			pgWorkers.RunReaper(bgCtx, 5*registryTTL, time.Minute)
 		}()
 	}
 	slog.Info("shared state store selected", "mode", mode)

--- a/internal/backend/process/allocators_layered_cache_error_test.go
+++ b/internal/backend/process/allocators_layered_cache_error_test.go
@@ -1,0 +1,145 @@
+package process
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+
+	"github.com/cynkra/blockyard/internal/redisstate"
+)
+
+// Cache-failure behavior for the layered port / UID allocators
+// (see #262, #288). Postgres is the cross-peer mutex; Redis is a
+// best-effort mirror. These tests pair a real Postgres primary with a
+// real Redis cache whose miniredis is poisoned via SetError, and
+// assert that Reserve / Alloc / Release / CleanupOwnedOrphans all
+// complete without surfacing the cache failure to the caller.
+
+func newLayeredPortAllocatorWithErroringCache(t *testing.T, first, last int) (*layeredPortAllocator, *miniredis.Miniredis) {
+	t.Helper()
+	db := testPGDB(t)
+	mr := miniredis.RunT(t)
+	client := redisstate.TestClient(t, mr.Addr())
+	pg := newPostgresPortAllocator(db, first, last, "host-a")
+	rd := newRedisPortAllocator(client, first, last, "host-a")
+	return newLayeredPortAllocator(pg, rd), mr
+}
+
+func newLayeredUIDAllocatorWithErroringCache(t *testing.T, first, last int) (*layeredUIDAllocator, *miniredis.Miniredis) {
+	t.Helper()
+	db := testPGDB(t)
+	mr := miniredis.RunT(t)
+	client := redisstate.TestClient(t, mr.Addr())
+	pg := newPostgresUIDAllocator(db, first, last, "host-a")
+	rd := newRedisUIDAllocator(client, first, last, "host-a")
+	return newLayeredUIDAllocator(pg, rd), mr
+}
+
+func TestLayeredPortAllocator_CacheErrors_ReserveSucceeds(t *testing.T) {
+	base := findFreePortRange(t, 3)
+	a, mr := newLayeredPortAllocatorWithErroringCache(t, base, base+2)
+
+	mr.SetError("READONLY simulated failure")
+
+	// Postgres still arbitrates ownership; the cache mirror just logs.
+	port, ln, err := a.Reserve()
+	if err != nil {
+		t.Fatalf("Reserve with cache errors: %v", err)
+	}
+	defer ln.Close()
+	if port < base || port > base+2 {
+		t.Errorf("port %d out of range [%d..%d]", port, base, base+2)
+	}
+}
+
+func TestLayeredPortAllocator_CacheErrors_ReleaseSucceeds(t *testing.T) {
+	base := findFreePortRange(t, 3)
+	a, mr := newLayeredPortAllocatorWithErroringCache(t, base, base+2)
+
+	port, ln, err := a.Reserve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ln.Close()
+
+	mr.SetError("READONLY simulated failure")
+	a.Release(port) // must not panic or block
+
+	// Primary must be cleared regardless of cache error — a subsequent
+	// Reserve should be able to hand the port back out.
+	mr.SetError("") // clear to let Reserve's mirror succeed
+	var freshLns []net.Listener
+	defer func() {
+		for _, ln := range freshLns {
+			ln.Close()
+		}
+	}()
+	for range 3 {
+		_, fresh, err := a.Reserve()
+		if err != nil {
+			t.Fatalf("unexpected exhaustion after release with cache errors: %v", err)
+		}
+		freshLns = append(freshLns, fresh)
+	}
+}
+
+func TestLayeredPortAllocator_CacheErrors_CleanupIsBestEffort(t *testing.T) {
+	base := findFreePortRange(t, 3)
+	a, mr := newLayeredPortAllocatorWithErroringCache(t, base, base+2)
+
+	mr.SetError("READONLY simulated failure")
+
+	// Cleanup at startup must not fail when Redis is unreachable —
+	// otherwise a Redis outage blocks recovery of orphaned Postgres rows.
+	if err := a.CleanupOwnedOrphans(context.Background()); err != nil {
+		t.Errorf("CleanupOwnedOrphans must tolerate cache errors, got: %v", err)
+	}
+}
+
+func TestLayeredUIDAllocator_CacheErrors_AllocSucceeds(t *testing.T) {
+	a, mr := newLayeredUIDAllocatorWithErroringCache(t, 60000, 60002)
+
+	mr.SetError("READONLY simulated failure")
+
+	uid, err := a.Alloc()
+	if err != nil {
+		t.Fatalf("Alloc with cache errors: %v", err)
+	}
+	if uid < 60000 || uid > 60002 {
+		t.Errorf("uid %d out of range [60000..60002]", uid)
+	}
+}
+
+func TestLayeredUIDAllocator_CacheErrors_ReleaseSucceeds(t *testing.T) {
+	a, mr := newLayeredUIDAllocatorWithErroringCache(t, 60000, 60002)
+
+	uid, err := a.Alloc()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mr.SetError("READONLY simulated failure")
+	a.Release(uid) // must not panic
+
+	// Primary should have released the UID; after clearing the cache
+	// error, re-Alloc should succeed without surfacing a false exhaustion.
+	mr.SetError("")
+	if _, err := a.Alloc(); err != nil {
+		t.Fatalf("Alloc after release-with-errors: %v", err)
+	}
+	if _, err := a.Alloc(); err != nil {
+		t.Fatalf("second Alloc: %v", err)
+	}
+}
+
+func TestLayeredUIDAllocator_CacheErrors_CleanupIsBestEffort(t *testing.T) {
+	a, mr := newLayeredUIDAllocatorWithErroringCache(t, 60000, 60002)
+
+	mr.SetError("READONLY simulated failure")
+
+	if err := a.CleanupOwnedOrphans(context.Background()); err != nil {
+		t.Errorf("CleanupOwnedOrphans must tolerate cache errors, got: %v", err)
+	}
+}

--- a/internal/backend/process/ports_layered.go
+++ b/internal/backend/process/ports_layered.go
@@ -3,6 +3,7 @@ package process
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 )
 
@@ -47,14 +48,17 @@ func (p *layeredPortAllocator) InUse() int {
 	return p.cache.InUse()
 }
 
-// CleanupOwnedOrphans cleans both layers — primary first (correctness),
-// then cache (mirror).
+// CleanupOwnedOrphans cleans the primary (correctness). The cache mirror
+// is cleaned best-effort: a Redis outage at startup must not block
+// recovery of orphaned Postgres rows, and any stale cache keys will
+// naturally churn as live workers reclaim their slots. Matches the
+// primary/cache contract in ports_layered.go's header.
 func (p *layeredPortAllocator) CleanupOwnedOrphans(ctx context.Context) error {
 	if err := p.primary.CleanupOwnedOrphans(ctx); err != nil {
 		return fmt.Errorf("primary: %w", err)
 	}
 	if err := p.cache.CleanupOwnedOrphans(ctx); err != nil {
-		return fmt.Errorf("cache: %w", err)
+		slog.Warn("layered port cleanup: cache best-effort", "error", err)
 	}
 	return nil
 }

--- a/internal/backend/process/uids_layered.go
+++ b/internal/backend/process/uids_layered.go
@@ -3,6 +3,7 @@ package process
 import (
 	"context"
 	"fmt"
+	"log/slog"
 )
 
 // layeredUIDAllocator pairs a Postgres-primary allocator with a Redis
@@ -36,12 +37,16 @@ func (u *layeredUIDAllocator) InUse() int {
 	return u.cache.InUse()
 }
 
+// CleanupOwnedOrphans cleans the primary (correctness). The cache mirror
+// is cleaned best-effort: a Redis outage at startup must not block
+// recovery of orphaned Postgres rows. See ports_layered.go for the
+// matching reasoning.
 func (u *layeredUIDAllocator) CleanupOwnedOrphans(ctx context.Context) error {
 	if err := u.primary.CleanupOwnedOrphans(ctx); err != nil {
 		return fmt.Errorf("primary: %w", err)
 	}
 	if err := u.cache.CleanupOwnedOrphans(ctx); err != nil {
-		return fmt.Errorf("cache: %w", err)
+		slog.Warn("layered uid cleanup: cache best-effort", "error", err)
 	}
 	return nil
 }

--- a/internal/ops/ops.go
+++ b/internal/ops/ops.go
@@ -137,9 +137,13 @@ func StartupCleanup(ctx context.Context, srv *server.Server, passive bool) error
 			"count", count)
 	}
 
-	// Reconcile Redis worker map against containers still running.
-	// With in-memory stores this is a no-op (All() returns empty).
-	workerIDs := srv.Workers.All()
+	// Reconcile the worker map against containers still running on this
+	// process's backend. Scoped to this ServerID so a sibling pod's boot
+	// doesn't wipe our workers — Backend.ListManaged only sees locally
+	// managed resources, so comparing against a global Workers.All()
+	// would flag every peer's worker as stale. With in-memory stores
+	// WorkersForServer falls back to All(), which is empty on first boot.
+	workerIDs := srv.Workers.WorkersForServer(srv.ServerID)
 	if len(workerIDs) > 0 {
 		remaining, _ := srv.Backend.ListManaged(ctx)
 		alive := make(map[string]bool, len(remaining))
@@ -201,7 +205,10 @@ func evictDrainedWorkers(ctx context.Context, srv *server.Server) {
 }
 
 func pollOnce(ctx context.Context, srv *server.Server, misses map[string]int) {
-	workerIDs := srv.Workers.All()
+	// Only health-check workers owned by this process — Backend.HealthCheck
+	// can't reach a sibling pod's workers, and issuing the probe against
+	// them would yield spurious eviction misses.
+	workerIDs := srv.Workers.WorkersForServer(srv.ServerID)
 	if len(workerIDs) == 0 {
 		return
 	}
@@ -365,7 +372,9 @@ func drainAndEvictAll(ctx context.Context, srv *server.Server, workerIDs []strin
 // fails in-progress builds. Called after HTTP server drain and background
 // goroutine cancellation.
 func GracefulShutdown(ctx context.Context, srv *server.Server) {
-	workerIDs := srv.Workers.All()
+	// Only tear down workers this process owns — a peer's workers live
+	// on and must not be evicted by our shutdown.
+	workerIDs := srv.Workers.WorkersForServer(srv.ServerID)
 	if len(workerIDs) > 0 {
 		drainAndEvictAll(ctx, srv, workerIDs)
 	}

--- a/internal/redisstate/redisstate.go
+++ b/internal/redisstate/redisstate.go
@@ -18,11 +18,22 @@ type Client struct {
 }
 
 // New parses the config, connects, and verifies with a PING.
+//
+// Redis is a best-effort cache layer under the Postgres-primary stores
+// (see #262) — requests block on Postgres, not Redis. A sluggish or
+// unreachable Redis must fail fast so mirror writes / cache reads don't
+// hold a request for the go-redis default (3s write, 3s read, 5s dial).
+// 500 ms is long enough for a healthy local Redis and short enough that
+// a 30 s restart adds ≤ 500 ms per affected operation.
 func New(ctx context.Context, cfg *config.RedisConfig) (*Client, error) {
 	opts, err := redis.ParseURL(cfg.URL)
 	if err != nil {
 		return nil, fmt.Errorf("parse redis url: %w", err)
 	}
+	opts.DialTimeout = 500 * time.Millisecond
+	opts.ReadTimeout = 500 * time.Millisecond
+	opts.WriteTimeout = 500 * time.Millisecond
+	opts.PoolTimeout = 500 * time.Millisecond
 
 	rdb := redis.NewClient(opts)
 

--- a/internal/registry/layered_cache_error_test.go
+++ b/internal/registry/layered_cache_error_test.go
@@ -9,17 +9,20 @@ import (
 	"github.com/cynkra/blockyard/internal/redisstate"
 )
 
-// Cache-failure behavior for LayeredRegistry (see #262). MemoryRegistry
-// stands in for the Postgres primary; a real RedisRegistry is wrapped
-// around a miniredis that we poison via SetError. Every method must
-// still surface the primary answer — that's the whole point of making
-// Postgres source-of-truth.
+// Cache-failure behavior for LayeredRegistry (see #262). Pairs a real
+// PostgresRegistry primary with a real RedisRegistry cache whose
+// miniredis is poisoned via SetError. Using the production primary
+// (not MemoryRegistry) ensures the SQL path behaves correctly when
+// the cache fails mid-operation.
+//
+// Skips when BLOCKYARD_TEST_POSTGRES_URL is not set. CI's `unit` job
+// always provides one.
 
-func newLayeredRegistryWithErroringCache(t *testing.T) (*LayeredRegistry, *MemoryRegistry, *miniredis.Miniredis) {
+func newLayeredRegistryWithErroringCache(t *testing.T) (*LayeredRegistry, *PostgresRegistry, *miniredis.Miniredis) {
 	t.Helper()
+	primary := NewPostgresRegistry(testPGDB(t), time.Hour)
 	mr := miniredis.RunT(t)
 	client := redisstate.TestClient(t, mr.Addr())
-	primary := NewMemoryRegistry()
 	cache := NewRedisRegistry(client, time.Hour)
 	return NewLayeredRegistry(primary, cache), primary, mr
 }
@@ -63,11 +66,11 @@ func TestLayeredRegistry_CacheErrors_DeleteClearsPrimary(t *testing.T) {
 
 // TestLayeredRegistry_CacheRestartRewarms simulates the DoD: Redis
 // comes back empty and the next read backfills the cache from the
-// primary without user-visible impact.
+// Postgres primary without user-visible impact.
 func TestLayeredRegistry_CacheRestartRewarms(t *testing.T) {
+	primary := NewPostgresRegistry(testPGDB(t), time.Hour)
 	mr := miniredis.RunT(t)
 	client := redisstate.TestClient(t, mr.Addr())
-	primary := NewMemoryRegistry()
 	cache := NewRedisRegistry(client, time.Hour)
 	r := NewLayeredRegistry(primary, cache)
 

--- a/internal/registry/layered_cache_error_test.go
+++ b/internal/registry/layered_cache_error_test.go
@@ -1,0 +1,89 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+
+	"github.com/cynkra/blockyard/internal/redisstate"
+)
+
+// Cache-failure behavior for LayeredRegistry (see #262). MemoryRegistry
+// stands in for the Postgres primary; a real RedisRegistry is wrapped
+// around a miniredis that we poison via SetError. Every method must
+// still surface the primary answer — that's the whole point of making
+// Postgres source-of-truth.
+
+func newLayeredRegistryWithErroringCache(t *testing.T) (*LayeredRegistry, *MemoryRegistry, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redisstate.TestClient(t, mr.Addr())
+	primary := NewMemoryRegistry()
+	cache := NewRedisRegistry(client, time.Hour)
+	return NewLayeredRegistry(primary, cache), primary, mr
+}
+
+func TestLayeredRegistry_CacheErrors_GetFallsBackToPrimary(t *testing.T) {
+	r, primary, mr := newLayeredRegistryWithErroringCache(t)
+	primary.Set("w1", "127.0.0.1:3838")
+
+	mr.SetError("READONLY simulated failure")
+
+	addr, ok := r.Get("w1")
+	if !ok || addr != "127.0.0.1:3838" {
+		t.Fatalf("Get = (%q, %v), want (127.0.0.1:3838, true)", addr, ok)
+	}
+}
+
+func TestLayeredRegistry_CacheErrors_SetPersistsPrimary(t *testing.T) {
+	r, primary, mr := newLayeredRegistryWithErroringCache(t)
+	mr.SetError("READONLY simulated failure")
+
+	r.Set("w1", "127.0.0.1:3838")
+
+	addr, ok := primary.Get("w1")
+	if !ok || addr != "127.0.0.1:3838" {
+		t.Errorf("primary = (%q, %v), want (127.0.0.1:3838, true) — cache errors must not drop the write",
+			addr, ok)
+	}
+}
+
+func TestLayeredRegistry_CacheErrors_DeleteClearsPrimary(t *testing.T) {
+	r, primary, mr := newLayeredRegistryWithErroringCache(t)
+	primary.Set("w1", "127.0.0.1:3838")
+
+	mr.SetError("READONLY simulated failure")
+
+	r.Delete("w1")
+	if _, ok := primary.Get("w1"); ok {
+		t.Error("primary must be cleared even if cache delete errored")
+	}
+}
+
+// TestLayeredRegistry_CacheRestartRewarms simulates the DoD: Redis
+// comes back empty and the next read backfills the cache from the
+// primary without user-visible impact.
+func TestLayeredRegistry_CacheRestartRewarms(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redisstate.TestClient(t, mr.Addr())
+	primary := NewMemoryRegistry()
+	cache := NewRedisRegistry(client, time.Hour)
+	r := NewLayeredRegistry(primary, cache)
+
+	r.Set("w1", "127.0.0.1:3838")
+
+	// "Restart" Redis by wiping the dataset.
+	mr.FlushAll()
+	if _, ok := cache.Get("w1"); ok {
+		t.Fatal("precondition: cache should be empty post-restart")
+	}
+
+	addr, ok := r.Get("w1")
+	if !ok || addr != "127.0.0.1:3838" {
+		t.Fatalf("Get after restart = (%q, %v), want (127.0.0.1:3838, true)", addr, ok)
+	}
+	if _, ok := cache.Get("w1"); !ok {
+		t.Error("cache should be repopulated after the miss-through-read")
+	}
+}

--- a/internal/server/pg_only_integration_test.go
+++ b/internal/server/pg_only_integration_test.go
@@ -1,0 +1,211 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/cynkra/blockyard/internal/registry"
+	"github.com/cynkra/blockyard/internal/session"
+)
+
+// Postgres-only end-to-end integration for #262. No Redis at all.
+// Exercises the three postgres-primary stores together so the shared
+// blockyard_workers table (registry + workermap) and the cross-store
+// worker/session linkage are actually hit as a set. This is the
+// Postgres-only DoD bullet: "Postgres-only mode (no Redis configured)
+// works correctly."
+//
+// Skips when BLOCKYARD_TEST_POSTGRES_URL is not set. CI's `unit` job
+// always provides one.
+
+type pgOnlyStack struct {
+	db       *sqlx.DB
+	sessions *session.PostgresStore
+	registry *registry.PostgresRegistry
+	workers  *PostgresWorkerMap
+}
+
+func newPGOnlyStack(t *testing.T) *pgOnlyStack {
+	t.Helper()
+	db := testPGDB(t)
+	return &pgOnlyStack{
+		db:       db,
+		sessions: session.NewPostgresStore(db, time.Hour),
+		registry: registry.NewPostgresRegistry(db, time.Minute),
+		workers:  NewPostgresWorkerMap(db, "server-1"),
+	}
+}
+
+// TestPGOnly_StickySessionLifecycle walks a realistic sticky-session
+// flow without Redis: spawn a worker, create a session routed to it,
+// touch, drain, delete, tear down. Pins that the three stores
+// compose correctly on top of the shared blockyard_workers table.
+func TestPGOnly_StickySessionLifecycle(t *testing.T) {
+	s := newPGOnlyStack(t)
+
+	// ── Spawn: workermap first (full row), then registry (address). In
+	// production cmd/blockyard writes workermap first and registry
+	// second; both must upsert onto the same row without clobbering
+	// each other's columns.
+	s.workers.Set("w1", ActiveWorker{
+		AppID:     "app1",
+		BundleID:  "b1",
+		StartedAt: time.Now(),
+	})
+	s.registry.Set("w1", "127.0.0.1:3838")
+
+	// Both views must now be coherent.
+	w, ok := s.workers.Get("w1")
+	if !ok || w.AppID != "app1" {
+		t.Fatalf("workers.Get = (%+v, %v), want app1/true", w, ok)
+	}
+	addr, ok := s.registry.Get("w1")
+	if !ok || addr != "127.0.0.1:3838" {
+		t.Fatalf("registry.Get = (%q, %v), want (127.0.0.1:3838, true)", addr, ok)
+	}
+
+	// ── Route a session to the worker.
+	s.sessions.Set("sess-1", session.Entry{
+		WorkerID:   "w1",
+		UserSub:    "user-a",
+		LastAccess: time.Now(),
+	})
+
+	entry, ok := s.sessions.Get("sess-1")
+	if !ok || entry.WorkerID != "w1" {
+		t.Fatalf("sessions.Get = (%+v, %v), want w1/true", entry, ok)
+	}
+
+	// Subsequent requests for the same session must keep the routing
+	// via Touch (the hot-path operation).
+	if !s.sessions.Touch("sess-1") {
+		t.Error("Touch on existing session should return true")
+	}
+
+	// ── Drain: mark the worker draining. The registry entry must stay
+	// so in-flight sessions can still reach it; only new-session
+	// routing would skip it.
+	s.workers.SetDraining("w1")
+	w, _ = s.workers.Get("w1")
+	if !w.Draining {
+		t.Error("worker should report draining after SetDraining")
+	}
+	if _, ok := s.registry.Get("w1"); !ok {
+		t.Error("registry must still resolve a draining worker")
+	}
+
+	// ── Session ends. Session row goes away; worker stays until torn
+	// down by the health loop.
+	s.sessions.Delete("sess-1")
+	if _, ok := s.sessions.Get("sess-1"); ok {
+		t.Error("sessions.Get should miss after Delete")
+	}
+
+	// ── Teardown: workermap and registry both clear the blockyard_workers
+	// row. Either order is valid; the last Delete wins.
+	s.registry.Delete("w1")
+	s.workers.Delete("w1")
+	if _, ok := s.workers.Get("w1"); ok {
+		t.Error("worker should be gone after teardown")
+	}
+	if _, ok := s.registry.Get("w1"); ok {
+		t.Error("registry should be empty after teardown")
+	}
+}
+
+// TestPGOnly_RegistryHeartbeatExpiry pins the TTL contract in a
+// full-stack context: if the health poller stops refreshing a worker,
+// registry.Get starts returning false after registryTTL, and the
+// workermap still knows the row exists (because heartbeat expiry is
+// a registry concern, not a workermap one).
+func TestPGOnly_RegistryHeartbeatExpiry(t *testing.T) {
+	s := newPGOnlyStack(t)
+
+	s.workers.Set("w1", ActiveWorker{AppID: "app1", BundleID: "b1", StartedAt: time.Now()})
+	s.registry.Set("w1", "127.0.0.1:3838")
+
+	// Simulate a dropped heartbeat: push last_heartbeat past the TTL.
+	if _, err := s.db.Exec(
+		`UPDATE blockyard_workers SET last_heartbeat = now() - interval '2 minutes' WHERE id = $1`,
+		"w1",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := s.registry.Get("w1"); ok {
+		t.Error("registry should treat stale-heartbeat worker as gone")
+	}
+	// workermap has no TTL of its own — the row is still discoverable
+	// until something explicitly deletes it.
+	if _, ok := s.workers.Get("w1"); !ok {
+		t.Error("workermap should still see the row (TTL is registry-only)")
+	}
+}
+
+// TestPGOnly_SessionExpirySweep pins the DoD bullet that "sessions that
+// are created and then never touched again" get swept by the
+// PostgresStore background expiry, independent of Redis.
+func TestPGOnly_SessionExpirySweep(t *testing.T) {
+	db := testPGDB(t)
+	// Short idleTTL so expires_at lands in the past after a Sleep.
+	s := session.NewPostgresStore(db, 10*time.Millisecond)
+
+	s.Set("sess-old", session.Entry{WorkerID: "w1", LastAccess: time.Now()})
+
+	// Run the expiry loop briefly; it deletes past-due rows.
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		s.RunExpiry(ctx, 20*time.Millisecond)
+		close(done)
+	}()
+	<-done
+
+	if _, ok := s.Get("sess-old"); ok {
+		t.Error("expired session should be gone after RunExpiry")
+	}
+}
+
+// TestPGOnly_RerouteAfterWorkerReplacement mirrors a rolling update:
+// sessions on w1 get rerouted onto w2, and the session store reports
+// the new worker for subsequent lookups. Runs end-to-end against
+// Postgres primaries for all three stores.
+func TestPGOnly_RerouteAfterWorkerReplacement(t *testing.T) {
+	s := newPGOnlyStack(t)
+
+	// Two workers for the same app — simulates a rolling update in
+	// progress.
+	s.workers.Set("w1", ActiveWorker{AppID: "app1", BundleID: "b1", StartedAt: time.Now()})
+	s.registry.Set("w1", "127.0.0.1:3838")
+	s.workers.Set("w2", ActiveWorker{AppID: "app1", BundleID: "b2", StartedAt: time.Now()})
+	s.registry.Set("w2", "127.0.0.1:3839")
+
+	s.sessions.Set("sess-1", session.Entry{WorkerID: "w1", LastAccess: time.Now()})
+	s.sessions.Set("sess-2", session.Entry{WorkerID: "w1", LastAccess: time.Now()})
+
+	// Reroute both sessions off w1 onto w2.
+	if n := s.sessions.RerouteWorker("w1", "w2"); n != 2 {
+		t.Errorf("RerouteWorker = %d, want 2", n)
+	}
+
+	for _, id := range []string{"sess-1", "sess-2"} {
+		e, ok := s.sessions.Get(id)
+		if !ok {
+			t.Errorf("%s should still exist", id)
+			continue
+		}
+		if e.WorkerID != "w2" {
+			t.Errorf("%s worker = %q, want w2", id, e.WorkerID)
+		}
+	}
+	if n := s.sessions.CountForWorker("w1"); n != 0 {
+		t.Errorf("CountForWorker(w1) = %d, want 0", n)
+	}
+	if n := s.sessions.CountForWorker("w2"); n != 2 {
+		t.Errorf("CountForWorker(w2) = %d, want 2", n)
+	}
+}

--- a/internal/server/pg_only_integration_test.go
+++ b/internal/server/pg_only_integration_test.go
@@ -170,6 +170,39 @@ func TestPGOnly_SessionExpirySweep(t *testing.T) {
 	}
 }
 
+// TestPGOnly_MultipodWorkerIsolation pins the multi-pod safety that
+// #262 enables: two blockyard processes sharing a Postgres see the full
+// blockyard_workers table, but each must only touch its own workers.
+// ops.StartupCleanup / pollOnce / GracefulShutdown all scope to
+// Workers.WorkersForServer(ServerID) for exactly this reason — without
+// the filter, pod B's boot would wipe pod A's workers (every Workers.All()
+// entry would look stale against pod B's local backend).
+func TestPGOnly_MultipodWorkerIsolation(t *testing.T) {
+	db := testPGDB(t)
+	podA := NewPostgresWorkerMap(db, "server-A")
+	podB := NewPostgresWorkerMap(db, "server-B")
+
+	podA.Set("wa1", ActiveWorker{AppID: "app1", BundleID: "b1", StartedAt: time.Now()})
+	podA.Set("wa2", ActiveWorker{AppID: "app1", BundleID: "b1", StartedAt: time.Now()})
+	podB.Set("wb1", ActiveWorker{AppID: "app1", BundleID: "b1", StartedAt: time.Now()})
+
+	gotA := podA.WorkersForServer("server-A")
+	if len(gotA) != 2 {
+		t.Errorf("podA sees %v, want its own two workers", gotA)
+	}
+	gotB := podB.WorkersForServer("server-B")
+	if len(gotB) != 1 || gotB[0] != "wb1" {
+		t.Errorf("podB sees %v, want [wb1]", gotB)
+	}
+
+	// Global view confirms the shared table holds all three — the
+	// filter is what makes scoped reconcile safe, not isolation of
+	// storage.
+	if n := podA.Count(); n != 3 {
+		t.Errorf("global Count = %d, want 3 (shared table)", n)
+	}
+}
+
 // TestPGOnly_RerouteAfterWorkerReplacement mirrors a rolling update:
 // sessions on w1 get rerouted onto w2, and the session store reports
 // the new worker for subsequent lookups. Runs end-to-end against

--- a/internal/server/state.go
+++ b/internal/server/state.go
@@ -43,6 +43,13 @@ type Server struct {
 	ErrorLog *errorlog.Store
 	Metrics  *telemetry.Metrics
 
+	// ServerID uniquely identifies this process among peers sharing the
+	// same Postgres / Redis (see #262). Health-poll, startup-reconcile,
+	// and graceful-shutdown use it via Workers.WorkersForServer so they
+	// only act on workers this process owns — otherwise a sibling pod's
+	// boot would wipe this pod's workers from the shared table.
+	ServerID string
+
 	// Auth fields — nil when [oidc] is not configured (v0 compat).
 	OIDCClient   *auth.OIDCClient
 	SigningKey    *auth.SigningKey

--- a/internal/server/workermap_layered_cache_error_test.go
+++ b/internal/server/workermap_layered_cache_error_test.go
@@ -9,21 +9,24 @@ import (
 	"github.com/cynkra/blockyard/internal/redisstate"
 )
 
-// Cache-failure behavior for LayeredWorkerMap (see #262). MemoryWorkerMap
-// stands in for the Postgres primary; a real RedisWorkerMap is wrapped
-// around a miniredis that we poison via SetError. Every method must
-// still surface the primary answer — that's the whole point of making
-// Postgres source-of-truth.
+// Cache-failure behavior for LayeredWorkerMap (see #262). Pairs a real
+// PostgresWorkerMap primary with a real RedisWorkerMap cache whose
+// miniredis is poisoned via SetError. Using the production primary
+// (not MemoryWorkerMap) ensures the SQL path behaves correctly when
+// the cache fails mid-operation.
 //
 // The per-method degradation of RedisWorkerMap itself is covered in
 // workermap_redis_error_test.go; this file pins the *Layered* contract:
 // errors on the cache side don't corrupt the primary view.
+//
+// Skips when BLOCKYARD_TEST_POSTGRES_URL is not set. CI's `unit` job
+// always provides one.
 
-func newLayeredWorkerMapWithErroringCache(t *testing.T) (*LayeredWorkerMap, *MemoryWorkerMap, *miniredis.Miniredis) {
+func newLayeredWorkerMapWithErroringCache(t *testing.T) (*LayeredWorkerMap, *PostgresWorkerMap, *miniredis.Miniredis) {
 	t.Helper()
+	primary := NewPostgresWorkerMap(testPGDB(t), "test-host")
 	mr := miniredis.RunT(t)
 	client := redisstate.TestClient(t, mr.Addr())
-	primary := NewMemoryWorkerMap()
 	cache := NewRedisWorkerMap(client, "test-host")
 	return NewLayeredWorkerMap(primary, cache), primary, mr
 }
@@ -53,7 +56,7 @@ func TestLayeredWorkerMap_CacheErrors_SetPersistsPrimary(t *testing.T) {
 
 func TestLayeredWorkerMap_CacheErrors_DeleteClearsPrimary(t *testing.T) {
 	m, primary, mr := newLayeredWorkerMapWithErroringCache(t)
-	primary.Set("w1", ActiveWorker{AppID: "app1"})
+	primary.Set("w1", ActiveWorker{AppID: "app1", BundleID: "b1", StartedAt: time.Now()})
 
 	mr.SetError("READONLY simulated failure")
 
@@ -65,9 +68,9 @@ func TestLayeredWorkerMap_CacheErrors_DeleteClearsPrimary(t *testing.T) {
 
 func TestLayeredWorkerMap_CacheErrors_AggregatesReflectPrimary(t *testing.T) {
 	m, primary, mr := newLayeredWorkerMapWithErroringCache(t)
-	primary.Set("w1", ActiveWorker{AppID: "app1"})
-	primary.Set("w2", ActiveWorker{AppID: "app1"})
-	primary.Set("w3", ActiveWorker{AppID: "app2"})
+	primary.Set("w1", ActiveWorker{AppID: "app1", BundleID: "b1", StartedAt: time.Now()})
+	primary.Set("w2", ActiveWorker{AppID: "app1", BundleID: "b1", StartedAt: time.Now()})
+	primary.Set("w3", ActiveWorker{AppID: "app2", BundleID: "b2", StartedAt: time.Now()})
 
 	mr.SetError("READONLY simulated failure")
 
@@ -84,7 +87,7 @@ func TestLayeredWorkerMap_CacheErrors_AggregatesReflectPrimary(t *testing.T) {
 
 func TestLayeredWorkerMap_CacheErrors_MarkDrainingUpdatesPrimary(t *testing.T) {
 	m, primary, mr := newLayeredWorkerMapWithErroringCache(t)
-	primary.Set("w1", ActiveWorker{AppID: "app1"})
+	primary.Set("w1", ActiveWorker{AppID: "app1", BundleID: "b1", StartedAt: time.Now()})
 
 	mr.SetError("READONLY simulated failure")
 
@@ -100,11 +103,11 @@ func TestLayeredWorkerMap_CacheErrors_MarkDrainingUpdatesPrimary(t *testing.T) {
 
 // TestLayeredWorkerMap_CacheRestartRewarms simulates the DoD: Redis
 // comes back empty and subsequent reads backfill the cache from the
-// primary without user-visible impact.
+// Postgres primary without user-visible impact.
 func TestLayeredWorkerMap_CacheRestartRewarms(t *testing.T) {
+	primary := NewPostgresWorkerMap(testPGDB(t), "test-host")
 	mr := miniredis.RunT(t)
 	client := redisstate.TestClient(t, mr.Addr())
-	primary := NewMemoryWorkerMap()
 	cache := NewRedisWorkerMap(client, "test-host")
 	m := NewLayeredWorkerMap(primary, cache)
 

--- a/internal/server/workermap_layered_cache_error_test.go
+++ b/internal/server/workermap_layered_cache_error_test.go
@@ -1,0 +1,126 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+
+	"github.com/cynkra/blockyard/internal/redisstate"
+)
+
+// Cache-failure behavior for LayeredWorkerMap (see #262). MemoryWorkerMap
+// stands in for the Postgres primary; a real RedisWorkerMap is wrapped
+// around a miniredis that we poison via SetError. Every method must
+// still surface the primary answer — that's the whole point of making
+// Postgres source-of-truth.
+//
+// The per-method degradation of RedisWorkerMap itself is covered in
+// workermap_redis_error_test.go; this file pins the *Layered* contract:
+// errors on the cache side don't corrupt the primary view.
+
+func newLayeredWorkerMapWithErroringCache(t *testing.T) (*LayeredWorkerMap, *MemoryWorkerMap, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redisstate.TestClient(t, mr.Addr())
+	primary := NewMemoryWorkerMap()
+	cache := NewRedisWorkerMap(client, "test-host")
+	return NewLayeredWorkerMap(primary, cache), primary, mr
+}
+
+func TestLayeredWorkerMap_CacheErrors_GetFallsBackToPrimary(t *testing.T) {
+	m, primary, mr := newLayeredWorkerMapWithErroringCache(t)
+	primary.Set("w1", ActiveWorker{AppID: "app1", BundleID: "b1", StartedAt: time.Now()})
+
+	mr.SetError("READONLY simulated failure")
+
+	w, ok := m.Get("w1")
+	if !ok || w.AppID != "app1" {
+		t.Fatalf("Get = (%+v, %v), want app1/true", w, ok)
+	}
+}
+
+func TestLayeredWorkerMap_CacheErrors_SetPersistsPrimary(t *testing.T) {
+	m, primary, mr := newLayeredWorkerMapWithErroringCache(t)
+	mr.SetError("READONLY simulated failure")
+
+	m.Set("w1", ActiveWorker{AppID: "app1", BundleID: "b1", StartedAt: time.Now()})
+
+	if _, ok := primary.Get("w1"); !ok {
+		t.Error("primary must hold the entry even if cache write errored")
+	}
+}
+
+func TestLayeredWorkerMap_CacheErrors_DeleteClearsPrimary(t *testing.T) {
+	m, primary, mr := newLayeredWorkerMapWithErroringCache(t)
+	primary.Set("w1", ActiveWorker{AppID: "app1"})
+
+	mr.SetError("READONLY simulated failure")
+
+	m.Delete("w1")
+	if _, ok := primary.Get("w1"); ok {
+		t.Error("primary must be cleared even if cache delete errored")
+	}
+}
+
+func TestLayeredWorkerMap_CacheErrors_AggregatesReflectPrimary(t *testing.T) {
+	m, primary, mr := newLayeredWorkerMapWithErroringCache(t)
+	primary.Set("w1", ActiveWorker{AppID: "app1"})
+	primary.Set("w2", ActiveWorker{AppID: "app1"})
+	primary.Set("w3", ActiveWorker{AppID: "app2"})
+
+	mr.SetError("READONLY simulated failure")
+
+	if n := m.Count(); n != 3 {
+		t.Errorf("Count = %d, want 3", n)
+	}
+	if n := m.CountForApp("app1"); n != 2 {
+		t.Errorf("CountForApp(app1) = %d, want 2", n)
+	}
+	if ids := m.ForApp("app1"); len(ids) != 2 {
+		t.Errorf("ForApp(app1) = %v, want two entries", ids)
+	}
+}
+
+func TestLayeredWorkerMap_CacheErrors_MarkDrainingUpdatesPrimary(t *testing.T) {
+	m, primary, mr := newLayeredWorkerMapWithErroringCache(t)
+	primary.Set("w1", ActiveWorker{AppID: "app1"})
+
+	mr.SetError("READONLY simulated failure")
+
+	ids := m.MarkDraining("app1")
+	if len(ids) != 1 || ids[0] != "w1" {
+		t.Fatalf("MarkDraining = %v, want [w1]", ids)
+	}
+	w, _ := primary.Get("w1")
+	if !w.Draining {
+		t.Error("primary entry should be marked draining")
+	}
+}
+
+// TestLayeredWorkerMap_CacheRestartRewarms simulates the DoD: Redis
+// comes back empty and subsequent reads backfill the cache from the
+// primary without user-visible impact.
+func TestLayeredWorkerMap_CacheRestartRewarms(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redisstate.TestClient(t, mr.Addr())
+	primary := NewMemoryWorkerMap()
+	cache := NewRedisWorkerMap(client, "test-host")
+	m := NewLayeredWorkerMap(primary, cache)
+
+	m.Set("w1", ActiveWorker{AppID: "app1", BundleID: "b1", StartedAt: time.Now()})
+
+	// "Restart" Redis by wiping the dataset.
+	mr.FlushAll()
+	if _, ok := cache.Get("w1"); ok {
+		t.Fatal("precondition: cache should be empty post-restart")
+	}
+
+	w, ok := m.Get("w1")
+	if !ok || w.AppID != "app1" {
+		t.Fatalf("Get after restart = (%+v, %v), want app1/true", w, ok)
+	}
+	if _, ok := cache.Get("w1"); !ok {
+		t.Error("cache should be repopulated after the miss-through-read")
+	}
+}

--- a/internal/server/workermap_postgres.go
+++ b/internal/server/workermap_postgres.go
@@ -282,4 +282,51 @@ func (m *PostgresWorkerMap) execUpdate(query, op string, args ...any) {
 	}
 }
 
+// RunReaper deletes blockyard_workers rows whose last_heartbeat has been
+// stale for longer than `threshold`, every `interval`. Blocks until
+// ctx is cancelled. Caller runs it in a goroutine.
+//
+// Motivation: Redis workermap entries had implicit TTLs that cleaned up
+// after a pod died without graceful shutdown. Postgres doesn't expire
+// rows, so without this sweep a crashed pod's workers linger in the
+// shared blockyard_workers table — Registry.Get hides them via its own
+// last_heartbeat filter, but WorkerMap's Count / ForApp / IdleWorkers /
+// AppIDs would keep reporting ghosts and skew scheduler decisions.
+//
+// Pick a threshold well above registryTTL so a transient network blip
+// (heartbeat writes briefly blocked) doesn't reap a worker the health
+// poller will resume updating seconds later. cmd/blockyard/main.go
+// uses 5 × registryTTL, giving 60 s of recovery slack on top of the
+// 15 s "Registry considers dead" signal with default health intervals.
+func (m *PostgresWorkerMap) RunReaper(ctx context.Context, threshold, interval time.Duration) {
+	if threshold <= 0 {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.reapStale(ctx, threshold)
+		}
+	}
+}
+
+func (m *PostgresWorkerMap) reapStale(ctx context.Context, threshold time.Duration) {
+	cutoff := time.Now().Add(-threshold)
+	res, err := m.db.ExecContext(ctx,
+		`DELETE FROM blockyard_workers WHERE last_heartbeat < $1`, cutoff,
+	)
+	if err != nil {
+		slog.Error("postgres worker reaper", "error", err)
+		return
+	}
+	if n, _ := res.RowsAffected(); n > 0 {
+		slog.Info("postgres worker reaper: removed stale rows",
+			"count", n, "cutoff", cutoff)
+	}
+}
+
 var _ WorkerMap = (*PostgresWorkerMap)(nil)

--- a/internal/server/workermap_postgres_test.go
+++ b/internal/server/workermap_postgres_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"net/url"
@@ -149,6 +150,62 @@ func TestPostgresWorkerMapIdleSinceNullRoundTrip(t *testing.T) {
 	}
 	if !w.IdleSince.IsZero() {
 		t.Errorf("IdleSince = %v, want zero value", w.IdleSince)
+	}
+}
+
+// TestPostgresWorkerMapReaper covers the crashed-pod cleanup path: a
+// worker whose last_heartbeat falls past the reaper threshold gets its
+// row deleted so WorkerMap aggregate queries don't report a ghost.
+// Mirrors the session RunExpiry contract but operates on the shared
+// blockyard_workers table instead of a dedicated sessions table.
+func TestPostgresWorkerMapReaper(t *testing.T) {
+	db := testPGDB(t)
+	m := NewPostgresWorkerMap(db, "test-host")
+
+	m.Set("w-alive", ActiveWorker{AppID: "app1", BundleID: "b1", StartedAt: time.Now()})
+	m.Set("w-dead", ActiveWorker{AppID: "app1", BundleID: "b1", StartedAt: time.Now()})
+
+	// Push w-dead's heartbeat past the reaper threshold. w-alive's stays
+	// fresh (now()).
+	if _, err := db.Exec(
+		`UPDATE blockyard_workers SET last_heartbeat = now() - interval '10 minutes' WHERE id = $1`,
+		"w-dead",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	m.reapStale(context.Background(), 5*time.Minute)
+
+	if _, ok := m.Get("w-dead"); ok {
+		t.Error("stale worker should be reaped")
+	}
+	if _, ok := m.Get("w-alive"); !ok {
+		t.Error("fresh worker must survive the reaper")
+	}
+}
+
+// TestPostgresWorkerMapReaperZeroThresholdIsNoOp pins the
+// "disable reaper via threshold=0" contract — callers that skip the
+// reaper (e.g. single-pod debug runs) shouldn't have to not-schedule
+// it, they can schedule it with 0 and get a cheap early-return.
+func TestPostgresWorkerMapReaperZeroThresholdIsNoOp(t *testing.T) {
+	db := testPGDB(t)
+	m := NewPostgresWorkerMap(db, "test-host")
+
+	m.Set("w1", ActiveWorker{AppID: "app1", BundleID: "b1", StartedAt: time.Now()})
+	if _, err := db.Exec(
+		`UPDATE blockyard_workers SET last_heartbeat = now() - interval '1 hour' WHERE id = $1`,
+		"w1",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // RunReaper returns immediately on threshold <= 0
+	m.RunReaper(ctx, 0, time.Millisecond)
+
+	if _, ok := m.Get("w1"); !ok {
+		t.Error("threshold=0 should leave stale rows alone")
 	}
 }
 

--- a/internal/session/layered_cache_error_test.go
+++ b/internal/session/layered_cache_error_test.go
@@ -1,0 +1,152 @@
+package session
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+
+	"github.com/cynkra/blockyard/internal/redisstate"
+)
+
+// Cache-failure behavior for LayeredStore (see #262). The whole point of
+// making Postgres the primary is that Redis can go away — be restarted
+// for cert rotation, evicted, partitioned — without user-visible impact.
+// These tests pair an in-process MemoryStore (stand-in for Postgres)
+// with a real RedisStore whose miniredis is poisoned via SetError, then
+// assert every Store method still returns the correct primary answer.
+
+func newLayeredWithErroringCache(t *testing.T) (*LayeredStore, *MemoryStore, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redisstate.TestClient(t, mr.Addr())
+	primary := NewMemoryStore()
+	cache := NewRedisStore(client, time.Hour)
+	return NewLayeredStore(primary, cache), primary, mr
+}
+
+func TestLayeredStore_CacheErrors_GetFallsBackToPrimary(t *testing.T) {
+	s, primary, mr := newLayeredWithErroringCache(t)
+
+	now := time.Now().Truncate(time.Second)
+	primary.Set("sess-1", Entry{WorkerID: "w1", UserSub: "u", LastAccess: now})
+
+	mr.SetError("READONLY simulated failure")
+
+	e, ok := s.Get("sess-1")
+	if !ok {
+		t.Fatal("Get must succeed via primary when cache errors")
+	}
+	if e.WorkerID != "w1" {
+		t.Errorf("WorkerID = %q, want %q", e.WorkerID, "w1")
+	}
+}
+
+func TestLayeredStore_CacheErrors_SetPersistsPrimary(t *testing.T) {
+	s, primary, mr := newLayeredWithErroringCache(t)
+	mr.SetError("READONLY simulated failure")
+
+	s.Set("sess-1", Entry{WorkerID: "w1", LastAccess: time.Now()})
+
+	if _, ok := primary.Get("sess-1"); !ok {
+		t.Error("primary must hold the entry even if cache write errored")
+	}
+}
+
+func TestLayeredStore_CacheErrors_TouchReturnsPrimary(t *testing.T) {
+	s, primary, mr := newLayeredWithErroringCache(t)
+	primary.Set("sess-1", Entry{WorkerID: "w1", LastAccess: time.Now().Add(-time.Hour)})
+
+	mr.SetError("READONLY simulated failure")
+
+	if !s.Touch("sess-1") {
+		t.Error("Touch must report true based on primary, not cache")
+	}
+}
+
+func TestLayeredStore_CacheErrors_DeleteClearsPrimary(t *testing.T) {
+	s, primary, mr := newLayeredWithErroringCache(t)
+	primary.Set("sess-1", Entry{WorkerID: "w1", LastAccess: time.Now()})
+
+	mr.SetError("READONLY simulated failure")
+
+	s.Delete("sess-1")
+	if _, ok := primary.Get("sess-1"); ok {
+		t.Error("primary must be cleared even if cache delete errored")
+	}
+}
+
+func TestLayeredStore_CacheErrors_DeleteByWorkerReturnsPrimaryCount(t *testing.T) {
+	s, primary, mr := newLayeredWithErroringCache(t)
+	primary.Set("sess-1", Entry{WorkerID: "w1", LastAccess: time.Now()})
+	primary.Set("sess-2", Entry{WorkerID: "w1", LastAccess: time.Now()})
+
+	mr.SetError("READONLY simulated failure")
+
+	if n := s.DeleteByWorker("w1"); n != 2 {
+		t.Errorf("DeleteByWorker = %d, want 2 (primary count)", n)
+	}
+}
+
+func TestLayeredStore_CacheErrors_CountAggregatesFromPrimary(t *testing.T) {
+	s, primary, mr := newLayeredWithErroringCache(t)
+	primary.Set("sess-1", Entry{WorkerID: "w1"})
+	primary.Set("sess-2", Entry{WorkerID: "w1"})
+
+	mr.SetError("READONLY simulated failure")
+
+	if n := s.CountForWorker("w1"); n != 2 {
+		t.Errorf("CountForWorker = %d, want 2", n)
+	}
+	if n := s.CountForWorkers([]string{"w1"}); n != 2 {
+		t.Errorf("CountForWorkers = %d, want 2", n)
+	}
+}
+
+func TestLayeredStore_CacheErrors_RerouteRunsAgainstPrimary(t *testing.T) {
+	s, primary, mr := newLayeredWithErroringCache(t)
+	primary.Set("sess-1", Entry{WorkerID: "w1", LastAccess: time.Now()})
+
+	mr.SetError("READONLY simulated failure")
+
+	if n := s.RerouteWorker("w1", "w2"); n != 1 {
+		t.Errorf("RerouteWorker = %d, want 1", n)
+	}
+	e, _ := primary.Get("sess-1")
+	if e.WorkerID != "w2" {
+		t.Errorf("primary worker_id = %q, want %q", e.WorkerID, "w2")
+	}
+}
+
+// TestLayeredStore_CacheRestartRewarms simulates the parent DoD:
+// Redis goes away (miniredis.Close via mr.FastForward + SetError),
+// then comes back empty, and subsequent reads repopulate the cache
+// from the primary without user-visible impact.
+func TestLayeredStore_CacheRestartRewarms(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redisstate.TestClient(t, mr.Addr())
+	primary := NewMemoryStore()
+	cache := NewRedisStore(client, time.Hour)
+	s := NewLayeredStore(primary, cache)
+
+	// Pre-restart: both layers hold the session.
+	s.Set("sess-1", Entry{WorkerID: "w1", LastAccess: time.Now()})
+	if _, ok := cache.Get("sess-1"); !ok {
+		t.Fatal("precondition: cache should hold the entry")
+	}
+
+	// Redis "restarts": wipe the dataset to model a fresh instance.
+	mr.FlushAll()
+	if _, ok := cache.Get("sess-1"); ok {
+		t.Fatal("precondition: cache should be empty post-restart")
+	}
+
+	// Read through the Layered store: cache miss + primary hit + backfill.
+	e, ok := s.Get("sess-1")
+	if !ok || e.WorkerID != "w1" {
+		t.Fatalf("Get after restart = (%+v, %v), want w1/true", e, ok)
+	}
+	if _, ok := cache.Get("sess-1"); !ok {
+		t.Error("cache should be repopulated after the miss-through-read")
+	}
+}

--- a/internal/session/layered_cache_error_test.go
+++ b/internal/session/layered_cache_error_test.go
@@ -12,15 +12,20 @@ import (
 // Cache-failure behavior for LayeredStore (see #262). The whole point of
 // making Postgres the primary is that Redis can go away — be restarted
 // for cert rotation, evicted, partitioned — without user-visible impact.
-// These tests pair an in-process MemoryStore (stand-in for Postgres)
-// with a real RedisStore whose miniredis is poisoned via SetError, then
-// assert every Store method still returns the correct primary answer.
+// These tests pair a real PostgresStore primary with a real RedisStore
+// cache whose miniredis is poisoned via SetError, then assert every
+// Store method still returns the correct primary answer. Using the
+// production primary (not MemoryStore) ensures the SQL path behaves
+// correctly when the cache fails mid-operation.
+//
+// Skips when BLOCKYARD_TEST_POSTGRES_URL is not set. CI's `unit` job
+// always provides one.
 
-func newLayeredWithErroringCache(t *testing.T) (*LayeredStore, *MemoryStore, *miniredis.Miniredis) {
+func newLayeredWithErroringCache(t *testing.T) (*LayeredStore, *PostgresStore, *miniredis.Miniredis) {
 	t.Helper()
+	primary := NewPostgresStore(testPGDB(t), time.Hour)
 	mr := miniredis.RunT(t)
 	client := redisstate.TestClient(t, mr.Addr())
-	primary := NewMemoryStore()
 	cache := NewRedisStore(client, time.Hour)
 	return NewLayeredStore(primary, cache), primary, mr
 }
@@ -90,8 +95,8 @@ func TestLayeredStore_CacheErrors_DeleteByWorkerReturnsPrimaryCount(t *testing.T
 
 func TestLayeredStore_CacheErrors_CountAggregatesFromPrimary(t *testing.T) {
 	s, primary, mr := newLayeredWithErroringCache(t)
-	primary.Set("sess-1", Entry{WorkerID: "w1"})
-	primary.Set("sess-2", Entry{WorkerID: "w1"})
+	primary.Set("sess-1", Entry{WorkerID: "w1", LastAccess: time.Now()})
+	primary.Set("sess-2", Entry{WorkerID: "w1", LastAccess: time.Now()})
 
 	mr.SetError("READONLY simulated failure")
 
@@ -118,14 +123,14 @@ func TestLayeredStore_CacheErrors_RerouteRunsAgainstPrimary(t *testing.T) {
 	}
 }
 
-// TestLayeredStore_CacheRestartRewarms simulates the parent DoD:
-// Redis goes away (miniredis.Close via mr.FastForward + SetError),
-// then comes back empty, and subsequent reads repopulate the cache
-// from the primary without user-visible impact.
+// TestLayeredStore_CacheRestartRewarms simulates the parent DoD: Redis
+// "restarts" (miniredis FlushAll wipes the dataset), and subsequent
+// reads repopulate the cache from the Postgres primary without
+// user-visible impact.
 func TestLayeredStore_CacheRestartRewarms(t *testing.T) {
+	primary := NewPostgresStore(testPGDB(t), time.Hour)
 	mr := miniredis.RunT(t)
 	client := redisstate.TestClient(t, mr.Addr())
-	primary := NewMemoryStore()
 	cache := NewRedisStore(client, time.Hour)
 	s := NewLayeredStore(primary, cache)
 


### PR DESCRIPTION
## Summary
- Adds layered-cache error tests (session, registry, worker map, port/UID allocators) against `PostgresStore`/`PostgresRegistry`/`PostgresWorkerMap` primaries so the parent DoD ("Redis restart causes zero user-visible impact") is pinned with real SQL on the wire.
- Adds a Postgres-only end-to-end integration test that walks a sticky-session lifecycle (spawn → route → touch → drain → reroute → reap → teardown) without any Redis.
- Fixes `layeredPortAllocator` / `layeredUIDAllocator` `CleanupOwnedOrphans` to treat the cache side as best-effort — Redis down at startup no longer blocks Postgres orphan recovery.
- Pins Redis client timeouts to 500 ms so a Redis outage adds ≤ 500 ms per mirror op instead of the go-redis 3-5 s defaults.
- Scopes the worker reconcile (`StartupCleanup` / `pollOnce` / `GracefulShutdown`) to the owning `server_id` via `WorkersForServer(srv.ServerID)`, so a sibling pod's boot can't wipe this pod's rows from the shared `blockyard_workers` table.
- Adds `PostgresWorkerMap.RunReaper` to sweep rows whose `last_heartbeat` is past 5 × registryTTL — restores the implicit TTL the Redis workermap had, preventing crashed-pod ghosts from skewing `Count`/`ForApp`/`IdleWorkers`.

Fixes #262