### PR TITLE
test(misc): close coverage gaps and fix e2e upload

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -202,8 +202,8 @@ jobs:
         if: always() && github.event_name != 'pull_request' && github.event_name != 'push'
         with:
           name: coverage-e2e
-          path: coverage-e2e-*.out
-          if-no-files-found: ignore
+          path: coverage-e2e.out
+          if-no-files-found: error
           retention-days: 1
       - uses: actions/upload-artifact@v7
         if: failure()

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -287,6 +287,22 @@ jobs:
       - name: List coverage files
         run: ls -la coverage-*.out 2>/dev/null || echo "No coverage files found"
 
+      # Catch silent upload regressions (e.g. an artifact path that
+      # stops matching after a rename). Codecov's carryforward keeps
+      # showing stale data when a flag drops out, so the only signal
+      # is here. Annotates loudly but does not fail the queue —
+      # coverage reporting is not on the critical path.
+      - name: Verify expected coverage flags present
+        run: |
+          expected="unit cli docker idp openbao pak redis ui process-root process-setuid process-unprivileged examples e2e"
+          missing=""
+          for flag in $expected; do
+            [ -f "coverage-$flag.out" ] || missing="$missing $flag"
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::Missing coverage artifacts for flags:$missing"
+          fi
+
       # Merge all profiles and print total.
       - name: Merge coverage profiles
         run: |

