### PR TITLE
fix(process): extend bwrap host-mapping deadline for slow CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,9 +473,15 @@ jobs:
         # default module cache path blows up. Point GOCACHE/GOMODCACHE
         # at /tmp which is always world-writable. Same override used
         # for root and non-root test runs so the paths are symmetric.
+        #
+        # BLOCKYARD_TEST_BWRAP_MODE is read by
+        # TestCheckBwrapHostUIDMapping so the test knows what bwrap
+        # capability profile to expect — reliably, rather than via a
+        # timing-racy re-probe of bwrap from within the test (#299).
         env:
           GOCACHE: /tmp/gocache
           GOMODCACHE: /tmp/gomodcache
+          BLOCKYARD_TEST_BWRAP_MODE: ${{ matrix.mode }}
         run: |
           mkdir -p "$GOCACHE" "$GOMODCACHE"
           case "${{ matrix.mode }}" in
@@ -495,6 +501,7 @@ jobs:
                 PATH="$PATH" \
                 GOCACHE="$GOCACHE" \
                 GOMODCACHE="$GOMODCACHE" \
+                BLOCKYARD_TEST_BWRAP_MODE="$BLOCKYARD_TEST_BWRAP_MODE" \
                 go test -count=1 -tags process_test \
                 -coverprofile=coverage-process-${{ matrix.mode }}.out \
                 -coverpkg=./internal/... \

--- a/internal/backend/process/preflight_internal_test.go
+++ b/internal/backend/process/preflight_internal_test.go
@@ -60,11 +60,25 @@ func TestCheckBwrapHostUIDMapping(t *testing.T) {
 	}
 }
 
-// probeBwrapModeInternal is the internal-package twin of the
-// detectBwrapMode helper in process_integration_test.go. We can't
-// share the helper because the integration tests live in
-// `package process_test` and this file lives in `package process`.
-// Returns "unavailable", "host-mapped", or "no-host-map".
+// probeBwrapModeInternal classifies the CI environment's bwrap
+// capability profile. Previous versions re-probed bwrap from within
+// the test by spawning a throwaway sandbox and inspecting /proc; that
+// race'd the kernel's uid_map write and classified slow runners
+// incorrectly, which is how #299 slipped through (helper saw
+// "host-mapped" while the real check was still snapshotting a partial
+// remap). The CI workflow already knows the mode — it just needs to
+// tell the test. We read BLOCKYARD_TEST_BWRAP_MODE, which the
+// `process (root|setuid|unprivileged)` matrix jobs set explicitly.
+//
+// When the env var is unset (running the tagged test outside the
+// matrix — e.g., a dev's laptop), fall back to the old probe so the
+// test still makes SOMETHING of the local environment. The fallback
+// can still flake, but it only runs off-CI where test failures don't
+// block merges.
+//
+// Returns "unavailable" (bwrap not installed / userns blocked),
+// "host-mapped" (root or setuid modes — check should return OK), or
+// "no-host-map" (unprivileged mode — check should return Error).
 func probeBwrapModeInternal(t *testing.T) string {
 	t.Helper()
 	if _, err := exec.LookPath("bwrap"); err != nil {
@@ -79,6 +93,14 @@ func probeBwrapModeInternal(t *testing.T) string {
 		"--", "/bin/true").Run(); err != nil {
 		return "unavailable"
 	}
+	switch os.Getenv("BLOCKYARD_TEST_BWRAP_MODE") {
+	case "root", "setuid":
+		return "host-mapped"
+	case "unprivileged":
+		return "no-host-map"
+	}
+	// Fallback: no CI hint, re-probe with the pre-#299 timing-based
+	// classifier. Not reliable under load — see the doc comment above.
 	probeUID := os.Getuid() + 12345
 	if probeUID == os.Getuid() {
 		probeUID++


### PR DESCRIPTION
## Summary

- `checkBwrapHostUIDMapping` poll deadline bumped 1s → 2s; bwrap child sleep 2s → 3s to keep the process strictly alive past the deadline.
- If the deadline still hits while the kernel was mid-remap (uid_map written, gid_map not yet — or vice versa), emit a distinct "did not converge" error instead of the misleading "bwrap --uid/--gid do not affect the host view" message. Future recurrences will be unambiguous.
- No behavior change for the genuine no-host-map configuration path (unprivileged userns without setuid bwrap): still ends on State A (both ids = caller's) and returns the existing "host view" error.

Fixes #299