### PR TITLE
ci(misc): skip redundant docker-cache save on self-collision

### DIFF
--- a/.github/actions/docker-cache/action.yml
+++ b/.github/actions/docker-cache/action.yml
@@ -37,12 +37,20 @@ runs:
         password: ${{ inputs.token }}
 
     - uses: actions/cache/restore@v5
+      id: restore
       if: inputs.phase == 'setup'
       with:
         path: /tmp/docker-cache
         key: docker-${{ github.job }}-${{ inputs.key }}-wk${{ steps.meta.outputs.week }}-${{ github.run_id }}
         restore-keys: |
           docker-${{ github.job }}-${{ inputs.key }}-wk${{ steps.meta.outputs.week }}-
+
+    # Persist the matched key so the save phase (a separate composite
+    # invocation) can detect self-collision and skip a redundant save.
+    - name: Persist cache-matched-key
+      if: inputs.phase == 'setup'
+      shell: bash
+      run: echo "DOCKER_CACHE_MATCHED_KEY=${{ steps.restore.outputs.cache-matched-key }}" >> "$GITHUB_ENV"
 
     - name: Load cached images
       if: inputs.phase == 'setup'
@@ -119,8 +127,15 @@ runs:
         echo "hash=$hash" >> "$GITHUB_OUTPUT"
         echo "skip=false" >> "$GITHUB_OUTPUT"
 
+    # Skip when the computed save-key equals the key just restored:
+    # eviction + re-save of identically-named tarballs produces the same
+    # hash, and actions/cache/save@v5 emits a misleading "another job may
+    # be creating this cache" warning on a redundant reserve.
     - uses: actions/cache/save@v5
-      if: inputs.phase == 'save' && steps.snap.outputs.skip != 'true'
+      if: >-
+        inputs.phase == 'save'
+        && steps.snap.outputs.skip != 'true'
+        && format('docker-{0}-{1}-wk{2}-{3}', github.job, inputs.key, steps.meta.outputs.week, steps.snap.outputs.hash) != env.DOCKER_CACHE_MATCHED_KEY
       with:
         path: /tmp/docker-cache
         key: docker-${{ github.job }}-${{ inputs.key }}-wk${{ steps.meta.outputs.week }}-${{ steps.snap.outputs.hash }}


### PR DESCRIPTION
## Summary

- Persist `cache-matched-key` from `actions/cache/restore` into `$GITHUB_ENV` during the setup phase.
- Skip `actions/cache/save` when the computed save-key equals that matched key — eviction + re-save of identically-named tarballs produces the same content hash, and `actions/cache/save@v5` emits a misleading "another job may be creating this cache" warning on the redundant reserve.
- Behavior on genuine content change (or first-of-week save) is unchanged.

Fixes #302