### PR TITLE
ci(misc): merge per-variant Trivy SARIFs into one category

### DIFF
--- a/.github/actions/scan-image/action.yml
+++ b/.github/actions/scan-image/action.yml
@@ -1,16 +1,18 @@
 name: Trivy image scan
 description: >
   Scan a ghcr.io container image for CVEs, filter through
-  .trivyignore.rego, and upload the SARIF to the GitHub Security tab.
-  Shared between publish.yml (continuous main) and release.yml (tagged
-  releases) so both apply the same severity threshold and ignore policy.
+  .trivyignore.rego, tag each result with the variant name, and
+  upload the SARIF as a workflow artifact. A later aggregation job
+  (actions/upload-sarif-merged) dedupes across variants before
+  pushing to the Security tab, so a CVE shared by multiple images
+  surfaces as a single alert listing every affected variant.
 
 inputs:
   image-ref:
     description: Full image reference (e.g. ghcr.io/cynkra/blockyard:build-linux-amd64).
     required: true
   variant:
-    description: Variant name (docker | process | everything) — used for the SARIF category and output filename.
+    description: Variant name (docker | process | everything | worker) — appears in merged SARIF alerts to identify affected images.
     required: true
   ghcr-username:
     description: GHCR username for pulling the image.
@@ -51,11 +53,25 @@ runs:
         TRIVY_USERNAME: ${{ inputs.ghcr-username }}
         TRIVY_PASSWORD: ${{ inputs.ghcr-token }}
 
-    - name: Upload Trivy results to GitHub Security tab
+    # Stamp the variant on every result so the downstream merge step
+    # can aggregate "affects: docker, process, everything" into a
+    # single alert. Runs on Trivy failure too so fail-on-findings
+    # still produces a taggable SARIF for the Security tab.
+    - name: Tag SARIF results with variant
       if: always()
-      uses: github/codeql-action/upload-sarif@v4
+      shell: bash
+      run: |
+        f=trivy-results-${{ inputs.variant }}.sarif
+        [ -f "$f" ] || exit 0
+        jq --arg v "${{ inputs.variant }}" '
+          .runs[].results[]?.properties.variant = $v
+        ' "$f" > "$f.tagged" && mv "$f.tagged" "$f"
+
+    - name: Upload Trivy SARIF as artifact
+      if: always()
+      uses: actions/upload-artifact@v7
       with:
-        sarif_file: trivy-results-${{ inputs.variant }}.sarif
-        # Per-variant category so the three scans don't overwrite each
-        # other's alerts in the Security tab.
-        category: trivy-${{ inputs.variant }}
+        name: sarif-${{ inputs.variant }}
+        path: trivy-results-${{ inputs.variant }}.sarif
+        retention-days: 1
+        if-no-files-found: warn

