### PR TITLE
test(proxy): skip TestDocsServesHTML when Hugo output is missing

### DIFF
--- a/internal/api/docs_test.go
+++ b/internal/api/docs_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 )
@@ -41,12 +42,18 @@ func TestDocsServesHTML(t *testing.T) {
 	}
 
 	body := rec.Body.String()
-	// The stub at internal/docs/dist/index.html ships when Hugo
-	// hasn't run. Skip locally so `go test ./...` stays green without
-	// out-of-band setup; CI's unit job builds docs first, so a real
-	// regression still fires the bk-hero check below.
+	// Stub at internal/docs/dist/index.html indicates the Hugo build
+	// step was skipped. In CI this is a contract violation — the unit
+	// job's Hugo prep must run so TestDocsServesHTML exercises the
+	// real embed (the gap that let broken docs reach prod before).
+	// Locally, skip so `go test ./...` stays green without requiring
+	// every developer to run Hugo first.
 	if strings.Contains(body, "Documentation was not included in this build") {
-		t.Skip("docs stub served — run `hugo --minify --baseURL /docs/` from docs/ and copy public/ to internal/docs/dist/ to exercise this test (CI unit job does this automatically)")
+		const msg = "docs stub served — run `hugo --minify --baseURL /docs/` from docs/ and copy public/ to internal/docs/dist/ to exercise this test (CI unit job does this automatically)"
+		if os.Getenv("CI") != "" {
+			t.Fatal(msg)
+		}
+		t.Skip(msg)
 	}
 	// Marker from docs/layouts/index.html; only present when Hugo
 	// produced real output with the hugo-book theme submodule. Also

--- a/internal/api/docs_test.go
+++ b/internal/api/docs_test.go
@@ -41,13 +41,12 @@ func TestDocsServesHTML(t *testing.T) {
 	}
 
 	body := rec.Body.String()
-	// Guard against the "docs not included" stub at
-	// internal/docs/dist/index.html being served because the Hugo
-	// build step was skipped. The stub is valid HTML, so status +
-	// content-type alone passes silently — that gap is exactly how
-	// broken docs reached production before.
+	// The stub at internal/docs/dist/index.html ships when Hugo
+	// hasn't run. Skip locally so `go test ./...` stays green without
+	// out-of-band setup; CI's unit job builds docs first, so a real
+	// regression still fires the bk-hero check below.
 	if strings.Contains(body, "Documentation was not included in this build") {
-		t.Fatal("served the docs stub placeholder — run `hugo --minify --baseURL /docs/` from docs/ and copy public/ to internal/docs/dist/ before testing (CI unit job does this automatically)")
+		t.Skip("docs stub served — run `hugo --minify --baseURL /docs/` from docs/ and copy public/ to internal/docs/dist/ to exercise this test (CI unit job does this automatically)")
 	}
 	// Marker from docs/layouts/index.html; only present when Hugo
 	// produced real output with the hugo-book theme submodule. Also


### PR DESCRIPTION
## Summary
- `TestDocsServesHTML` called `t.Fatal` when served the stub at `internal/docs/dist/index.html`, which is what ships when Hugo hasn't run — so every local `go test ./...` failed.
- In CI, keep `t.Fatal`: the stub detector is the only guard that enforces the unit job's Hugo-prep contract (the original gap that let broken docs reach prod).
- Locally, `t.Skip` with the same diagnostic so developers can run the full suite without building Hugo first. Gated on the `CI` env var.

Fixes #296