--- a/cmd/by/admin_integration_test.go
+++ b/cmd/by/admin_integration_test.go
@@ -1,0 +1,140 @@
+//go:build cli_test
+
+package main
+
+import (
+	"testing"
+)
+
+// TestCLI_Admin exercises the `by admin` subcommands against the
+// same mock-API harness as the other CLI integration tests.
+// admin_test.go covers cobra wiring; this file covers behaviour.
+func TestCLI_Admin(t *testing.T) {
+	t.Run("status_idle", func(t *testing.T) {
+		m := newMock(t)
+		m.on("GET", "/api/v1/admin/update/status", 200, map[string]string{
+			"state": "idle",
+		})
+		r := run(t, m, "admin", "status")
+		assertExit(t, r, 0)
+		assertContains(t, r.Stdout, "idle")
+	})
+
+	t.Run("status_json", func(t *testing.T) {
+		m := newMock(t)
+		m.on("GET", "/api/v1/admin/update/status", 200, map[string]any{
+			"state":   "running",
+			"task_id": "task-7",
+		})
+		r := run(t, m, "admin", "status", "--json")
+		assertExit(t, r, 0)
+		got := r.jsonMap()
+		if got["state"] != "running" {
+			t.Errorf("state = %v, want running", got["state"])
+		}
+		if got["task_id"] != "task-7" {
+			t.Errorf("task_id = %v, want task-7", got["task_id"])
+		}
+	})
+
+	t.Run("update_blocked_when_running", func(t *testing.T) {
+		m := newMock(t)
+		m.on("GET", "/api/v1/admin/update/status", 200, map[string]string{
+			"state": "running",
+		})
+		r := run(t, m, "admin", "update", "--yes")
+		assertExit(t, r, 1)
+		assertContains(t, r.Stderr, "update already in progress")
+	})
+
+	t.Run("update_yes_streams_progress", func(t *testing.T) {
+		m := newMock(t)
+		m.on("GET", "/api/v1/admin/update/status", 200, map[string]string{
+			"state": "idle",
+		})
+		m.on("POST", "/api/v1/admin/update", 202, map[string]string{
+			"task_id": "task-up",
+		})
+		m.onText("GET", "/api/v1/tasks/task-up/logs", "Pulling image...\nDone.\n")
+		m.on("GET", "/api/v1/tasks/task-up", 200, map[string]string{
+			"status": "completed",
+		})
+		r := run(t, m, "admin", "update", "--yes", "--channel", "main")
+		assertExit(t, r, 0)
+		assertContains(t, r.Stdout, "Pulling image")
+
+		body := bodyJSON(t, m.reqTo("POST", "/api/v1/admin/update"))
+		if body["channel"] != "main" {
+			t.Errorf("channel = %v, want main", body["channel"])
+		}
+	})
+
+	t.Run("update_failed_streams_then_errors", func(t *testing.T) {
+		m := newMock(t)
+		m.on("GET", "/api/v1/admin/update/status", 200, map[string]string{
+			"state": "idle",
+		})
+		m.on("POST", "/api/v1/admin/update", 202, map[string]string{
+			"task_id": "task-up",
+		})
+		m.onText("GET", "/api/v1/tasks/task-up/logs", "Pulling image...\nERROR: tag missing\n")
+		m.on("GET", "/api/v1/tasks/task-up", 200, map[string]string{
+			"status": "failed",
+		})
+		r := run(t, m, "admin", "update", "--yes")
+		assertExit(t, r, 1)
+	})
+
+	t.Run("update_json_returns_task_id", func(t *testing.T) {
+		m := newMock(t)
+		m.on("GET", "/api/v1/admin/update/status", 200, map[string]string{
+			"state": "idle",
+		})
+		m.on("POST", "/api/v1/admin/update", 202, map[string]string{
+			"task_id": "task-up",
+		})
+		r := run(t, m, "admin", "update", "--yes", "--json")
+		assertExit(t, r, 0)
+		got := r.jsonMap()
+		if got["task_id"] != "task-up" {
+			t.Errorf("task_id = %v, want task-up", got["task_id"])
+		}
+	})
+
+	t.Run("rollback_yes_streams_progress", func(t *testing.T) {
+		m := newMock(t)
+		m.on("POST", "/api/v1/admin/rollback", 202, map[string]string{
+			"task_id": "task-rb",
+		})
+		m.onText("GET", "/api/v1/tasks/task-rb/logs", "Reverting...\nDone.\n")
+		m.on("GET", "/api/v1/tasks/task-rb", 200, map[string]string{
+			"status": "completed",
+		})
+		r := run(t, m, "admin", "rollback", "--yes")
+		assertExit(t, r, 0)
+		assertContains(t, r.Stdout, "Reverting")
+	})
+
+	t.Run("rollback_unsupported_returns_error", func(t *testing.T) {
+		m := newMock(t)
+		m.on("POST", "/api/v1/admin/rollback", 501, map[string]string{
+			"error":   "not_supported",
+			"message": "rollback not supported by this backend",
+		})
+		r := run(t, m, "admin", "rollback", "--yes")
+		assertExit(t, r, 1)
+	})
+
+	t.Run("rollback_json_returns_task_id", func(t *testing.T) {
+		m := newMock(t)
+		m.on("POST", "/api/v1/admin/rollback", 202, map[string]string{
+			"task_id": "task-rb",
+		})
+		r := run(t, m, "admin", "rollback", "--yes", "--json")
+		assertExit(t, r, 0)
+		got := r.jsonMap()
+		if got["task_id"] != "task-rb" {
+			t.Errorf("task_id = %v, want task-rb", got["task_id"])
+		}
+	})
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -29,3 +29,4 @@ flags:
 
 ignore:
   - "internal/testutil/**"          # test helpers only
+  - "internal/preflight/docker_checks.go"  # moved to internal/backend/docker/preflight.go in 207dd28; carryforward keeps the ghost report alive

--- a/internal/api/bootstrap_test.go
+++ b/internal/api/bootstrap_test.go
@@ -1,0 +1,291 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/cynkra/blockyard/internal/auth"
+	"github.com/cynkra/blockyard/internal/config"
+	"github.com/cynkra/blockyard/internal/server"
+)
+
+const (
+	testBootstrapToken = "by_bootstrap_for_tests"
+	testInitialAdmin   = "admin-sub"
+)
+
+// armBootstrap configures srv for bootstrap exchange and returns the
+// httptest URL to POST against. Caller is responsible for calling
+// testServer first.
+func armBootstrap(t *testing.T, srv *server.Server) {
+	t.Helper()
+	if srv.Config.OIDC == nil {
+		srv.Config.OIDC = &config.OidcConfig{}
+	}
+	srv.Config.OIDC.InitialAdmin = testInitialAdmin
+	srv.BootstrapTokenHash = auth.HashPAT(testBootstrapToken)
+	srv.BootstrapRedeemed.Store(false)
+}
+
+func bootstrapReq(token string, body io.Reader) *http.Request {
+	req, _ := http.NewRequest("POST", "/api/v1/bootstrap", body)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return req
+}
+
+func TestBootstrap_NotConfigured(t *testing.T) {
+	srv, ts := testServer(t)
+	// Deliberately do NOT arm bootstrap — leave hash empty.
+	_ = srv
+
+	resp, err := http.Post(ts.URL+"/api/v1/bootstrap", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestBootstrap_AlreadyRedeemed(t *testing.T) {
+	srv, ts := testServer(t)
+	armBootstrap(t, srv)
+	srv.BootstrapRedeemed.Store(true)
+
+	req := bootstrapReq(testBootstrapToken, strings.NewReader(`{}`))
+	resp, err := http.DefaultClient.Do(mustURL(t, req, ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusGone {
+		t.Errorf("status = %d, want 410", resp.StatusCode)
+	}
+}
+
+func TestBootstrap_NoBearer(t *testing.T) {
+	srv, ts := testServer(t)
+	armBootstrap(t, srv)
+
+	req := bootstrapReq("", strings.NewReader(`{}`))
+	resp, err := http.DefaultClient.Do(mustURL(t, req, ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestBootstrap_WrongToken(t *testing.T) {
+	srv, ts := testServer(t)
+	armBootstrap(t, srv)
+
+	req := bootstrapReq("by_completely_wrong_value", strings.NewReader(`{}`))
+	resp, err := http.DefaultClient.Do(mustURL(t, req, ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", resp.StatusCode)
+	}
+	if srv.BootstrapRedeemed.Load() {
+		t.Error("BootstrapRedeemed should remain false on wrong token")
+	}
+}
+
+func TestBootstrap_BadBody(t *testing.T) {
+	srv, ts := testServer(t)
+	armBootstrap(t, srv)
+
+	req := bootstrapReq(testBootstrapToken, strings.NewReader(`not json`))
+	resp, err := http.DefaultClient.Do(mustURL(t, req, ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+	if srv.BootstrapRedeemed.Load() {
+		t.Error("BootstrapRedeemed should remain false on bad body")
+	}
+}
+
+func TestBootstrap_BadExpires(t *testing.T) {
+	srv, ts := testServer(t)
+	armBootstrap(t, srv)
+
+	body := strings.NewReader(`{"expires_in":"forever"}`)
+	req := bootstrapReq(testBootstrapToken, body)
+	resp, err := http.DefaultClient.Do(mustURL(t, req, ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestBootstrap_HappyPath(t *testing.T) {
+	srv, ts := testServer(t)
+	armBootstrap(t, srv)
+
+	body := strings.NewReader(`{"name":"my-pat","expires_in":"24h"}`)
+	req := bootstrapReq(testBootstrapToken, body)
+	resp, err := http.DefaultClient.Do(mustURL(t, req, ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("status = %d, want 201", resp.StatusCode)
+	}
+
+	var got map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if s, _ := got["name"].(string); s != "my-pat" {
+		t.Errorf("name = %q, want my-pat", s)
+	}
+	if s, _ := got["token"].(string); s == "" {
+		t.Error("token missing from response")
+	}
+	if s, _ := got["expires_at"].(string); s == "" {
+		t.Error("expires_at should be set when expires_in given")
+	}
+
+	if !srv.BootstrapRedeemed.Load() {
+		t.Error("BootstrapRedeemed should be true after success")
+	}
+
+	// Initial admin user must exist with admin role.
+	user, err := srv.DB.GetUser(testInitialAdmin)
+	if err != nil {
+		t.Fatalf("GetUser(%q): %v", testInitialAdmin, err)
+	}
+	if user.Role != "admin" {
+		t.Errorf("initial admin role = %q, want admin", user.Role)
+	}
+}
+
+func TestBootstrap_DefaultName(t *testing.T) {
+	srv, ts := testServer(t)
+	armBootstrap(t, srv)
+
+	req := bootstrapReq(testBootstrapToken, strings.NewReader(`{}`))
+	resp, err := http.DefaultClient.Do(mustURL(t, req, ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", resp.StatusCode)
+	}
+
+	var got map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if s, _ := got["name"].(string); s != "bootstrap" {
+		t.Errorf("name = %q, want bootstrap (default)", s)
+	}
+}
+
+func TestBootstrap_BurnsToken(t *testing.T) {
+	srv, ts := testServer(t)
+	armBootstrap(t, srv)
+
+	// First call succeeds.
+	req := bootstrapReq(testBootstrapToken, strings.NewReader(`{}`))
+	resp, err := http.DefaultClient.Do(mustURL(t, req, ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("first call status = %d, want 201", resp.StatusCode)
+	}
+
+	// Second call with the same token returns 410.
+	req2 := bootstrapReq(testBootstrapToken, strings.NewReader(`{}`))
+	resp2, err := http.DefaultClient.Do(mustURL(t, req2, ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusGone {
+		t.Errorf("second call status = %d, want 410", resp2.StatusCode)
+	}
+}
+
+// TestBootstrap_ConcurrentRedeem fires N requests in parallel and asserts
+// exactly one wins. Guards the CompareAndSwap that burns the token.
+func TestBootstrap_ConcurrentRedeem(t *testing.T) {
+	srv, ts := testServer(t)
+	armBootstrap(t, srv)
+
+	const N = 8
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		created int
+		gone    int
+	)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := bootstrapReq(testBootstrapToken, bytes.NewReader([]byte(`{}`)))
+			resp, err := http.DefaultClient.Do(mustURL(t, req, ts.URL))
+			if err != nil {
+				return
+			}
+			defer resp.Body.Close()
+			mu.Lock()
+			defer mu.Unlock()
+			switch resp.StatusCode {
+			case http.StatusCreated:
+				created++
+			case http.StatusGone:
+				gone++
+			}
+		}()
+	}
+	wg.Wait()
+
+	if created != 1 {
+		t.Errorf("created = %d, want exactly 1", created)
+	}
+	if created+gone != N {
+		t.Errorf("created + gone = %d, want %d (all responses accounted for)", created+gone, N)
+	}
+}
+
+// mustURL rewrites the request URL to point at the httptest server.
+// Allows building requests with relative paths above for readability.
+func mustURL(t *testing.T, req *http.Request, base string) *http.Request {
+	t.Helper()
+	u, err := req.URL.Parse(base + req.URL.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.URL = u
+	req.Host = u.Host
+	return req
+}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -9,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -746,6 +748,150 @@ func TestRollbackActivateFailsNoMigration(t *testing.T) {
 	}
 	if !killed.Load() {
 		t.Error("instance must be killed")
+	}
+}
+
+func TestRollbackUnsupportedFactory(t *testing.T) {
+	factory := &fakeServerFactory{supportsRollback: false}
+	o, _ := newTestOrchestrator(t, factory, &mockChecker{})
+	sender := newSender(t)
+
+	err := o.Rollback(context.Background(), sender, func() {
+		t.Fatal("shutdownFn must not be called when factory rejects")
+	})
+	if err == nil {
+		t.Fatal("expected error for unsupported factory")
+	}
+	if !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("error %q should mention 'not supported'", err.Error())
+	}
+}
+
+func TestRollbackMalformedBackupMeta(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	database, err := db.Open(config.DatabaseConfig{Driver: "sqlite", Path: dbPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	// Write a *.meta.json with invalid JSON to force the non-ErrNoBackup
+	// read-error branch.
+	bad := filepath.Join(dir, "20260101T000000Z.meta.json")
+	if err := os.WriteFile(bad, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	factory := &fakeServerFactory{supportsRollback: true}
+	o, _ := newTestOrchestrator(t, factory, &mockChecker{})
+	o.db = database
+	o.cfg.Database.Path = dbPath
+	sender := newSender(t)
+
+	err = o.Rollback(context.Background(), sender, func() {
+		t.Fatal("shutdownFn must not be called before any side effects")
+	})
+	if err == nil {
+		t.Fatal("expected error for malformed metadata")
+	}
+	if !strings.Contains(err.Error(), "read backup metadata") {
+		t.Errorf("error %q should mention 'read backup metadata'", err.Error())
+	}
+}
+
+func TestRollbackPreUpdateFails(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	database, err := db.Open(config.DatabaseConfig{Driver: "sqlite", Path: dbPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	if _, err := database.BackupWithMeta(context.Background(), "v1.0.0"); err != nil {
+		t.Fatal(err)
+	}
+
+	factory := &fakeServerFactory{
+		supportsRollback: true,
+		preUpdateErr:     errors.New("image pull denied"),
+	}
+
+	var shutdownCalled bool
+	o, tracker := newTestOrchestrator(t, factory, &mockChecker{})
+	o.db = database
+	o.cfg.Database.Path = dbPath
+	sender := newSender(t)
+
+	err = o.Rollback(context.Background(), sender, func() { shutdownCalled = true })
+	if err == nil {
+		t.Fatal("expected error when PreUpdate fails")
+	}
+	if !strings.Contains(err.Error(), "pull old image") {
+		t.Errorf("error %q should mention 'pull old image'", err.Error())
+	}
+	// PreUpdate runs before any down-migration → not fatal.
+	if shutdownCalled {
+		t.Error("shutdownFn must not be called before down-migration")
+	}
+	if tracker.drained.Load() != 0 {
+		t.Error("drain must not be called when rollback fails before activation")
+	}
+}
+
+func TestRollbackWaitReadyTimesOut(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	database, err := db.Open(config.DatabaseConfig{Driver: "sqlite", Path: dbPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	if _, err := database.BackupWithMeta(context.Background(), "v1.0.0"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Address with no listener → /readyz never returns 200.
+	deadAddr := "127.0.0.1:1" // port 1 reliably refuses connections
+
+	killed := atomic.Bool{}
+	factory := &fakeServerFactory{
+		supportsRollback: true,
+		createInstanceFn: func(context.Context, string, []string, task.Sender) (newServerInstance, error) {
+			return &fakeInstance{
+				id:     "rollback-instance",
+				addr:   deadAddr,
+				killFn: func(context.Context) { killed.Store(true) },
+			}, nil
+		},
+	}
+
+	o, tracker := newTestOrchestrator(t, factory, &mockChecker{})
+	o.db = database
+	o.cfg.Database.Path = dbPath
+	// Tight deadline so the test doesn't hang on the 1s ticker.
+	o.cfg.Proxy.WorkerStartTimeout = config.Duration{Duration: 100 * time.Millisecond}
+	sender := newSender(t)
+
+	var shutdownCalled bool
+	err = o.Rollback(context.Background(), sender, func() { shutdownCalled = true })
+	if err == nil {
+		t.Fatal("expected error when waitReady times out")
+	}
+	if !strings.Contains(err.Error(), "never became ready") {
+		t.Errorf("error %q should mention 'never became ready'", err.Error())
+	}
+	if !killed.Load() {
+		t.Error("the failed instance must be killed")
+	}
+	// No migration ran → not fatal, drain not called.
+	if shutdownCalled {
+		t.Error("shutdownFn must not be called when no migration ran")
+	}
+	if tracker.drained.Load() != 0 {
+		t.Error("drain must not be called when waitReady fails")
 	}
 }
 

--- a/tests/examples/hello_shiny_test.go
+++ b/tests/examples/hello_shiny_test.go
@@ -3,6 +3,7 @@
 package examples_test
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/cookiejar"
@@ -98,6 +99,51 @@ func TestHelloShiny(t *testing.T) {
 		client *http.Client
 		token  string
 	)
+
+	// Exercise the bootstrap-token → PAT exchange end-to-end against a
+	// real server. Unit coverage lives in internal/api/bootstrap_test.go;
+	// this guards against router/middleware/config-wiring regressions
+	// the unit test cannot catch. Runs first so the token isn't burned
+	// by anything else in this stack.
+	t.Run("bootstrap_token_exchange", func(t *testing.T) {
+		req, _ := http.NewRequest("POST",
+			baseURL+"/api/v1/bootstrap",
+			strings.NewReader(`{"name":"bootstrap-e2e","expires_in":"1h"}`))
+		req.Header.Set("Authorization", "Bearer by_bootstrap_for_examples")
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("bootstrap exchange: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("bootstrap status %d: %s", resp.StatusCode, b)
+		}
+		var got map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+			t.Fatalf("decode bootstrap response: %v", err)
+		}
+		tok, _ := got["token"].(string)
+		if !strings.HasPrefix(tok, "by_") {
+			t.Fatalf("bootstrap token %q missing by_ prefix", tok)
+		}
+
+		// Second call must be rejected — the token is one-shot.
+		req2, _ := http.NewRequest("POST",
+			baseURL+"/api/v1/bootstrap",
+			strings.NewReader(`{}`))
+		req2.Header.Set("Authorization", "Bearer by_bootstrap_for_examples")
+		req2.Header.Set("Content-Type", "application/json")
+		resp2, err := http.DefaultClient.Do(req2)
+		if err != nil {
+			t.Fatalf("second bootstrap: %v", err)
+		}
+		resp2.Body.Close()
+		if resp2.StatusCode != http.StatusGone {
+			t.Fatalf("second bootstrap status = %d, want 410", resp2.StatusCode)
+		}
+	})
 
 	t.Run("auth", func(t *testing.T) {
 		cookies := dexLogin(t, baseURL, dexURL, dexEmail1, dexPassword)


### PR DESCRIPTION
## Summary
- Fix `coverage-e2e-*.out` glob mismatch so playwright coverage reaches Codecov again (broken since `4636632`, ~2pp drop). Tighten `if-no-files-found` to `error` and add a flag-presence assertion so the next silent regression annotates instead of disappearing.
- Drop the ghost `internal/preflight/docker_checks.go` entry from Codecov — file was renamed in `207dd28` but `carryforward: true` kept it in the report at a frozen 52.87%.
- Add unit + e2e tests for `internal/api/bootstrap.go` (1.3% → 88.5%) — security-critical one-time PAT exchange that had no Go-level coverage.
- Add CLI integration tests for `by admin {update,rollback,status}` (admin.go 27% → 57%) and rollback.go pre-migration error paths (63% → 74%).