--- a/.github/actions/upload-sarif-merged/action.yml
+++ b/.github/actions/upload-sarif-merged/action.yml
@@ -1,0 +1,77 @@
+name: Merge & upload per-variant Trivy SARIFs
+description: >
+  Download every sarif-* artifact produced by the scan-image action
+  in this run, merge results that share a (ruleId, first-location
+  URI, startLine) key across variants — aggregating the tagged
+  variant names into the alert message — and upload once under a
+  single category. GitHub code scanning dedupes within a category,
+  so this collapses the same libssl/libcurl/... CVE across all
+  variant images into one Security-tab alert that still names every
+  affected variant.
+
+inputs:
+  category:
+    description: SARIF category under which to upload the merged result (e.g. trivy-server, trivy-worker).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/download-artifact@v8
+      with:
+        pattern: sarif-*
+        path: sarif-input
+        merge-multiple: true
+
+    - name: Merge SARIFs by (ruleId, location)
+      id: merge
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p sarif-output
+        shopt -s nullglob
+        files=(sarif-input/*.sarif)
+        if [ ${#files[@]} -eq 0 ]; then
+          echo "No SARIF artifacts found; skipping upload."
+          echo "uploaded=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        jq -s '
+          (.[0].runs[0] | del(.results)) as $baseRun
+          | [.[] | .runs[] | .results[]?] as $all
+          | ($all | group_by([
+              .ruleId,
+              (.locations[0]?.physicalLocation?.artifactLocation?.uri // ""),
+              (.locations[0]?.physicalLocation?.region?.startLine // 0)
+            ])) as $groups
+          | {
+              "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+              version: "2.1.0",
+              runs: [
+                $baseRun + {
+                  results: [
+                    $groups[] | (
+                      ([.[].properties.variant // empty] | unique) as $variants
+                      | (.[0]) + {
+                          message: {
+                            text: (
+                              (.[0].message.text // "")
+                              + (if ($variants | length) > 0
+                                 then " [affects: " + ($variants | join(", ")) + "]"
+                                 else "" end)
+                            )
+                          }
+                        }
+                    )
+                  ]
+                }
+              ]
+            }
+        ' "${files[@]}" > sarif-output/merged.sarif
+        echo "uploaded=true" >> "$GITHUB_OUTPUT"
+
+    - uses: github/codeql-action/upload-sarif@v4
+      if: steps.merge.outputs.uploaded == 'true'
+      with:
+        sarif_file: sarif-output/merged.sarif
+        category: ${{ inputs.category }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,7 +103,6 @@ jobs:
     timeout-minutes: 5
     permissions:
       packages: read
-      security-events: write
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/scan-image
@@ -112,6 +111,19 @@ jobs:
           variant: ${{ matrix.variant }}
           ghcr-username: ${{ github.actor }}
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-sarif:
+    needs: scan-image
+    if: ${{ always() && needs.scan-image.result != 'skipped' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/upload-sarif-merged
+        with:
+          category: trivy-server
 
   manifest:
     needs: [server-image, scan-image]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,6 @@ jobs:
     timeout-minutes: 10
     permissions:
       packages: read
-      security-events: write
     strategy:
       # Scan amd64 only — arch-specific CVE delta is typically zero
       # and doubling the matrix doubles CI cost. Trivy per variant
@@ -56,6 +55,21 @@ jobs:
           ghcr-username: ${{ github.actor }}
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-findings: "true"
+
+  # Runs even when scan-image fails (fail-on-findings=true on release)
+  # so CVEs that block the release still surface in the Security tab.
+  upload-sarif:
+    needs: scan-image
+    if: ${{ always() && needs.scan-image.result != 'skipped' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/upload-sarif-merged
+        with:
+          category: trivy-server
 
   server-manifest:
     needs: scan-image

--- a/.github/workflows/worker-publish.yml
+++ b/.github/workflows/worker-publish.yml
@@ -40,7 +40,6 @@ jobs:
     timeout-minutes: 5
     permissions:
       packages: read
-      security-events: write
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/scan-image
@@ -52,6 +51,19 @@ jobs:
           variant: worker
           ghcr-username: ${{ github.actor }}
           ghcr-token: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-sarif:
+    needs: scan-worker-image
+    if: ${{ always() && needs.scan-worker-image.result != 'skipped' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/upload-sarif-merged
+        with:
+          category: trivy-worker
 
   worker-manifest:
     needs: [worker-image, scan-worker-image]


### PR DESCRIPTION
## Summary
- Collapse `trivy-docker` / `trivy-process` / `trivy-everything` into a single `trivy-server` category so shared-base CVEs (libssl, libcurl, …) stop appearing 3× in the Security tab.
- `scan-image` now stamps each result with `properties.variant` and uploads the SARIF as a workflow artifact instead of pushing directly.
- New `upload-sarif-merged` composite action downloads every `sarif-*` artifact, groups by `(ruleId, location URI, startLine)`, aggregates variants into the message as `[affects: docker, process, everything]`, and uploads once under the target category.
- Wired into `publish.yml`, `release.yml`, and `worker-publish.yml`; upload job runs `if: always()` so release-gating CVEs still surface even when Trivy's `fail-on-findings` blocks the manifest.
- Pre-existing alerts under the old per-variant categories won't auto-close — dismiss manually once `trivy-server` backfills.