### PR TITLE
ci(misc): pin codecov-cli to avoid latest/ endpoint race

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -320,9 +320,13 @@ jobs:
       - name: Upload coverage to Codecov
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          # Pin codecov-cli to avoid races on the `latest/` endpoint,
+          # where a release rolling between the two curl calls left us
+          # with a binary and checksum from different versions.
+          CODECOV_CLI_VERSION: v11.2.8
         run: |
-          curl -fsSL https://cli.codecov.io/latest/linux/codecov -o ./codecov
-          curl -fsSL https://cli.codecov.io/latest/linux/codecov.SHA256SUM -o ./codecov.SHA256SUM
+          curl -fsSL "https://cli.codecov.io/${CODECOV_CLI_VERSION}/linux/codecov" -o ./codecov
+          curl -fsSL "https://cli.codecov.io/${CODECOV_CLI_VERSION}/linux/codecov.SHA256SUM" -o ./codecov.SHA256SUM
           sha256sum -c codecov.SHA256SUM
           chmod +x ./codecov
           for f in coverage-*.out; do


### PR DESCRIPTION
## Summary
- `https://cli.codecov.io/latest/linux/codecov` is a moving pointer — if Codecov rolled a new CLI release between the binary and SHA256 curls, `sha256sum -c` rejected the mismatch and dequeued an unrelated PR (#300).
- Pin to `v11.2.8` via a `CODECOV_CLI_VERSION` env var so both files come from the same versioned directory, eliminating the race.

Fixes #310