### PR TITLE
feat(db): per-user PG role provisioning on first login

### DIFF
--- a/cmd/blockyard/main.go
+++ b/cmd/blockyard/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cynkra/blockyard/internal/audit"
 	"github.com/cynkra/blockyard/internal/auth"
 	"github.com/cynkra/blockyard/internal/backend"
+	"github.com/cynkra/blockyard/internal/boardstorage"
 	"github.com/cynkra/blockyard/internal/config"
 	"github.com/cynkra/blockyard/internal/db"
 	"github.com/cynkra/blockyard/internal/drain"
@@ -170,6 +171,17 @@ func main() {
 			slog.Error("board storage preflight failed", "error", err)
 			os.Exit(1)
 		}
+
+		// blockyard_admin bootstrap (#284). Uses PG16-only GRANT
+		// syntax; the preflight above is what makes this safe to run
+		// unconditionally here.
+		adminCtx, adminCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		err = boardstorage.EnsureBlockyardAdmin(adminCtx, database)
+		adminCancel()
+		if err != nil {
+			slog.Error("board storage admin bootstrap failed", "error", err)
+			os.Exit(1)
+		}
 	}
 
 	// Initialize backend via the tag-gated factory map.
@@ -287,6 +299,19 @@ func main() {
 		if err := integration.Bootstrap(context.Background(), srv.VaultClient, cfg.Openbao.JWTAuthPath, cfg.Openbao.SkipPolicyScopeCheck); err != nil {
 			slog.Error("OpenBao bootstrap failed", "error", err)
 			os.Exit(1)
+		}
+	}
+
+	// Board-storage provisioner — constructed only when both vault
+	// and board storage are configured. Drives per-user PG role +
+	// vault static-role setup from the OIDC callback and from the
+	// admin deactivate/reactivate path (#284).
+	if cfg.Database.BoardStorage {
+		srv.BoardStorage = &boardstorage.Provisioner{
+			DB:              database,
+			Vault:           srv.VaultClient,
+			VaultMount:      cfg.Database.VaultMount,
+			VaultDBConnName: cfg.Database.VaultDBConnection,
 		}
 	}
 

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cynkra/blockyard/internal/audit"
 	"github.com/cynkra/blockyard/internal/auth"
+	"github.com/cynkra/blockyard/internal/boardstorage"
 	"github.com/cynkra/blockyard/internal/db"
 	"github.com/cynkra/blockyard/internal/integration"
 	"github.com/cynkra/blockyard/internal/server"
