### PR TITLE
fix(proxy): clear WriteTimeout on log-streaming endpoints

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -32,6 +32,13 @@ import (
 const testPAT = "by_testtoken000000000000000000000000000000000"
 
 func testServer(t *testing.T) (*server.Server, *httptest.Server) {
+	return testServerWithWriteTimeout(t, 0)
+}
+
+// testServerWithWriteTimeout is testServer but applies the given
+// WriteTimeout to the underlying http.Server. A zero value leaves the
+// httptest default in place.
+func testServerWithWriteTimeout(t *testing.T, writeTimeout time.Duration) (*server.Server, *httptest.Server) {
 	t.Helper()
 	tmp := t.TempDir()
 
@@ -60,7 +67,11 @@ func testServer(t *testing.T) (*server.Server, *httptest.Server) {
 	var wg sync.WaitGroup
 	srv.RestoreWG = &wg
 	handler := NewRouter(srv, func() {}, nil, context.Background())
-	ts := httptest.NewServer(handler)
+	ts := httptest.NewUnstartedServer(handler)
+	if writeTimeout > 0 {
+		ts.Config.WriteTimeout = writeTimeout
+	}
+	ts.Start()
 	t.Cleanup(ts.Close)
 	// Wait for restore goroutines before DB/TempDir cleanup (LIFO order).
 	t.Cleanup(wg.Wait)
@@ -938,6 +949,42 @@ func TestTaskLogsRunningTaskCompletes(t *testing.T) {
 	}
 	if !strings.Contains(string(body), "live line") {
 		t.Errorf("expected live line in output, got %q", body)
+	}
+}
+
+// Regression test for #306: a long-running build must not be cut by the
+// server's WriteTimeout. The handler clears the per-response deadline so
+// the stream can outlive WriteTimeout.
+func TestTaskLogsOutlivesWriteTimeout(t *testing.T) {
+	const writeTimeout = 100 * time.Millisecond
+	srv, ts := testServerWithWriteTimeout(t, writeTimeout)
+
+	sender := srv.Tasks.Create("task-logs-slow", "")
+	sender.Write("buffered line")
+
+	go func() {
+		// Sleep well past WriteTimeout before emitting the final line.
+		time.Sleep(3 * writeTimeout)
+		sender.Write("late line")
+		sender.Complete(task.Completed)
+	}()
+
+	req := authReq("GET", ts.URL+"/api/v1/tasks/task-logs-slow/logs", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !strings.Contains(string(body), "late line") {
+		t.Errorf("expected late line after WriteTimeout, got %q", body)
 	}
 }
 

--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -1086,6 +1086,13 @@ func AppLogs(srv *server.Server) http.HandlerFunc {
 		streamParam := r.URL.Query().Get("stream")
 		noStream := streamParam == "false"
 
+		// Long-running workers can outlive the server's WriteTimeout;
+		// clear the per-response deadline so live tailing stays open
+		// until the worker exits or the client disconnects.
+		if !ended && !noStream {
+			_ = http.NewResponseController(w).SetWriteDeadline(time.Time{})
+		}
+
 		w.Header().Set("Content-Type", "text/plain")
 		w.Header().Set("Transfer-Encoding", "chunked")
 

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -94,6 +95,11 @@ func TaskLogs(srv *server.Server) http.HandlerFunc {
 			notFound(w, "task "+taskID+" not found")
 			return
 		}
+
+		// Builds can run longer than the server's WriteTimeout; clear the
+		// per-response deadline so the stream stays open until the task
+		// finishes or the client disconnects.
+		_ = http.NewResponseController(w).SetWriteDeadline(time.Time{})
 
 		w.Header().Set("Content-Type", "text/plain")
 		w.Header().Set("Transfer-Encoding", "chunked")


### PR DESCRIPTION
## Summary
- The HTTP server's 60s WriteTimeout was severing `/tasks/{id}/logs` and `/apps/{id}/logs` streams mid-response, surfacing as the `TestHelloPocketbase/user1_deploy` flake (`deploy --wait` returned `running` after ~61s while the build kept going).
- Clear the per-response deadline via `http.NewResponseController(w).SetWriteDeadline(time.Time{})` so streams live until the task ends or the client disconnects; `r.Context()` cancellation still handles client/server shutdown.
- Adds a regression test that runs the streaming handler against an `httptest.Server` with a 100ms `WriteTimeout` and asserts a line emitted after 300ms still arrives. Verified the test fails (`EOF` mid-read) without the fix.

Fixes #306