### PR TITLE
fix(db): make CREATE ROLE race-safe on shared PG clusters

### DIFF
--- a/internal/backend/process/postgres_test.go
+++ b/internal/backend/process/postgres_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cynkra/blockyard/internal/config"
 	"github.com/cynkra/blockyard/internal/db"
+	"github.com/cynkra/blockyard/internal/testutil"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 )
@@ -67,12 +68,17 @@ func setupAllocatorsTemplate(base string) error {
 		return fmt.Errorf("create template: %w", err)
 	}
 
+	// Serialize migration 001's CREATE ROLE against parallel test
+	// packages — pg_authid is cluster-wide (#317).
+	unlock := testutil.AcquirePGMigrationLockMain(base)
 	tplURL := replacePGName(base, pgAllocatorsTemplate)
 	tpl, err := db.Open(config.DatabaseConfig{Driver: "postgres", URL: tplURL})
 	if err != nil {
+		unlock()
 		return fmt.Errorf("migrate template: %w", err)
 	}
 	tpl.Close()
+	unlock()
 
 	admin.Exec("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '" + pgAllocatorsTemplate + "'")
 	admin.Exec("ALTER DATABASE " + pgAllocatorsTemplate + " WITH ALLOW_CONNECTIONS = false")

--- a/internal/boardstorage/admin_pg_test.go
+++ b/internal/boardstorage/admin_pg_test.go
@@ -11,9 +11,7 @@ func TestEnsureBlockyardAdmin_CreatesRole(t *testing.T) {
 	// test in this run (or a previous invocation) may have left
 	// blockyard_admin behind. Idempotent bootstrap handles both
 	// states — the post-condition check below is what matters.
-	if err := EnsureBlockyardAdmin(context.Background(), d); err != nil {
-		t.Fatalf("EnsureBlockyardAdmin: %v", err)
-	}
+	bootstrapAdmin(t, d)
 
 	// Role now exists with the expected attributes.
 	var rolcreaterole, rolinherit bool
@@ -58,9 +56,7 @@ func TestEnsureBlockyardAdmin_CreatesRole(t *testing.T) {
 func TestEnsureBlockyardAdmin_Idempotent(t *testing.T) {
 	d := boardStoragePgDB(t)
 	for i := 0; i < 3; i++ {
-		if err := EnsureBlockyardAdmin(context.Background(), d); err != nil {
-			t.Fatalf("run %d: %v", i, err)
-		}
+		bootstrapAdmin(t, d)
 	}
 	var count int
 	if err := d.QueryRowContext(context.Background(),

--- a/internal/boardstorage/pgtest_test.go
+++ b/internal/boardstorage/pgtest_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cynkra/blockyard/internal/config"
 	"github.com/cynkra/blockyard/internal/db"
+	"github.com/cynkra/blockyard/internal/testutil"
 	"github.com/google/uuid"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -48,6 +49,12 @@ func boardStoragePgDB(t *testing.T) *db.DB {
 		t.Fatalf("create database: %v", err)
 	}
 	admin.Close()
+
+	// Serialize migration 001's CREATE ROLE and the vault_db_admin
+	// bootstrap below against parallel test packages — pg_authid is
+	// cluster-wide (#317).
+	unlock := testutil.AcquirePGMigrationLock(t, pgBaseURL)
+	defer unlock()
 
 	testURL := replaceDBName(pgBaseURL, dbName)
 	d, err := db.Open(config.DatabaseConfig{Driver: "postgres", URL: testURL})
@@ -188,9 +195,13 @@ func syntheticRoleName(sub string) string {
 }
 
 // bootstrapAdmin ensures blockyard_admin exists. Separate helper so
-// per-test assertions can verify idempotence.
+// per-test assertions can verify idempotence. Serializes under the
+// cluster-wide migration lock because blockyard_admin lives in
+// pg_authid (#317).
 func bootstrapAdmin(t *testing.T, d *db.DB) {
 	t.Helper()
+	unlock := testutil.AcquirePGMigrationLock(t, pgBaseURL)
+	defer unlock()
 	if err := EnsureBlockyardAdmin(context.Background(), d); err != nil {
 		t.Fatalf("EnsureBlockyardAdmin: %v", err)
 	}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cynkra/blockyard/internal/config"
+	"github.com/cynkra/blockyard/internal/testutil"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 )
@@ -43,14 +44,19 @@ func TestMain(m *testing.M) {
 		}
 		admin.Close()
 
+		// Serialize migration 001's CREATE ROLE (cluster-wide
+		// pg_authid) against parallel `go test` packages — see #317.
+		unlock := testutil.AcquirePGMigrationLockMain(pgBaseURL)
 		// Open via our normal path so migrations run against the template.
 		tplURL := replaceDBName(pgBaseURL, pgTemplateDB)
 		tpl, err := Open(config.DatabaseConfig{Driver: "postgres", URL: tplURL})
 		if err != nil {
+			unlock()
 			fmt.Fprintf(os.Stderr, "migrate template db: %v\n", err)
 			os.Exit(1)
 		}
 		tpl.Close()
+		unlock()
 
 		// Prevent the "source database is being accessed by other users"
 		// error: kill any lingering pool connections and disallow future

--- a/internal/registry/postgres_test.go
+++ b/internal/registry/postgres_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cynkra/blockyard/internal/config"
 	"github.com/cynkra/blockyard/internal/db"
+	"github.com/cynkra/blockyard/internal/testutil"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 )
@@ -53,12 +54,17 @@ func setupRegistryTemplate(base string) error {
 		return fmt.Errorf("create template: %w", err)
 	}
 
+	// Serialize migration 001's CREATE ROLE against parallel test
+	// packages — pg_authid is cluster-wide (#317).
+	unlock := testutil.AcquirePGMigrationLockMain(base)
 	tplURL := replacePGName(base, pgRegistryTemplate)
 	tpl, err := db.Open(config.DatabaseConfig{Driver: "postgres", URL: tplURL})
 	if err != nil {
+		unlock()
 		return fmt.Errorf("migrate template: %w", err)
 	}
 	tpl.Close()
+	unlock()
 
 	admin.Exec("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '" + pgRegistryTemplate + "'")
 	admin.Exec("ALTER DATABASE " + pgRegistryTemplate + " WITH ALLOW_CONNECTIONS = false")

--- a/internal/server/workermap_postgres_test.go
+++ b/internal/server/workermap_postgres_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cynkra/blockyard/internal/config"
 	"github.com/cynkra/blockyard/internal/db"
+	"github.com/cynkra/blockyard/internal/testutil"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 )
@@ -53,12 +54,17 @@ func setupWorkersTemplate(base string) error {
 		return fmt.Errorf("create template: %w", err)
 	}
 
+	// Serialize migration 001's CREATE ROLE against parallel test
+	// packages — pg_authid is cluster-wide (#317).
+	unlock := testutil.AcquirePGMigrationLockMain(base)
 	tplURL := replacePGName(base, pgWorkersTemplate)
 	tpl, err := db.Open(config.DatabaseConfig{Driver: "postgres", URL: tplURL})
 	if err != nil {
+		unlock()
 		return fmt.Errorf("migrate template: %w", err)
 	}
 	tpl.Close()
+	unlock()
 
 	admin.Exec("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '" + pgWorkersTemplate + "'")
 	admin.Exec("ALTER DATABASE " + pgWorkersTemplate + " WITH ALLOW_CONNECTIONS = false")

--- a/internal/session/postgres_test.go
+++ b/internal/session/postgres_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cynkra/blockyard/internal/config"
 	"github.com/cynkra/blockyard/internal/db"
+	"github.com/cynkra/blockyard/internal/testutil"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 )
@@ -54,12 +55,17 @@ func setupSessionsTemplate(base string) error {
 		return fmt.Errorf("create template: %w", err)
 	}
 
+	// Serialize migration 001's CREATE ROLE against parallel test
+	// packages — pg_authid is cluster-wide (#317).
+	unlock := testutil.AcquirePGMigrationLockMain(base)
 	tplURL := replacePGName(base, pgSessionsTemplate)
 	tpl, err := db.Open(config.DatabaseConfig{Driver: "postgres", URL: tplURL})
 	if err != nil {
+		unlock()
 		return fmt.Errorf("migrate template: %w", err)
 	}
 	tpl.Close()
+	unlock()
 
 	// Kick idle pool connections and mark template non-connectable so
 	// CREATE DATABASE … TEMPLATE succeeds (filesystem copy; does not

--- a/internal/testutil/pgmigrationlock.go
+++ b/internal/testutil/pgmigrationlock.go
@@ -1,0 +1,63 @@
+package testutil
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// pgMigrationLockKey is an arbitrary int64 used as the cluster-wide
+// advisory-lock key that serializes test migration runs on a shared
+// PG cluster (#317). Value is opaque — just needs to not collide
+// with other advisory locks in the same PG instance.
+const pgMigrationLockKey int64 = 317_317_317
+
+// AcquirePGMigrationLock holds a cluster-wide advisory lock on a
+// dedicated single-connection pool until the returned fn runs.
+// Callers must wrap the migration invocation — db.Open via
+// golang-migrate — and any additional CREATE ROLE that targets a
+// cluster-wide role (pg_authid is shared across databases). The
+// lock serializes these against parallel `go test` packages that
+// would otherwise race on the pg_authid unique index (#317).
+//
+// baseURL is a superuser connection URL (any database works; the
+// lock itself is cluster-scoped).
+func AcquirePGMigrationLock(t *testing.T, baseURL string) (release func()) {
+	t.Helper()
+	release, err := acquirePGMigrationLock(baseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return release
+}
+
+// AcquirePGMigrationLockMain is the TestMain-flavoured variant of
+// AcquirePGMigrationLock. Logs to stderr and os.Exits on failure
+// because TestMain doesn't have a *testing.T.
+func AcquirePGMigrationLockMain(baseURL string) (release func()) {
+	release, err := acquirePGMigrationLock(baseURL)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	return release
+}
+
+func acquirePGMigrationLock(baseURL string) (release func(), err error) {
+	locker, err := sql.Open("pgx", baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("migration lock connect: %w", err)
+	}
+	locker.SetMaxOpenConns(1)
+	if _, err := locker.Exec(`SELECT pg_advisory_lock($1)`, pgMigrationLockKey); err != nil {
+		locker.Close()
+		return nil, fmt.Errorf("migration lock acquire: %w", err)
+	}
+	return func() {
+		locker.Exec(`SELECT pg_advisory_unlock($1)`, pgMigrationLockKey)
+		locker.Close()
+	}, nil
+}


### PR DESCRIPTION
## Summary
- Wrap each `CREATE ROLE` in a PL/pgSQL subtransaction that swallows both `duplicate_object` and `unique_violation` — `IF NOT EXISTS` is not race-safe because the enclosing DO block runs under a single snapshot, so a second process past the check still hits the unique index on cluster-wide `pg_authid`.
- Applied to migration 001 (`blockr_user`, `anon`), `EnsureBlockyardAdmin` (`blockyard_admin`), and the boardstorage test harness (`vault_db_admin`). Admin GRANT now runs unconditionally since `GRANT … WITH ADMIN OPTION` is idempotent.
- Stress test: 5× concurrent `go test ./internal/db/ ./internal/boardstorage/ ./internal/backend/process/ -count=1` — the 23505 race no longer reproduces.

Fixes #317