@@ -363,6 +364,21 @@ func UpdateUser(srv *server.Server) http.HandlerFunc {
 		if user == nil {
 			notFound(w, "user not found")
 			return
+		}
+
+		// Mirror the active flag onto the per-user PG role (#284).
+		// DROP would fail once `boards.owner_sub` references the role
+		// by name; NOLOGIN blocks the user without breaking ownership.
+		// Only runs when board storage is enabled AND this user has
+		// been provisioned — unprovisioned users have no PG role to
+		// flip.
+		if body.Active != nil && srv.BoardStorage != nil {
+			if pgRole, perr := srv.DB.GetUserPgRole(r.Context(), sub); perr == nil && pgRole != "" {
+				if err := boardstorage.SetRoleLogin(r.Context(), srv.DB, pgRole, *body.Active); err != nil {
+					slog.Warn("failed to sync PG role LOGIN state",
+						"sub", sub, "role", pgRole, "active", *body.Active, "error", err)
+				}
+			}
 		}
 
 		if srv.AuditLog != nil {

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -375,7 +375,7 @@ func UpdateUser(srv *server.Server) http.HandlerFunc {
 		if body.Active != nil && srv.BoardStorage != nil {
 			if pgRole, perr := srv.DB.GetUserPgRole(r.Context(), sub); perr == nil && pgRole != "" {
 				if err := boardstorage.SetRoleLogin(r.Context(), srv.DB, pgRole, *body.Active); err != nil {
-					slog.Warn("failed to sync PG role LOGIN state",
+					slog.Warn("failed to sync PG role LOGIN state", //nolint:gosec // G706: slog structured logging handles this
 						"sub", sub, "role", pgRole, "active", *body.Active, "error", err)
 				}
 			}

--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
@@ -40,6 +41,15 @@ type Deps struct {
 	UserSessions *UserSessionStore
 	AuditLog     *audit.Log
 	DB           *db.DB
+
+	// BoardStorageProvisioner, when non-nil, runs the per-user PG
+	// role / vault static-role provisioning after a successful OIDC
+	// login. Wired in from main.go only when database.board_storage
+	// is enabled. A failure aborts the login with 502 so the user
+	// does not start a session with missing credentials; a retry on
+	// next login replays cleanly because every provisioning step is
+	// idempotent.
+	BoardStorageProvisioner func(ctx context.Context, sub string) error
 }
 
 // defaultUserRole returns the role to assign to a brand-new OIDC user.
@@ -263,6 +273,20 @@ func CallbackHandler(deps *Deps) http.HandlerFunc {
 			if dbUser != nil && !dbUser.Active {
 				slog.Warn("deactivated user attempted login", "sub", subClaim)
 				http.Error(w, "account deactivated", http.StatusForbidden)
+				return
+			}
+		}
+
+		// 5b. Board-storage first-login provisioning. Runs after the
+		// users row exists so SetUserPgRole (the final step inside the
+		// provisioner) has a row to update. Failure aborts the login
+		// with 502 — no session cookie is issued, and retrying on the
+		// next login replays cleanly because every step is idempotent.
+		if deps.BoardStorageProvisioner != nil {
+			if err := deps.BoardStorageProvisioner(r.Context(), subClaim); err != nil {
+				slog.Error("board storage provisioning failed",
+					"sub", subClaim, "error", err)
+				http.Error(w, "bad gateway", http.StatusBadGateway)
 				return
 			}
 		}

--- a/internal/boardstorage/admin.go
+++ b/internal/boardstorage/admin.go
@@ -1,0 +1,41 @@
+package boardstorage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cynkra/blockyard/internal/db"
+)
+
+// ensureAdminSQL is idempotent — safe to run at every boot. Uses
+// PG16-only GRANT syntax (INHERIT FALSE, SET FALSE); callers must
+// gate on the PG16+ preflight from #283 before invoking.
+//
+// Load-bearing property: blockyard_admin can GRANT blockr_user to
+// per-user roles (ADMIN OPTION) but cannot itself SET ROLE
+// blockr_user (SET FALSE) nor inherit its privileges (INHERIT
+// FALSE). So a compromised admin connection can provision and
+// deactivate users, but cannot read or write user data.
+const ensureAdminSQL = `DO $$ BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'blockyard_admin') THEN
+        CREATE ROLE blockyard_admin NOINHERIT CREATEROLE;
+        GRANT blockr_user TO blockyard_admin
+            WITH ADMIN OPTION, INHERIT FALSE, SET FALSE;
+    END IF;
+END $$`
+
+// EnsureBlockyardAdmin runs the idempotent startup SQL that creates
+// the blockyard_admin role (and grants it ADMIN OPTION on
+// blockr_user) when board storage is enabled. No-op if the role
+// already exists.
+//
+// Not a migration: the GRANT syntax is PG16-only, and operators
+// may run on PG13/14/15 with board storage disabled. Migrations
+// are dialect-sensitive but not version-sensitive; this sidesteps
+// that by living in Go startup code guarded by the preflight.
+func EnsureBlockyardAdmin(ctx context.Context, d *db.DB) error {
+	if _, err := d.ExecContext(ctx, ensureAdminSQL); err != nil {
+		return fmt.Errorf("ensure blockyard_admin: %w", err)
+	}
+	return nil
+}

--- a/internal/boardstorage/admin_pg_test.go
+++ b/internal/boardstorage/admin_pg_test.go
@@ -1,0 +1,74 @@
+package boardstorage
+
+import (
+	"context"
+	"testing"
+)
+
+func TestEnsureBlockyardAdmin_CreatesRole(t *testing.T) {
+	d := boardStoragePgDB(t)
+	// PG roles are cluster-global, not per-database, so an earlier
+	// test in this run (or a previous invocation) may have left
+	// blockyard_admin behind. Idempotent bootstrap handles both
+	// states — the post-condition check below is what matters.
+	if err := EnsureBlockyardAdmin(context.Background(), d); err != nil {
+		t.Fatalf("EnsureBlockyardAdmin: %v", err)
+	}
+
+	// Role now exists with the expected attributes.
+	var rolcreaterole, rolinherit bool
+	err := d.QueryRowContext(context.Background(),
+		`SELECT rolcreaterole, rolinherit FROM pg_roles WHERE rolname = 'blockyard_admin'`,
+	).Scan(&rolcreaterole, &rolinherit)
+	if err != nil {
+		t.Fatalf("query role attrs: %v", err)
+	}
+	if !rolcreaterole {
+		t.Error("blockyard_admin missing CREATEROLE")
+	}
+	if rolinherit {
+		t.Error("blockyard_admin should be NOINHERIT")
+	}
+
+	// Membership check: blockr_user granted WITH ADMIN OPTION, SET
+	// FALSE, INHERIT FALSE. pg_auth_members exposes all three as
+	// booleans.
+	var admin, inherit, setOpt bool
+	err = d.QueryRowContext(context.Background(), `
+        SELECT m.admin_option, m.inherit_option, m.set_option
+        FROM pg_auth_members m
+        JOIN pg_roles r ON r.oid = m.roleid
+        JOIN pg_roles g ON g.oid = m.member
+        WHERE r.rolname = 'blockr_user' AND g.rolname = 'blockyard_admin'`,
+	).Scan(&admin, &inherit, &setOpt)
+	if err != nil {
+		t.Fatalf("pg_auth_members: %v", err)
+	}
+	if !admin {
+		t.Error("blockr_user grant to blockyard_admin missing ADMIN OPTION")
+	}
+	if inherit {
+		t.Error("blockr_user grant should be INHERIT FALSE")
+	}
+	if setOpt {
+		t.Error("blockr_user grant should be SET FALSE")
+	}
+}
+
+func TestEnsureBlockyardAdmin_Idempotent(t *testing.T) {
+	d := boardStoragePgDB(t)
+	for i := 0; i < 3; i++ {
+		if err := EnsureBlockyardAdmin(context.Background(), d); err != nil {
+			t.Fatalf("run %d: %v", i, err)
+		}
+	}
+	var count int
+	if err := d.QueryRowContext(context.Background(),
+		`SELECT count(*) FROM pg_roles WHERE rolname = 'blockyard_admin'`,
+	).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("blockyard_admin count = %d, want 1", count)
+	}
+}

--- a/internal/boardstorage/pgtest_test.go
+++ b/internal/boardstorage/pgtest_test.go
@@ -1,0 +1,215 @@
+package boardstorage
+
+import (
+	"context"
+	"database/sql"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cynkra/blockyard/internal/config"
+	"github.com/cynkra/blockyard/internal/db"
+	"github.com/google/uuid"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// pgBaseURL is the superuser connection URL, populated by the CI job
+// that runs this package's tests. Empty locally → tests skip.
+var pgBaseURL = os.Getenv("BLOCKYARD_TEST_POSTGRES_URL")
+
+// boardStoragePgDB opens an isolated PostgreSQL database for one test,
+// runs migrations, and pre-creates roles the board-storage flow
+// depends on but that migrations don't provide (they're deployment
+// setup in production — see #285):
+//
+//   - vault_db_admin: GRANT target for per-user ADMIN OPTION chain.
+//   - blockyard_admin: created here so the provisioner's GRANT
+//     blockr_user path runs exactly once; tests also assert the
+//     bootstrap SQL is idempotent via EnsureBlockyardAdmin.
+//
+// Each test gets a fresh database via CREATE DATABASE on the shared
+// server; the database is dropped on cleanup.
+func boardStoragePgDB(t *testing.T) *db.DB {
+	t.Helper()
+	if pgBaseURL == "" {
+		t.Skip("BLOCKYARD_TEST_POSTGRES_URL not set")
+	}
+	dbName := "test_" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16]
+	admin, err := sql.Open("pgx", pgBaseURL)
+	if err != nil {
+		t.Fatalf("admin open: %v", err)
+	}
+	if _, err := admin.Exec("CREATE DATABASE " + dbName); err != nil {
+		admin.Close()
+		t.Fatalf("create database: %v", err)
+	}
+	admin.Close()
+
+	testURL := replaceDBName(pgBaseURL, dbName)
+	d, err := db.Open(config.DatabaseConfig{Driver: "postgres", URL: testURL})
+	if err != nil {
+		t.Fatalf("open migrated db: %v", err)
+	}
+
+	// Pre-create roles that operators set up in deployment (#285).
+	// Tests don't run the full deployment; creating them here
+	// satisfies the per-user GRANT chain the provisioner emits.
+	mustExec(t, d, `DO $$ BEGIN
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'vault_db_admin') THEN
+            CREATE ROLE vault_db_admin NOINHERIT;
+        END IF;
+    END $$`)
+
+	t.Cleanup(func() {
+		d.Close()
+		cleanup, _ := sql.Open("pgx", pgBaseURL)
+		defer cleanup.Close()
+		// Kill lingering connections so DROP DATABASE succeeds even
+		// if pool close left a conn in TIME_WAIT.
+		cleanup.Exec(`SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+                        WHERE datname = $1`, dbName)
+		cleanup.Exec("DROP DATABASE IF EXISTS " + dbName)
+	})
+	return d
+}
+
+func mustExec(t *testing.T, d *db.DB, stmt string, args ...any) {
+	t.Helper()
+	if _, err := d.ExecContext(context.Background(), stmt, args...); err != nil {
+		t.Fatalf("exec %q: %v", stmt, err)
+	}
+}
+
+func replaceDBName(rawURL, newDB string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	u.Path = "/" + newDB
+	return u.String()
+}
+
+// connectAs returns a *sql.DB authenticated as roleName with the
+// given password, search_path pinned to blockyard+public for RLS
+// tests. Caller closes.
+func connectAs(t *testing.T, dbName, roleName, password string) *sql.DB {
+	t.Helper()
+	conn := openAs(dbName, roleName, password)
+	if conn == nil {
+		t.Fatalf("connect as %s failed", roleName)
+	}
+	return conn
+}
+
+// tryConnectAs returns nil when the role cannot log in (e.g. after
+// NOLOGIN) without failing the test. Caller closes a non-nil result.
+func tryConnectAs(dbName, roleName, password string) *sql.DB {
+	return openAs(dbName, roleName, password)
+}
+
+func openAs(dbName, roleName, password string) *sql.DB {
+	u, err := url.Parse(pgBaseURL)
+	if err != nil {
+		return nil
+	}
+	u.User = url.UserPassword(roleName, password)
+	u.Path = "/" + dbName
+	q := u.Query()
+	q.Set("search_path", "blockyard,public")
+	u.RawQuery = q.Encode()
+	conn, err := sql.Open("pgx", u.String())
+	if err != nil {
+		return nil
+	}
+	if err := conn.Ping(); err != nil {
+		conn.Close()
+		return nil
+	}
+	return conn
+}
+
+// dbNameFromURL extracts the path-as-db-name from a connection URL,
+// used to thread the test database name into per-role connect-as
+// helpers.
+func dbNameFromURL(t *testing.T, d *db.DB) string {
+	t.Helper()
+	// The sqlx.DB doesn't expose its URL, so round-trip through PG's
+	// current_database(). Cheaper than threading state.
+	var name string
+	if err := d.QueryRowContext(context.Background(),
+		`SELECT current_database()`).Scan(&name); err != nil {
+		t.Fatalf("select current_database: %v", err)
+	}
+	return name
+}
+
+// provisionUserRoleSQL runs the three SQL statements the provisioner
+// would emit, but with a caller-chosen password so tests can
+// connect as the new role. Skips the vault step. Returns the
+// normalized role name.
+func provisionUserRoleSQL(t *testing.T, d *db.DB, sub, password string) string {
+	t.Helper()
+	roleName := NormalizePgRole(sub)
+	if err := ensureUserRole(context.Background(), d, roleName, password); err != nil {
+		t.Fatalf("ensureUserRole: %v", err)
+	}
+	// Upsert a users row for the sub then persist pg_role, same as
+	// the full provisioner would.
+	_, err := d.ExecContext(context.Background(),
+		`INSERT INTO blockyard.users (sub, email, name, last_login)
+         VALUES ($1, $2, $3, now())
+         ON CONFLICT (sub) DO UPDATE SET email = EXCLUDED.email`,
+		sub, sub+"@example.com", sub)
+	if err != nil {
+		t.Fatalf("insert users row: %v", err)
+	}
+	if err := d.SetUserPgRole(context.Background(), sub, roleName); err != nil {
+		t.Fatalf("SetUserPgRole: %v", err)
+	}
+	return roleName
+}
+
+// bootstrapAdmin ensures blockyard_admin exists. Separate helper so
+// per-test assertions can verify idempotence.
+func bootstrapAdmin(t *testing.T, d *db.DB) {
+	t.Helper()
+	if err := EnsureBlockyardAdmin(context.Background(), d); err != nil {
+		t.Fatalf("EnsureBlockyardAdmin: %v", err)
+	}
+}
+
+// ensureNoRows asserts q returns zero rows under the given
+// connection. Used by RLS tests to assert filtering.
+func ensureNoRows(t *testing.T, conn *sql.DB, q string, args ...any) {
+	t.Helper()
+	rows, err := conn.Query(q, args...)
+	if err != nil {
+		t.Fatalf("query %q: %v", q, err)
+	}
+	defer rows.Close()
+	if rows.Next() {
+		t.Fatalf("expected 0 rows from %q; got at least one", q)
+	}
+}
+
+// expectErrContains runs exec and asserts the error message contains
+// substr (case-insensitive). Used to spot-check "permission denied"
+// and "restrict_violation" error paths without binding on PG error
+// codes that vary across versions.
+func expectErrContains(t *testing.T, conn *sql.DB, stmt, substr string) {
+	t.Helper()
+	_, err := conn.Exec(stmt)
+	if err == nil {
+		t.Fatalf("expected error containing %q; stmt %q succeeded", substr, stmt)
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(substr)) {
+		t.Fatalf("error mismatch: stmt %q: %q does not contain %q",
+			stmt, err.Error(), substr)
+	}
+}
+
+// currentDB is a re-exported version to keep "db name from URL" off
+// the hot path of each subtest.
+func currentDB(t *testing.T, d *db.DB) string { return dbNameFromURL(t, d) }

--- a/internal/boardstorage/provision.go
+++ b/internal/boardstorage/provision.go
@@ -1,0 +1,161 @@
+package boardstorage
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/cynkra/blockyard/internal/db"
+	"github.com/cynkra/blockyard/internal/integration"
+)
+
+// defaultRotationPeriod is the static-role rotation cadence registered
+// with vault. Matches the value in the #284 spec; not currently
+// operator-configurable.
+const defaultRotationPeriod = "24h"
+
+// Provisioner orchestrates the per-user side-effects at OIDC first
+// login: create the PG role, register it with vault's database
+// secrets engine, persist the normalized role on the users row.
+//
+// Every step is idempotent, and `users.pg_role` is written last —
+// so a login interrupted between steps replays cleanly next time
+// (CREATE ROLE IF NOT EXISTS, GRANT is a no-op when already granted,
+// vault POST is upsert). The durable signal that provisioning
+// completed is users.pg_role being non-NULL.
+type Provisioner struct {
+	DB              *db.DB
+	Vault           *integration.Client
+	VaultMount      string // cfg.Database.VaultMount
+	VaultDBConnName string // cfg.Database.VaultDBConnection
+}
+
+// ProvisionUser runs the first-login flow for `sub`. Fast-path:
+// returns nil immediately if users.pg_role is already populated.
+// Otherwise executes the four-step provisioning and, on success,
+// writes pg_role to the users row.
+//
+// On any error, leaves users.pg_role NULL so the next login retries
+// from scratch. Partial state (an orphan PG role or a vault static
+// role without a matching users row) is tolerated because every
+// step short-circuits on re-run.
+func (p *Provisioner) ProvisionUser(ctx context.Context, sub string) error {
+	existing, err := p.DB.GetUserPgRole(ctx, sub)
+	if err != nil {
+		return err
+	}
+	if existing != "" {
+		return nil
+	}
+
+	roleName := NormalizePgRole(sub)
+	password, err := randomPassword()
+	if err != nil {
+		return err
+	}
+
+	if err := ensureUserRole(ctx, p.DB, roleName, password); err != nil {
+		return err
+	}
+
+	if err := p.Vault.DatabaseStaticRoleCreate(
+		ctx, p.VaultMount, roleName, roleName,
+		p.VaultDBConnName, defaultRotationPeriod,
+	); err != nil {
+		return fmt.Errorf("register vault static role %s: %w", roleName, err)
+	}
+
+	if err := p.DB.SetUserPgRole(ctx, sub, roleName); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ensureUserRole creates the per-user PG role (if absent) and grants
+// the two required memberships. Idempotent: CREATE is guarded by an
+// existence check, and the two GRANTs are no-ops when already in
+// place.
+//
+// Runs as blockyard's configured admin connection, which must hold
+// CREATEROLE + ADMIN OPTION on blockr_user. In production that
+// identity is `blockyard_admin` (created by the startup SQL); in
+// tests it's typically the superuser that owns the database.
+func ensureUserRole(ctx context.Context, d *db.DB, roleName, password string) error {
+	var exists bool
+	if err := d.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = $1)`,
+		roleName,
+	).Scan(&exists); err != nil {
+		return fmt.Errorf("check role %s: %w", roleName, err)
+	}
+	ident := pgIdent(roleName)
+	if !exists {
+		// Password is hex-only (64 chars from crypto/rand); no quote
+		// escaping needed but pgLiteral handles it regardless.
+		stmt := fmt.Sprintf(`CREATE ROLE %s LOGIN PASSWORD %s`, ident, pgLiteral(password))
+		if _, err := d.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("create role %s: %w", roleName, err)
+		}
+	}
+	// INHERIT TRUE lets the user session act as blockr_user for
+	// SELECT/INSERT/UPDATE/DELETE on the board tables. SET FALSE
+	// prevents `SET ROLE blockr_user` — that would let a user create
+	// rows owned by the group role, which breaks RLS's
+	// current_user-based ownership check.
+	if _, err := d.ExecContext(ctx,
+		fmt.Sprintf(`GRANT blockr_user TO %s WITH INHERIT TRUE, SET FALSE`, ident),
+	); err != nil {
+		return fmt.Errorf("grant blockr_user to %s: %w", roleName, err)
+	}
+	// ADMIN OPTION on the per-user role lets vault_db_admin rotate
+	// its password. PG16 requires membership with ADMIN OPTION for
+	// one role to ALTER another's password.
+	if _, err := d.ExecContext(ctx,
+		fmt.Sprintf(`GRANT %s TO vault_db_admin WITH ADMIN OPTION`, ident),
+	); err != nil {
+		return fmt.Errorf("grant %s to vault_db_admin: %w", roleName, err)
+	}
+	return nil
+}
+
+// SetRoleLogin flips a per-user role between LOGIN and NOLOGIN.
+// Called from the admin deactivation path: we don't DROP the role
+// (that would fail once boards reference it as owner via the
+// `owner_sub` FK-adjacent mapping), but flipping LOGIN has the same
+// effect of blocking access while preserving ownership references.
+func SetRoleLogin(ctx context.Context, d *db.DB, roleName string, login bool) error {
+	verb := "NOLOGIN"
+	if login {
+		verb = "LOGIN"
+	}
+	_, err := d.ExecContext(ctx, fmt.Sprintf(`ALTER ROLE %s %s`, pgIdent(roleName), verb))
+	if err != nil {
+		return fmt.Errorf("alter role %s %s: %w", roleName, verb, err)
+	}
+	return nil
+}
+
+func randomPassword() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("rand read: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// pgIdent wraps s as a double-quoted PG identifier. NormalizePgRole
+// already constrains its output to [a-z0-9_], so quoting is for
+// consistency rather than safety. Embedded double quotes are
+// escaped per PG rules.
+func pgIdent(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}
+
+// pgLiteral wraps s as a single-quoted PG string literal. Used for
+// the CREATE ROLE … PASSWORD … clause where bind parameters are
+// not accepted (DDL).
+func pgLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}

--- a/internal/boardstorage/provision_pg_test.go
+++ b/internal/boardstorage/provision_pg_test.go
@@ -1,0 +1,241 @@
+package boardstorage
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/cynkra/blockyard/internal/integration"
+)
+
+// mockVault stubs vault's POST {mount}/static-roles/{name} endpoint.
+// Records every call so tests can assert the payload, and lets tests
+// simulate vault-down by setting fail = true.
+type mockVault struct {
+	mu     sync.Mutex
+	calls  []mockVaultCall
+	server *httptest.Server
+	fail   bool
+}
+
+type mockVaultCall struct {
+	path string
+	body string
+}
+
+func newMockVault(t *testing.T) *mockVault {
+	t.Helper()
+	m := &mockVault{}
+	m.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		m.mu.Lock()
+		m.calls = append(m.calls, mockVaultCall{path: r.URL.Path, body: string(body)})
+		fail := m.fail
+		m.mu.Unlock()
+		if fail {
+			http.Error(w, "forced failure", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(m.server.Close)
+	return m
+}
+
+func (m *mockVault) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.calls)
+}
+
+func (m *mockVault) lastCall() (mockVaultCall, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.calls) == 0 {
+		return mockVaultCall{}, false
+	}
+	return m.calls[len(m.calls)-1], true
+}
+
+func (m *mockVault) setFail(fail bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.fail = fail
+}
+
+func newVaultClient(m *mockVault) *integration.Client {
+	return integration.NewClient(m.server.URL, func() string { return "mock-admin-token" })
+}
+
+func TestProvisionUser_HappyPath(t *testing.T) {
+	d := boardStoragePgDB(t)
+	bootstrapAdmin(t, d)
+	m := newMockVault(t)
+
+	// users row must exist before ProvisionUser runs — matches the
+	// CallbackHandler sequence (upsert user, then provision).
+	_, err := d.ExecContext(context.Background(),
+		`INSERT INTO blockyard.users (sub, email, name, last_login)
+         VALUES ($1, $2, $3, now())`,
+		"alice", "alice@example.com", "Alice")
+	if err != nil {
+		t.Fatalf("insert users: %v", err)
+	}
+
+	p := &Provisioner{
+		DB:              d,
+		Vault:           newVaultClient(m),
+		VaultMount:      "database",
+		VaultDBConnName: "postgresql",
+	}
+	if err := p.ProvisionUser(context.Background(), "alice"); err != nil {
+		t.Fatalf("ProvisionUser: %v", err)
+	}
+
+	// PG role exists with LOGIN.
+	var canLogin bool
+	err = d.QueryRowContext(context.Background(),
+		`SELECT rolcanlogin FROM pg_roles WHERE rolname = 'user_alice'`,
+	).Scan(&canLogin)
+	if err != nil {
+		t.Fatalf("query user_alice: %v", err)
+	}
+	if !canLogin {
+		t.Error("user_alice should have LOGIN")
+	}
+
+	// Vault received exactly one call to the expected path.
+	if got, want := m.callCount(), 1; got != want {
+		t.Fatalf("vault call count = %d, want %d", got, want)
+	}
+	call, _ := m.lastCall()
+	if call.path != "/v1/database/static-roles/user_alice" {
+		t.Errorf("vault path = %q", call.path)
+	}
+	for _, needle := range []string{`"username":"user_alice"`, `"db_name":"postgresql"`, `"rotation_period":"24h"`} {
+		if !strings.Contains(call.body, needle) {
+			t.Errorf("vault body missing %q: %s", needle, call.body)
+		}
+	}
+
+	// users.pg_role persisted.
+	pgRole, err := d.GetUserPgRole(context.Background(), "alice")
+	if err != nil {
+		t.Fatalf("GetUserPgRole: %v", err)
+	}
+	if pgRole != "user_alice" {
+		t.Errorf("pg_role = %q, want %q", pgRole, "user_alice")
+	}
+}
+
+func TestProvisionUser_IdempotentAcrossLogins(t *testing.T) {
+	d := boardStoragePgDB(t)
+	bootstrapAdmin(t, d)
+	m := newMockVault(t)
+	_, err := d.ExecContext(context.Background(),
+		`INSERT INTO blockyard.users (sub, email, name, last_login)
+         VALUES ($1, $2, $3, now())`,
+		"bob", "bob@example.com", "Bob")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := &Provisioner{
+		DB:              d,
+		Vault:           newVaultClient(m),
+		VaultMount:      "database",
+		VaultDBConnName: "postgresql",
+	}
+	if err := p.ProvisionUser(context.Background(), "bob"); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	first := m.callCount()
+	// Second login: pg_role is already set, fast-path kicks in, no
+	// vault or SQL work at all.
+	if err := p.ProvisionUser(context.Background(), "bob"); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if got := m.callCount(); got != first {
+		t.Errorf("second login hit vault: %d → %d calls", first, got)
+	}
+}
+
+func TestProvisionUser_VaultFailureLeavesNoPersistedState(t *testing.T) {
+	d := boardStoragePgDB(t)
+	bootstrapAdmin(t, d)
+	m := newMockVault(t)
+	m.setFail(true)
+	_, err := d.ExecContext(context.Background(),
+		`INSERT INTO blockyard.users (sub, email, name, last_login)
+         VALUES ($1, $2, $3, now())`,
+		"carol", "carol@example.com", "Carol")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := &Provisioner{
+		DB:              d,
+		Vault:           newVaultClient(m),
+		VaultMount:      "database",
+		VaultDBConnName: "postgresql",
+	}
+	err = p.ProvisionUser(context.Background(), "carol")
+	if err == nil {
+		t.Fatal("expected provisioning to fail with vault down")
+	}
+
+	// users.pg_role must NOT be persisted.
+	pgRole, gerr := d.GetUserPgRole(context.Background(), "carol")
+	if gerr != nil {
+		t.Fatal(gerr)
+	}
+	if pgRole != "" {
+		t.Errorf("pg_role should be empty after vault failure; got %q", pgRole)
+	}
+
+	// Retry after vault recovers must succeed and leave the system
+	// in the same end state as a clean first login.
+	m.setFail(false)
+	if err := p.ProvisionUser(context.Background(), "carol"); err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	pgRole, _ = d.GetUserPgRole(context.Background(), "carol")
+	if pgRole != "user_carol" {
+		t.Errorf("pg_role after retry = %q", pgRole)
+	}
+}
+
+func TestSetRoleLogin_TogglesLoginAttribute(t *testing.T) {
+	d := boardStoragePgDB(t)
+	bootstrapAdmin(t, d)
+	// Set up a user role with a known password so we can query its
+	// attributes directly.
+	const sub = "dave"
+	roleName := provisionUserRoleSQL(t, d, sub, "testpassword")
+
+	for _, tc := range []struct {
+		name  string
+		login bool
+	}{
+		{"deactivate", false},
+		{"reactivate", true},
+		{"idempotent-reactivate", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := SetRoleLogin(context.Background(), d, roleName, tc.login); err != nil {
+				t.Fatalf("SetRoleLogin: %v", err)
+			}
+			var canLogin bool
+			if err := d.QueryRowContext(context.Background(),
+				`SELECT rolcanlogin FROM pg_roles WHERE rolname = $1`, roleName,
+			).Scan(&canLogin); err != nil {
+				t.Fatal(err)
+			}
+			if canLogin != tc.login {
+				t.Errorf("rolcanlogin = %v, want %v", canLogin, tc.login)
+			}
+		})
+	}
+}

--- a/internal/boardstorage/rls_pg_test.go
+++ b/internal/boardstorage/rls_pg_test.go
@@ -1,0 +1,420 @@
+package boardstorage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+)
+
+// rlsFixture provisions two users (alice, bob) with known passwords
+// and returns sql.DB handles authenticated as each of them. The
+// owner-all and share-on-restricted policies are exercised against
+// these connections in the subtests below.
+type rlsFixture struct {
+	admin *sql.DB // the migrator/bootstrap connection (superuser)
+
+	aliceSub  string
+	aliceRole string
+	aliceDB   *sql.DB
+
+	bobSub  string
+	bobRole string
+	bobDB   *sql.DB
+
+	// Seeded board IDs by ACL type, owned by bob.
+	bobPrivateID    string
+	bobPublicID     string
+	bobRestrictedID string
+	bobRestrictedVersion string // id of the single version
+}
+
+func newRLSFixture(t *testing.T) *rlsFixture {
+	t.Helper()
+	d := boardStoragePgDB(t)
+	bootstrapAdmin(t, d)
+
+	const alicePw, bobPw = "alicepw", "bobpw"
+	aliceRole := provisionUserRoleSQL(t, d, "alice@example.com", alicePw)
+	bobRole := provisionUserRoleSQL(t, d, "bob@example.com", bobPw)
+
+	dbName := currentDB(t, d)
+	fx := &rlsFixture{
+		admin:     d.DB.DB,
+		aliceSub:  "alice@example.com",
+		aliceRole: aliceRole,
+		aliceDB:   connectAs(t, dbName, aliceRole, alicePw),
+		bobSub:    "bob@example.com",
+		bobRole:   bobRole,
+		bobDB:     connectAs(t, dbName, bobRole, bobPw),
+	}
+	t.Cleanup(func() {
+		fx.aliceDB.Close()
+		fx.bobDB.Close()
+	})
+
+	// Seed three boards owned by bob, one per ACL type. Uses bob's
+	// own connection so the INSERT passes WITH CHECK (owner_all).
+	for _, row := range []struct {
+		alias    string
+		aclType  string
+		target   *string
+	}{
+		{"private-board", "private", &fx.bobPrivateID},
+		{"public-board", "public", &fx.bobPublicID},
+		{"restricted-board", "restricted", &fx.bobRestrictedID},
+	} {
+		err := fx.bobDB.QueryRow(
+			`INSERT INTO blockyard.boards (owner_sub, board_id, name, acl_type)
+             VALUES ($1, $2, $3, $4) RETURNING id`,
+			fx.bobSub, row.alias, row.alias, row.aclType,
+		).Scan(row.target)
+		if err != nil {
+			t.Fatalf("seed %s: %v", row.alias, err)
+		}
+	}
+	// One version per seeded board (trigger requires ≥1 version for
+	// any subsequent delete).
+	for _, id := range []string{fx.bobPrivateID, fx.bobPublicID, fx.bobRestrictedID} {
+		target := ""
+		if id == fx.bobRestrictedID {
+			target = fx.bobRestrictedVersion
+			_ = target
+		}
+		var verID string
+		err := fx.bobDB.QueryRow(
+			`INSERT INTO blockyard.board_versions (board_ref, data, format)
+             VALUES ($1, '{}'::jsonb, 'json') RETURNING id`,
+			id,
+		).Scan(&verID)
+		if err != nil {
+			t.Fatalf("seed version for %s: %v", id, err)
+		}
+		if id == fx.bobRestrictedID {
+			fx.bobRestrictedVersion = verID
+		}
+	}
+
+	return fx
+}
+
+// ---- Operational RLS: owner path ----
+
+func TestRLS_OwnerCRUD(t *testing.T) {
+	fx := newRLSFixture(t)
+
+	// SELECT own board.
+	var name string
+	err := fx.bobDB.QueryRow(
+		`SELECT name FROM blockyard.boards WHERE id = $1`, fx.bobPrivateID,
+	).Scan(&name)
+	if err != nil {
+		t.Fatalf("own SELECT: %v", err)
+	}
+
+	// UPDATE own board.
+	if _, err := fx.bobDB.Exec(
+		`UPDATE blockyard.boards SET name = 'renamed' WHERE id = $1`, fx.bobPrivateID,
+	); err != nil {
+		t.Fatalf("own UPDATE: %v", err)
+	}
+
+	// INSERT a version on own board.
+	if _, err := fx.bobDB.Exec(
+		`INSERT INTO blockyard.board_versions (board_ref, data, format)
+         VALUES ($1, '{"k":1}'::jsonb, 'json')`, fx.bobPrivateID,
+	); err != nil {
+		t.Fatalf("own version INSERT: %v", err)
+	}
+
+	// List: bob sees all three of his boards.
+	rows, err := fx.bobDB.Query(`SELECT id FROM blockyard.boards`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	seen := map[string]bool{}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatal(err)
+		}
+		seen[id] = true
+	}
+	for _, id := range []string{fx.bobPrivateID, fx.bobPublicID, fx.bobRestrictedID} {
+		if !seen[id] {
+			t.Errorf("bob's own board %s missing from list", id)
+		}
+	}
+}
+
+// ---- Operational RLS: cross-user visibility ----
+
+func TestRLS_PrivateIsolation(t *testing.T) {
+	fx := newRLSFixture(t)
+	ensureNoRows(t, fx.aliceDB,
+		`SELECT id FROM blockyard.boards WHERE id = $1`, fx.bobPrivateID)
+	ensureNoRows(t, fx.aliceDB,
+		`SELECT id FROM blockyard.board_versions WHERE board_ref = $1`,
+		fx.bobPrivateID)
+}
+
+func TestRLS_PublicRead(t *testing.T) {
+	fx := newRLSFixture(t)
+	var id string
+	err := fx.aliceDB.QueryRow(
+		`SELECT id FROM blockyard.boards WHERE id = $1`, fx.bobPublicID,
+	).Scan(&id)
+	if err != nil {
+		t.Fatalf("alice cannot read bob's public board: %v", err)
+	}
+	// Versions of a public board are also readable.
+	var count int
+	err = fx.aliceDB.QueryRow(
+		`SELECT count(*) FROM blockyard.board_versions WHERE board_ref = $1`,
+		fx.bobPublicID,
+	).Scan(&count)
+	if err != nil || count == 0 {
+		t.Fatalf("alice cannot read public versions: count=%d err=%v", count, err)
+	}
+}
+
+func TestRLS_RestrictedRead(t *testing.T) {
+	fx := newRLSFixture(t)
+	// Pre-condition: alice cannot read the restricted board.
+	ensureNoRows(t, fx.aliceDB,
+		`SELECT id FROM blockyard.boards WHERE id = $1`, fx.bobRestrictedID)
+
+	// Bob grants her access.
+	if _, err := fx.bobDB.Exec(
+		`INSERT INTO blockyard.board_shares (board_ref, shared_with_sub)
+         VALUES ($1, $2)`,
+		fx.bobRestrictedID, fx.aliceSub,
+	); err != nil {
+		t.Fatalf("bob share to alice: %v", err)
+	}
+
+	// Alice now sees it.
+	var id string
+	err := fx.aliceDB.QueryRow(
+		`SELECT id FROM blockyard.boards WHERE id = $1`, fx.bobRestrictedID,
+	).Scan(&id)
+	if err != nil {
+		t.Fatalf("alice cannot read shared board: %v", err)
+	}
+	// And its versions.
+	var verCount int
+	err = fx.aliceDB.QueryRow(
+		`SELECT count(*) FROM blockyard.board_versions WHERE board_ref = $1`,
+		fx.bobRestrictedID,
+	).Scan(&verCount)
+	if err != nil || verCount == 0 {
+		t.Fatalf("alice cannot read shared versions: count=%d err=%v", verCount, err)
+	}
+}
+
+func TestRLS_WriteProtection(t *testing.T) {
+	fx := newRLSFixture(t)
+
+	// Alice cannot INSERT a board claiming bob as owner: WITH CHECK
+	// on owner_all rejects the row.
+	_, err := fx.aliceDB.Exec(
+		`INSERT INTO blockyard.boards (owner_sub, board_id, name)
+         VALUES ($1, 'evil', 'evil')`, fx.bobSub,
+	)
+	if err == nil {
+		t.Fatal("alice was allowed to impersonate bob's ownership")
+	}
+
+	// Alice cannot UPDATE/DELETE bob's private board (she can't
+	// even SELECT it — row simply invisible).
+	res, err := fx.aliceDB.Exec(
+		`UPDATE blockyard.boards SET name = 'pwned' WHERE id = $1`,
+		fx.bobPrivateID,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error on UPDATE: %v", err)
+	}
+	if n, _ := res.RowsAffected(); n != 0 {
+		t.Fatalf("alice UPDATEd bob's private board: %d rows", n)
+	}
+
+	// Restricted with share: alice can SELECT, but still cannot
+	// UPDATE or DELETE — owner-only policies cover writes.
+	if _, err := fx.bobDB.Exec(
+		`INSERT INTO blockyard.board_shares (board_ref, shared_with_sub)
+         VALUES ($1, $2)`,
+		fx.bobRestrictedID, fx.aliceSub,
+	); err != nil {
+		t.Fatal(err)
+	}
+	res, err = fx.aliceDB.Exec(
+		`DELETE FROM blockyard.boards WHERE id = $1`, fx.bobRestrictedID,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error on DELETE: %v", err)
+	}
+	if n, _ := res.RowsAffected(); n != 0 {
+		t.Fatalf("alice DELETEd bob's restricted board: %d rows", n)
+	}
+}
+
+func TestRLS_ShareVisibility(t *testing.T) {
+	fx := newRLSFixture(t)
+	// Bob shares restricted with alice.
+	if _, err := fx.bobDB.Exec(
+		`INSERT INTO blockyard.board_shares (board_ref, shared_with_sub)
+         VALUES ($1, $2)`,
+		fx.bobRestrictedID, fx.aliceSub,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Bob sees his own shares as the board owner.
+	var bobCount int
+	err := fx.bobDB.QueryRow(
+		`SELECT count(*) FROM blockyard.board_shares WHERE board_ref = $1`,
+		fx.bobRestrictedID,
+	).Scan(&bobCount)
+	if err != nil || bobCount != 1 {
+		t.Fatalf("owner share visibility: count=%d err=%v", bobCount, err)
+	}
+
+	// Alice sees her own share row via shares_see_own.
+	var aliceCount int
+	err = fx.aliceDB.QueryRow(
+		`SELECT count(*) FROM blockyard.board_shares
+         WHERE shared_with_sub = $1`, fx.aliceSub,
+	).Scan(&aliceCount)
+	if err != nil || aliceCount != 1 {
+		t.Fatalf("share recipient visibility: count=%d err=%v", aliceCount, err)
+	}
+}
+
+func TestRLS_LastVersionDeleteRaises(t *testing.T) {
+	fx := newRLSFixture(t)
+	// Seeded board has exactly one version; trigger must fire.
+	_, err := fx.bobDB.Exec(
+		`DELETE FROM blockyard.board_versions WHERE id = $1`,
+		fx.bobRestrictedVersion,
+	)
+	if err == nil {
+		t.Fatal("last-version delete should have been rejected")
+	}
+	// Add a second version, delete one → succeeds.
+	if _, err := fx.bobDB.Exec(
+		`INSERT INTO blockyard.board_versions (board_ref, data, format)
+         VALUES ($1, '{}'::jsonb, 'json')`,
+		fx.bobRestrictedID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fx.bobDB.Exec(
+		`DELETE FROM blockyard.board_versions WHERE id = $1`,
+		fx.bobRestrictedVersion,
+	); err != nil {
+		t.Fatalf("delete non-last version: %v", err)
+	}
+}
+
+// ---- Privilege escalation battery ----
+
+func TestRLS_UserCannotSetRoleBlockrUser(t *testing.T) {
+	fx := newRLSFixture(t)
+	expectErrContains(t, fx.aliceDB, `SET ROLE blockr_user`, "permission")
+}
+
+func TestRLS_UserCannotSetRoleOther(t *testing.T) {
+	fx := newRLSFixture(t)
+	expectErrContains(t, fx.aliceDB,
+		fmt.Sprintf(`SET ROLE %s`, fx.bobRole), "permission")
+}
+
+func TestRLS_UserCannotSetRoleAdmin(t *testing.T) {
+	fx := newRLSFixture(t)
+	expectErrContains(t, fx.aliceDB, `SET ROLE blockyard_admin`, "permission")
+}
+
+func TestRLS_UserCannotCreateOrAlterRoles(t *testing.T) {
+	fx := newRLSFixture(t)
+	expectErrContains(t, fx.aliceDB, `CREATE ROLE pwned`, "permission")
+	expectErrContains(t, fx.aliceDB, `ALTER ROLE blockr_user BYPASSRLS`, "permission")
+}
+
+func TestRLS_UserCannotAlterTables(t *testing.T) {
+	fx := newRLSFixture(t)
+	// DROP/ALTER on tables owned by the migrator must be rejected;
+	// the role doesn't own them and isn't a superuser.
+	expectErrContains(t, fx.aliceDB,
+		`DROP TABLE blockyard.boards`, "must be owner")
+	expectErrContains(t, fx.aliceDB,
+		`ALTER TABLE blockyard.boards DROP COLUMN id`, "must be owner")
+}
+
+func TestRLS_UserCannotReadRolePasswords(t *testing.T) {
+	fx := newRLSFixture(t)
+	expectErrContains(t, fx.aliceDB,
+		`SELECT rolpassword FROM pg_authid`, "permission")
+}
+
+func TestRLS_RowSecurityOffStillFiltered(t *testing.T) {
+	fx := newRLSFixture(t)
+	// `row_security = off` only lets the session bypass RLS when the
+	// role is the table owner or has BYPASSRLS. Alice is neither,
+	// so one of two outcomes is acceptable:
+	//   - PG errors with "would be affected by row-level security"
+	//     (it refuses to silently ignore the bypass attempt).
+	//   - The rows are still filtered and zero returned.
+	// Either outcome means the escalation attempt was blocked; the
+	// failure mode we're guarding against is bob's private rows
+	// coming back.
+	if _, err := fx.aliceDB.Exec(`SET row_security = off`); err != nil {
+		return
+	}
+	rows, err := fx.aliceDB.Query(
+		`SELECT id FROM blockyard.boards WHERE id = $1`, fx.bobPrivateID)
+	if err != nil {
+		// PG refused to run the query — escalation blocked.
+		return
+	}
+	defer rows.Close()
+	if rows.Next() {
+		t.Fatal("row_security=off with non-privileged role leaked bob's private board")
+	}
+}
+
+func TestRLS_UserCannotWriteUsersTable(t *testing.T) {
+	fx := newRLSFixture(t)
+	// blockr_user has SELECT but no INSERT/UPDATE/DELETE on users;
+	// attempting to rewrite pg_role (the identity map) must fail.
+	expectErrContains(t, fx.aliceDB,
+		`UPDATE blockyard.users SET pg_role = 'user_pwned'`, "permission")
+}
+
+// ---- Deactivation end-to-end ----
+
+func TestDeactivation_BlocksLogin(t *testing.T) {
+	d := boardStoragePgDB(t)
+	bootstrapAdmin(t, d)
+
+	const sub, pw = "eve@example.com", "evepw"
+	roleName := provisionUserRoleSQL(t, d, sub, pw)
+	dbName := currentDB(t, d)
+
+	// Baseline: login works before deactivation.
+	connectAs(t, dbName, roleName, pw).Close()
+
+	if err := SetRoleLogin(context.Background(), d, roleName, false); err != nil {
+		t.Fatalf("deactivate: %v", err)
+	}
+	if conn := tryConnectAs(dbName, roleName, pw); conn != nil {
+		conn.Close()
+		t.Fatal("expected login failure after NOLOGIN")
+	}
+
+	if err := SetRoleLogin(context.Background(), d, roleName, true); err != nil {
+		t.Fatalf("reactivate: %v", err)
+	}
+	// Login succeeds again after the flip.
+	connectAs(t, dbName, roleName, pw).Close()
+}

--- a/internal/boardstorage/role.go
+++ b/internal/boardstorage/role.go
@@ -1,0 +1,59 @@
+// Package boardstorage hosts the control-plane side of the board-storage
+// feature (see #283/#284): startup SQL, per-user PG role provisioning,
+// vault static-role registration. Runtime data access happens
+// directly between the R worker and PostgreSQL/vault; nothing in this
+// package is on that path.
+package boardstorage
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// maxRoleNameLen is PostgreSQL's NAMEDATALEN-1 (63 chars). Identifiers
+// longer than this are silently truncated by the server, which would
+// collide two subs whose normalized forms share a 63-char prefix;
+// we truncate deterministically with a stable hash suffix instead.
+const maxRoleNameLen = 63
+
+// NormalizePgRole converts an OIDC `sub` claim to a valid PostgreSQL
+// role name. The mapping is deterministic and idempotent across
+// logins: the same `sub` always produces the same role name.
+//
+// Rules:
+//
+//   - Prefix `user_`.
+//   - Lowercase ASCII letters; digits pass through.
+//   - Every other rune (punctuation, non-ASCII, whitespace) → `_`.
+//   - If the result exceeds 63 chars, truncate and append a stable
+//     suffix derived from sha256(sub).
+//
+// The `user_` prefix is load-bearing: it namespaces per-user roles
+// away from group roles (blockr_user), the app role, and the admin
+// role, and lets vault policy templates match `user_*` for path
+// capabilities.
+func NormalizePgRole(sub string) string {
+	var b strings.Builder
+	b.Grow(len(sub) + len("user_"))
+	b.WriteString("user_")
+	for _, r := range sub {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + ('a' - 'A'))
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	name := b.String()
+	if len(name) <= maxRoleNameLen {
+		return name
+	}
+	h := sha256.Sum256([]byte(sub))
+	// 4 bytes = 8 hex chars + underscore = 9-char suffix. Leaves 54
+	// chars of normalized prefix before the collision-breaker.
+	suffix := "_" + hex.EncodeToString(h[:4])
+	return name[:maxRoleNameLen-len(suffix)] + suffix
+}

--- a/internal/boardstorage/role_test.go
+++ b/internal/boardstorage/role_test.go
@@ -1,0 +1,95 @@
+package boardstorage
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizePgRole(t *testing.T) {
+	cases := []struct {
+		name string
+		sub  string
+		want string
+	}{
+		{"ascii lowercase", "alice", "user_alice"},
+		{"ascii mixed case", "Alice", "user_alice"},
+		{"digits kept", "u42", "user_u42"},
+		{"email like", "alice@example.com", "user_alice_example_com"},
+		{"keycloak uuid", "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+			"user_a1b2c3d4_5678_90ab_cdef_1234567890ab"},
+		{"unicode folds to underscore", "üser.éxample", "user__ser__xample"},
+		{"spaces", "first last", "user_first_last"},
+		{"leading non-alnum", "_weird", "user__weird"},
+		{"empty sub", "", "user_"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NormalizePgRole(tc.sub)
+			if got != tc.want {
+				t.Fatalf("NormalizePgRole(%q) = %q, want %q", tc.sub, got, tc.want)
+			}
+			if len(got) > maxRoleNameLen {
+				t.Fatalf("length %d > %d", len(got), maxRoleNameLen)
+			}
+			if !strings.HasPrefix(got, "user_") {
+				t.Fatalf("missing user_ prefix: %q", got)
+			}
+		})
+	}
+}
+
+func TestNormalizePgRoleDeterministic(t *testing.T) {
+	// Same input must produce the same output across calls — load-
+	// bearing for "subsequent login is a no-op" in the first-login
+	// provisioning flow.
+	sub := "keycloak|very/strange:id#123"
+	a, b := NormalizePgRole(sub), NormalizePgRole(sub)
+	if a != b {
+		t.Fatalf("non-deterministic: %q vs %q", a, b)
+	}
+}
+
+func TestNormalizePgRoleTruncation(t *testing.T) {
+	// Construct a sub whose normalized form would exceed 63 chars so
+	// the hash-suffix branch runs. `user_` + 70 ascii chars = 75.
+	sub := strings.Repeat("a", 70)
+	got := NormalizePgRole(sub)
+	if len(got) != maxRoleNameLen {
+		t.Fatalf("length %d != %d", len(got), maxRoleNameLen)
+	}
+	if !strings.HasPrefix(got, "user_") {
+		t.Fatalf("missing user_ prefix: %q", got)
+	}
+	// Same sub → same truncated output.
+	if NormalizePgRole(sub) != got {
+		t.Fatal("truncation not deterministic")
+	}
+	// A different long sub that shares the 54-char prefix must not
+	// collide with this one, because the sha256-derived suffix
+	// differs.
+	other := strings.Repeat("a", 65) + "zzzzz"
+	if NormalizePgRole(other) == got {
+		t.Fatalf("collision on distinct long subs: %q", got)
+	}
+}
+
+func TestNormalizePgRoleRoleNamePattern(t *testing.T) {
+	// Every output must be a plain PG identifier: [a-z0-9_]+ so it
+	// works both quoted and unquoted in SQL.
+	samples := []string{
+		"alice", "Alice@corp.EXAMPLE", "sub|with/slashes",
+		"🙂emoji", strings.Repeat("x", 200),
+	}
+	for _, s := range samples {
+		got := NormalizePgRole(s)
+		for i, r := range got {
+			valid := (r >= 'a' && r <= 'z') ||
+				(r >= '0' && r <= '9') ||
+				r == '_'
+			if !valid {
+				t.Fatalf("sub=%q got=%q: invalid rune %q at index %d", s, got, r, i)
+			}
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -159,12 +159,20 @@ type DatabaseConfig struct {
 	// startup instead of using a static Database.URL password.
 	// Requires [openbao].
 	//
+	// VaultDBConnection names the vault database-engine connection
+	// blockyard targets when registering per-user static roles
+	// (#284) — the `{name}` from `{VaultMount}/config/{name}` the
+	// operator created at deploy time. Required when BoardStorage
+	// is true. Passed verbatim as the `db_name` field of
+	// `POST {mount}/static-roles/{name}`.
+	//
 	// BoardStorage enables the board-storage feature: adds a PG16+
 	// preflight at startup and (in #284) drives per-user role
 	// provisioning. Requires driver = "postgres" and [openbao].
-	VaultMount   string `toml:"vault_mount"`
-	VaultRole    string `toml:"vault_role"`
-	BoardStorage bool   `toml:"board_storage"`
+	VaultMount        string `toml:"vault_mount"`
+	VaultRole         string `toml:"vault_role"`
+	VaultDBConnection string `toml:"vault_db_connection"`
+	BoardStorage      bool   `toml:"board_storage"`
 }
 
 type ProxyConfig struct {
@@ -810,6 +818,9 @@ func validate(cfg *Config) error {
 		}
 		if cfg.Database.VaultMount == "" {
 			return fmt.Errorf("config: database.board_storage requires database.vault_mount")
+		}
+		if cfg.Database.VaultDBConnection == "" {
+			return fmt.Errorf("config: database.board_storage requires database.vault_db_connection")
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1288,13 +1288,24 @@ func TestDatabaseVaultMountDefault(t *testing.T) {
 }
 
 func TestDatabaseBoardStorageParsed(t *testing.T) {
-	cfg := loadFromString(t, databaseVaultTOML(t, `board_storage = true`))
+	cfg := loadFromString(t, databaseVaultTOML(t,
+		`board_storage = true`+"\n"+
+			`vault_db_connection = "postgresql"`))
 	if !cfg.Database.BoardStorage {
 		t.Error("expected database.board_storage = true")
 	}
 	if cfg.Database.VaultMount != "database" {
 		t.Errorf("vault_mount = %q, want default %q", cfg.Database.VaultMount, "database")
 	}
+	if cfg.Database.VaultDBConnection != "postgresql" {
+		t.Errorf("vault_db_connection = %q", cfg.Database.VaultDBConnection)
+	}
+}
+
+func TestValidationRejectsBoardStorageWithoutVaultDBConnection(t *testing.T) {
+	expectLoadError(t,
+		databaseVaultTOML(t, `board_storage = true`),
+		"database.board_storage requires database.vault_db_connection")
 }
 
 func TestDatabaseVaultRoleParsed(t *testing.T) {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -802,13 +802,19 @@ func (db *DB) FailStaleBuilds() (int64, error) {
 // --- Users ---
 
 // UserRow represents a row from the users table.
+//
+// PgRole is populated only on PostgreSQL when board storage is
+// enabled and the user has gone through first-login provisioning.
+// Column is absent on SQLite deployments (migration 006 is a no-op
+// there), so the pointer is always nil when scanning from SQLite.
 type UserRow struct {
-	Sub       string `db:"sub" json:"sub"`
-	Email     string `db:"email" json:"email"`
-	Name      string `db:"name" json:"name"`
-	Role      string `db:"role" json:"role"`
-	Active    bool   `db:"active" json:"active"`
-	LastLogin string `db:"last_login" json:"last_login"`
+	Sub       string  `db:"sub" json:"sub"`
+	Email     string  `db:"email" json:"email"`
+	Name      string  `db:"name" json:"name"`
+	Role      string  `db:"role" json:"role"`
+	Active    bool    `db:"active" json:"active"`
+	LastLogin string  `db:"last_login" json:"last_login"`
+	PgRole    *string `db:"pg_role" json:"pg_role,omitempty"`
 }
 
 // UpsertUser creates or updates a user record on OIDC login.
@@ -974,6 +980,41 @@ func (db *DB) UpdateUser(sub string, u UserUpdate) (*UserRow, error) {
 	}
 
 	return db.GetUser(sub)
+}
+
+// GetUserPgRole returns the per-user PG role name from users.pg_role,
+// or empty string when unset. Postgres-only: the column is added by
+// migration 006 which is a no-op on SQLite, so callers must not
+// invoke this outside board-storage code paths. Returns ("", nil)
+// for a missing row rather than an error — the caller's provisioner
+// treats that the same as "not yet provisioned".
+func (db *DB) GetUserPgRole(ctx context.Context, sub string) (string, error) {
+	var s sql.NullString
+	err := db.QueryRowContext(ctx,
+		`SELECT pg_role FROM blockyard.users WHERE sub = $1`, sub,
+	).Scan(&s)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("get users.pg_role: %w", err)
+	}
+	return s.String, nil
+}
+
+// SetUserPgRole persists the normalized PG role on the user row. The
+// final step of first-login provisioning — leaving it until last so
+// interrupted flows replay cleanly (pg_role is the durable signal
+// that provisioning completed). Postgres-only.
+func (db *DB) SetUserPgRole(ctx context.Context, sub, pgRole string) error {
+	_, err := db.ExecContext(ctx,
+		`UPDATE blockyard.users SET pg_role = $1 WHERE sub = $2`,
+		pgRole, sub,
+	)
+	if err != nil {
+		return fmt.Errorf("set users.pg_role: %w", err)
+	}
+	return nil
 }
 
 // --- App access (ACL) ---

--- a/internal/db/migrations/postgres/006_blockyard_schema.down.sql
+++ b/internal/db/migrations/postgres/006_blockyard_schema.down.sql
@@ -18,7 +18,11 @@ REVOKE SELECT ON blockyard.users FROM blockr_user;
 DROP TABLE IF EXISTS blockyard.board_shares CASCADE;
 DROP TABLE IF EXISTS blockyard.board_versions CASCADE;
 DROP TABLE IF EXISTS blockyard.boards CASCADE;
+DROP FUNCTION IF EXISTS blockyard.current_user_owns_board(UUID);
 DROP FUNCTION IF EXISTS blockyard.current_sub();
+
+DROP INDEX IF EXISTS blockyard.idx_users_pg_role;
+ALTER TABLE blockyard.users DROP COLUMN IF EXISTS pg_role;
 
 ALTER TABLE blockyard.apps                   SET SCHEMA public;
 ALTER TABLE blockyard.bundles                SET SCHEMA public;

--- a/internal/db/migrations/postgres/006_blockyard_schema.up.sql
+++ b/internal/db/migrations/postgres/006_blockyard_schema.up.sql
@@ -43,6 +43,15 @@ ALTER TABLE public.blockyard_workers      SET SCHEMA blockyard;
 ALTER TABLE public.blockyard_ports        SET SCHEMA blockyard;
 ALTER TABLE public.blockyard_uids         SET SCHEMA blockyard;
 
+-- Per-user PG role mapping. Populated by #284's first-login
+-- provisioning; NULL for users who never had board storage enabled.
+-- current_sub() below resolves current_user → sub via this column.
+-- Partial unique index allows many NULLs but enforces one user per
+-- populated role name.
+ALTER TABLE blockyard.users ADD COLUMN pg_role TEXT;
+CREATE UNIQUE INDEX idx_users_pg_role
+    ON blockyard.users(pg_role) WHERE pg_role IS NOT NULL;
+
 -- New board-storage tables in the finalized shape. Created
 -- schema-qualified so the rest of the migration is independent of
 -- whichever search_path resolution migrate picks.
@@ -84,13 +93,38 @@ CREATE TABLE blockyard.board_shares (
 CREATE INDEX idx_board_shares_shared_with
     ON blockyard.board_shares(shared_with_sub);
 
--- Identity stub for RLS. Returns NULL until #284 wires the real
--- users.pg_role resolution — policies below are fail-closed in the
--- interim. Co-located with the new schema; the legacy public
--- counterpart is dropped by 007.
+-- Identity resolution for RLS. Maps the PG role that opened this
+-- session (session_user, not current_user) back to the OIDC sub
+-- via users.pg_role. Using session_user is load-bearing: it keeps
+-- the mapping stable across SECURITY DEFINER boundaries — where
+-- current_user flips to the function owner — so the same helper
+-- works both in invoker-scoped policy bodies and inside the
+-- DEFINER-scoped helpers below. NOLOGIN admin connections
+-- (blockyard_admin) have no users row and therefore resolve to
+-- NULL, which fail-closes the policies they traverse.
 CREATE FUNCTION blockyard.current_sub() RETURNS TEXT AS $$
-    SELECT NULL::text
+    SELECT sub FROM blockyard.users WHERE pg_role = session_user
 $$ LANGUAGE sql STABLE;
+
+-- RLS policies on `boards` reference `board_shares`, and the
+-- owner-side policy on `board_shares` would otherwise need to
+-- reference `boards` — creating a cross-table policy cycle that PG
+-- rejects at query time ("infinite recursion detected in policy").
+--
+-- SECURITY DEFINER helper breaks the cycle: it reads `boards` as
+-- the function owner (migration user), bypassing RLS on that table.
+-- The predicate is locked to the caller's own identity via
+-- current_sub() (which uses session_user, unchanged across the
+-- SECURITY DEFINER boundary), so the helper leaks nothing beyond
+-- "do I own this board ID?" — which the caller already learns from
+-- their own SELECTs. search_path is pinned to guard against
+-- schema-shadow attacks by callers with CREATE on other schemas.
+CREATE FUNCTION blockyard.current_user_owns_board(b_id UUID) RETURNS BOOLEAN AS $$
+    SELECT EXISTS (
+        SELECT 1 FROM blockyard.boards
+        WHERE id = b_id AND owner_sub = blockyard.current_sub()
+    );
+$$ LANGUAGE sql SECURITY DEFINER STABLE SET search_path = blockyard, pg_catalog;
 
 -- RLS policies. Ownership is a board-level fact, so policies on
 -- children dereference via EXISTS against blockyard.boards.
@@ -142,17 +176,12 @@ CREATE POLICY version_restricted ON blockyard.board_versions FOR SELECT
 
 ALTER TABLE blockyard.board_shares ENABLE ROW LEVEL SECURITY;
 
+-- Owner-side policy uses the SECURITY DEFINER helper rather than
+-- inlining `EXISTS (… FROM blockyard.boards …)` to avoid the policy
+-- cycle with boards.restricted_read (which references board_shares).
 CREATE POLICY shares_owner ON blockyard.board_shares
-    USING (EXISTS (
-        SELECT 1 FROM blockyard.boards
-        WHERE boards.id = board_shares.board_ref
-        AND boards.owner_sub = blockyard.current_sub()
-    ))
-    WITH CHECK (EXISTS (
-        SELECT 1 FROM blockyard.boards
-        WHERE boards.id = board_shares.board_ref
-        AND boards.owner_sub = blockyard.current_sub()
-    ));
+    USING (blockyard.current_user_owns_board(board_ref))
+    WITH CHECK (blockyard.current_user_owns_board(board_ref));
 
 CREATE POLICY shares_see_own ON blockyard.board_shares FOR SELECT
     USING (shared_with_sub = blockyard.current_sub());

--- a/internal/integration/openbao.go
+++ b/internal/integration/openbao.go
@@ -174,6 +174,52 @@ func (c *Client) SecretExists(ctx context.Context, path string) (bool, error) {
 	return true, nil
 }
 
+// DatabaseStaticRoleCreate registers (or updates) a static DB role on
+// vault's `database` secrets engine. Called from blockyard's
+// first-login flow for board storage (#284): after the per-user PG
+// role user_<sub> exists, this tells vault to adopt it and start
+// rotating its password on the given period. Vault immediately
+// rotates the temporary password set at creation time; subsequent
+// reads of `{mount}/static-creds/{name}` return the current one.
+//
+// Idempotent: vault returns 200/204 on update of an existing role.
+//
+// Uses the admin AppRole token configured via [openbao].
+// POST {addr}/v1/{mount}/static-roles/{name}
+func (c *Client) DatabaseStaticRoleCreate(
+	ctx context.Context,
+	mount, name, username, dbName, rotationPeriod string,
+) error {
+	payload, err := json.Marshal(map[string]any{
+		"username":        username,
+		"db_name":         dbName,
+		"rotation_period": rotationPeriod,
+	})
+	if err != nil {
+		return fmt.Errorf("openbao db static-role create: marshal: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/v1/%s/static-roles/%s", c.addr, mount, name)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, strings.NewReader(string(payload)))
+	if err != nil {
+		return fmt.Errorf("openbao db static-role create: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Vault-Token", c.adminTokenFunc())
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("openbao db static-role create: %w", err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("openbao db static-role create %s: status %d", name, resp.StatusCode)
+	}
+	return nil
+}
+
 // kvReadResponse is the relevant subset of OpenBao's KV v2 read response.
 type kvReadResponse struct {
 	Data struct {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -303,6 +303,7 @@ func Handler(srv *server.Server) http.Handler {
 func injectCredentials(r *http.Request, srv *server.Server, appID, workerID string, maxSessionsPerWorker int) {
 	r.Header.Del("X-Blockyard-Vault-Token")
 	r.Header.Del("X-Blockyard-Session-Token")
+	r.Header.Del("X-Blockyard-Pg-Role")
 
 	if srv.VaultClient == nil {
 		return
@@ -311,6 +312,18 @@ func injectCredentials(r *http.Request, srv *server.Server, appID, workerID stri
 	user := auth.UserFromContext(r.Context())
 	if user == nil || user.AccessToken == "" {
 		return
+	}
+
+	// Board-storage per-user PG role name (#284). Independent of the
+	// vault token / session-token paths below — if the feature is
+	// enabled and this user has been provisioned, R constructs the
+	// `static-creds/<role>` path from this header plus the
+	// BLOCKYARD_VAULT_DB_MOUNT env var. Absent when unprovisioned so
+	// R can detect "not ready" deterministically.
+	if srv.Config.Database.BoardStorage {
+		if pgRole, err := srv.DB.GetUserPgRole(r.Context(), user.Sub); err == nil && pgRole != "" {
+			r.Header.Set("X-Blockyard-Pg-Role", pgRole)
+		}
 	}
 
 	if maxSessionsPerWorker > 1 {

--- a/internal/proxy/vault_test.go
+++ b/internal/proxy/vault_test.go
@@ -93,6 +93,7 @@ func TestInjectCredentials_StripsExistingHeaders(t *testing.T) {
 	r := httptest.NewRequest("GET", "/app/test-app/", nil)
 	r.Header.Set("X-Blockyard-Vault-Token", "spoofed-vault")
 	r.Header.Set("X-Blockyard-Session-Token", "spoofed-session")
+	r.Header.Set("X-Blockyard-Pg-Role", "spoofed-role")
 
 	injectCredentials(r, srv, "app-1", "worker-1", 1)
 
@@ -101,6 +102,22 @@ func TestInjectCredentials_StripsExistingHeaders(t *testing.T) {
 	}
 	if got := r.Header.Get("X-Blockyard-Session-Token"); got != "" {
 		t.Errorf("expected spoofed session header to be stripped, got %q", got)
+	}
+	if got := r.Header.Get("X-Blockyard-Pg-Role"); got != "" {
+		t.Errorf("expected spoofed pg-role header to be stripped, got %q", got)
+	}
+}
+
+func TestInjectCredentials_NoPgRoleWhenBoardStorageDisabled(t *testing.T) {
+	client := mockJWTLogin(t, "s.token", 3600)
+	srv := vaultServer(t, client)
+	// BoardStorage defaults to false on the Config built by vaultServer.
+
+	r := requestWithUser("user-1", "my-access-token")
+	injectCredentials(r, srv, "app-1", "worker-1", 1)
+
+	if got := r.Header.Get("X-Blockyard-Pg-Role"); got != "" {
+		t.Errorf("X-Blockyard-Pg-Role set with board_storage=false: %q", got)
 	}
 }
 

--- a/internal/proxy/ws.go
+++ b/internal/proxy/ws.go
@@ -54,6 +54,7 @@ func forwardClientHeaders(r *http.Request) http.Header {
 		"X-Shiny-Groups",
 		"X-Blockyard-Vault-Token",
 		"X-Blockyard-Session-Token",
+		"X-Blockyard-Pg-Role",
 	} {
 		if v := r.Header.Get(key); v != "" {
 			h.Set(key, v)

--- a/internal/server/state.go
+++ b/internal/server/state.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cynkra/blockyard/internal/audit"
 	"github.com/cynkra/blockyard/internal/auth"
 	"github.com/cynkra/blockyard/internal/backend"
+	"github.com/cynkra/blockyard/internal/boardstorage"
 	"github.com/cynkra/blockyard/internal/preflight"
 	"github.com/cynkra/blockyard/internal/bundle"
 	"github.com/cynkra/blockyard/internal/config"
@@ -61,6 +62,12 @@ type Server struct {
 	// OpenBao — nil when [openbao] is not configured.
 	VaultClient     *integration.Client
 	VaultTokenCache *integration.VaultTokenCache
+
+	// Board-storage provisioner — non-nil only when
+	// database.board_storage is enabled. Drives first-login
+	// provisioning from the OIDC callback and deactivation/reactivation
+	// from the admin update-user endpoint.
+	BoardStorage *boardstorage.Provisioner
 
 	// VaultTokenHealthy reports whether the vault token is valid.
 	// Non-nil only when AppRole auth is used (token renewal active).
@@ -260,7 +267,7 @@ func NewServerWithDefaultMetrics(cfg *config.Config, be backend.Backend, databas
 // Used by the router to wire auth handlers and middleware without a
 // circular import.
 func (srv *Server) AuthDeps() *auth.Deps {
-	return &auth.Deps{
+	deps := &auth.Deps{
 		Config:       srv.Config,
 		OIDCClient:   srv.OIDCClient,
 		SigningKey:    srv.SigningKey,
@@ -268,6 +275,10 @@ func (srv *Server) AuthDeps() *auth.Deps {
 		AuditLog:     srv.AuditLog,
 		DB:           srv.DB,
 	}
+	if srv.BoardStorage != nil {
+		deps.BoardStorageProvisioner = srv.BoardStorage.ProvisionUser
+	}
+	return deps
 }
 
 // ActiveWorker represents a running worker tracked by the server.

--- a/internal/server/state_test.go
+++ b/internal/server/state_test.go
@@ -508,6 +508,42 @@ func TestWorkerEnv_OpenbaoNoServices(t *testing.T) {
 	}
 }
 
+func TestWorkerEnv_BoardStorageDBMount(t *testing.T) {
+	srv := &Server{
+		Config: &config.Config{
+			Server: config.ServerConfig{Bind: ":8080"},
+			Database: config.DatabaseConfig{
+				Driver:       "postgres",
+				VaultMount:   "db-engine-42",
+				BoardStorage: true,
+			},
+		},
+	}
+	env := WorkerEnv(srv)
+	if env["BLOCKYARD_VAULT_DB_MOUNT"] != "db-engine-42" {
+		t.Errorf("BLOCKYARD_VAULT_DB_MOUNT = %q, want %q",
+			env["BLOCKYARD_VAULT_DB_MOUNT"], "db-engine-42")
+	}
+}
+
+func TestWorkerEnv_BoardStorageDisabledNoDBMount(t *testing.T) {
+	srv := &Server{
+		Config: &config.Config{
+			Server: config.ServerConfig{Bind: ":8080"},
+			Database: config.DatabaseConfig{
+				Driver:     "postgres",
+				VaultMount: "database",
+				// BoardStorage is false
+			},
+		},
+	}
+	env := WorkerEnv(srv)
+	if _, ok := env["BLOCKYARD_VAULT_DB_MOUNT"]; ok {
+		t.Errorf("BLOCKYARD_VAULT_DB_MOUNT set with board_storage disabled: %q",
+			env["BLOCKYARD_VAULT_DB_MOUNT"])
+	}
+}
+
 func TestWorkerEnv_ShinyHostDocker(t *testing.T) {
 	srv := &Server{
 		Config: &config.Config{

--- a/internal/server/workerenv.go
+++ b/internal/server/workerenv.go
@@ -40,6 +40,16 @@ func WorkerEnv(srv *Server) map[string]string {
 		}
 	}
 
+	// Board storage discovery (#284): R assembles
+	//   {VAULT_ADDR}/v1/{BLOCKYARD_VAULT_DB_MOUNT}/static-creds/{role}
+	// at runtime. Role is delivered per-session via the
+	// X-Blockyard-Pg-Role header; mount is deployment-level so it
+	// ships as env alongside VAULT_ADDR. Unset when the feature is
+	// disabled so workers never pick up a stale value after a flip.
+	if srv.Config.Database.BoardStorage {
+		env["BLOCKYARD_VAULT_DB_MOUNT"] = srv.Config.Database.VaultMount
+	}
+
 	return env
 }
 


### PR DESCRIPTION
## Summary
- `blockyard_admin` bootstrap role created at startup when `database.board_storage = true`; uses PG16-only GRANT syntax gated by the existing preflight.
- On OIDC first login, the callback normalizes the `sub` to a PG identifier, creates `user_<sub>` with `blockr_user` membership + ADMIN OPTION grant to `vault_db_admin`, registers the static role with vault, and persists `pg_role` on the users row — every step idempotent so an interrupted flow retries cleanly.
- `X-Blockyard-Pg-Role` session header and `BLOCKYARD_VAULT_DB_MOUNT` worker env let R assemble `static-creds/<role>` at runtime; admin deactivate/reactivate flips `LOGIN`/`NOLOGIN` on the PG role instead of dropping it.
- Migration 006 folds in the `users.pg_role` column and swaps the `current_sub()` stub for the real lookup; a SECURITY DEFINER helper (`current_user_owns_board`) breaks the boards↔board_shares policy cycle that would otherwise error as infinite recursion once identity resolves to non-NULL. `current_sub()` uses `session_user` so it stays stable across DEFINER boundaries.
- Integration coverage: first-login happy path, idempotent re-login, vault-down retry, deactivation round-trip, and an RLS battery (owner CRUD, private/public/restricted visibility, share writes, last-version trigger) plus privilege-escalation negatives (`SET ROLE`, `CREATE ROLE`, DDL, `pg_authid`, `row_security=off`, `users` write).

Fixes #284