### PR TITLE
feat(process): implement phase 3-9 (apparmor + cgroup delegation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ on:
           - openbao
           - pak
           - process
+          - apparmor-smoke
           - ui
           - redis
 
@@ -390,48 +391,42 @@ jobs:
           path: coverage-ui.out
           retention-days: 1
 
-  # The process backend supports three deployment modes (see
-  # backends.md / phase-3-7.md decision #5). All three are tested
-  # in parallel because the security-relevant preflight check
-  # (checkBwrapHostUIDMapping) and the iptables --uid-owner contract
-  # behave differently per mode and we want regressions in any
-  # single mode to surface immediately.
+  # The process backend supports two deployment modes after phase 3-9
+  # retired the `setuid-bwrap` mode (correctness — it never delivered
+  # per-worker host kuids and was mis-documented in phase 3-7).
+  # Both remaining modes run inside the --privileged CI container and
+  # exercise distinct production spawn paths:
   #
-  #   - root        — sudo go test, blockyard-as-root containerized
-  #                   mode. bwrap inherits CAP_SYS_ADMIN and writes
-  #                   any uid_map.
-  #   - setuid      — `chmod u+s /usr/bin/bwrap` then run unprivileged.
-  #                   Matches the Fedora/RHEL production default and
-  #                   the recommended path for native non-root
-  #                   blockyard on Debian 12+/Ubuntu 24.04+.
-  #   - unprivileged — disable Ubuntu 24.04's AppArmor restriction
-  #                    on unprivileged user namespaces and run as
-  #                    the runner user with no setuid. Workers can
-  #                    spawn but uid_map writes to foreign UIDs are
-  #                    rejected by the kernel — exactly the silent
-  #                    failure mode the preflight check is supposed
-  #                    to detect. The integration tests assert that
-  #                    checkBwrapHostUIDMapping returns Error here.
+  #   - root         — blockyard runs as container root; the spawn
+  #                    path fork+setuid's into the worker UID before
+  #                    exec(bwrap), producing host-effective worker
+  #                    kuids for the `-m owner` path.
+  #   - unprivileged — non-root blockyard; the fork+setuid shim is
+  #                    short-circuited, bwrap's uid_map remains
+  #                    identity-mapped to blockyard's own uid, and
+  #                    the integration tests verify that
+  #                    checkBwrapHostUIDMapping returns Info (not
+  #                    Error — phase 3-9 recharacterised non-root
+  #                    layer 6 as "inapplicable, steer to cgroup
+  #                    delegation" rather than "broken, blocks
+  #                    startup").
+  #
+  # AppArmor profile coverage lives in the standalone apparmor-smoke
+  # job below; --privileged bypasses AppArmor enforcement inside the
+  # container, so the profile's real behaviour can only be observed
+  # on the VM directly.
   process:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [unit]
     if: github.event_name != 'merge_group' && github.event_name != 'push' && (inputs.job == '' || inputs.job == 'process')
-    # Run inside the production worker image so TestRSmokeBoot
-    # exercises R (/usr/local/bin/R) from the exact path blockyard.toml
-    # points at. --privileged is required for the unprivileged matrix
-    # leg to write kernel.apparmor_restrict_unprivileged_userns (a
-    # non-namespaced sysctl that the kernel enforces for container
-    # processes too). Tests still run as a non-root user for the
-    # setuid/unprivileged modes, so the capability matrix is preserved
-    # per-test.
     container:
       image: ghcr.io/cynkra/blockyard-worker:4.4.3
       options: --privileged
     strategy:
       fail-fast: false
       matrix:
-        mode: [root, setuid, unprivileged]
+        mode: [root, unprivileged]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -441,40 +436,28 @@ jobs:
         run: |
           apt-get update
           apt-get install -y --no-install-recommends bubblewrap
-          # Non-root user used by setuid and unprivileged modes.
-          # root mode doesn't need it but creating it is cheap.
+          # Non-root user used by the unprivileged mode. root mode
+          # doesn't need it but creating it is cheap.
           useradd -m -u 2000 blockyard-runner
           # setup-go puts Go in /opt/hostedtoolcache owned by root.
           # The non-root user needs execute access on the Go binary;
           # GOCACHE/GOMODCACHE will go to the non-root user's $HOME.
           chmod -R a+rx /opt/hostedtoolcache/go || true
-      - name: Configure mode (${{ matrix.mode }})
+      - name: Relax AppArmor userns restriction
         run: |
-          # All three matrix modes need the AppArmor restriction on
-          # unprivileged userns disabled so that the non-root workers
-          # our fork+setuid shim produces can call unshare(CLONE_NEWUSER)
-          # inside bwrap. Ubuntu 24.04's default
-          # kernel.apparmor_restrict_unprivileged_userns=1 blocks this
-          # for processes that aren't in an AppArmor profile granting
-          # the userns capability; --privileged disables AppArmor
-          # inside the container but the sysctl is a host-level check
-          # tied to the process's profile state and still fires. `|| true`
-          # because the file is absent on kernels that don't ship the
-          # restriction at all.
+          # Both matrix modes need Ubuntu 24.04's AppArmor restriction
+          # on unprivileged userns disabled so bwrap's post-setuid
+          # (root leg) and direct non-root (unprivileged leg) userns
+          # unshare calls are not intercepted. --privileged disables
+          # AppArmor enforcement inside the container but the sysctl
+          # is a host-level check tied to the process's profile state
+          # and still fires. `|| true` because the file is absent on
+          # kernels that don't ship the restriction at all. The shipped
+          # AppArmor profile is not loadable here (process path inside
+          # --privileged container != /usr/local/bin/blockyard path the
+          # profile attaches to); profile-load coverage lives in the
+          # standalone apparmor-smoke job.
           sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
-          case "${{ matrix.mode }}" in
-            root)
-              : # nothing extra; blockyard runs as container root and
-                # the spawn path fork+setuid's into the worker UID
-                # before exec(bwrap).
-              ;;
-            setuid)
-              chmod u+s /usr/bin/bwrap
-              ;;
-            unprivileged)
-              : # sysctl already set above.
-              ;;
-          esac
       - name: Run process backend tests (${{ matrix.mode }})
         # /github/home (the HOME Actions sets inside container jobs)
         # isn't writable as root in the worker container, so go's
@@ -494,7 +477,7 @@ jobs:
                 ./internal/backend/process/... \
                 ./internal/orchestrator/...
               ;;
-            *)
+            unprivileged)
               # Run as the non-root user. chown the workspace + cache
               # so go test can write coverage and cache artifacts.
               chown -R blockyard-runner:blockyard-runner "$PWD" "$GOCACHE" "$GOMODCACHE"
@@ -515,6 +498,57 @@ jobs:
           name: coverage-process-${{ matrix.mode }}
           path: coverage-process-${{ matrix.mode }}.out
           retention-days: 1
+
+  # apparmor-smoke runs directly on the Ubuntu 24.04 VM — NOT inside
+  # a container — so the host AppArmor profile actually attaches to
+  # processes that match its path. The CI runner's VM image ships
+  # AppArmor 4.x and has kernel.apparmor_restrict_unprivileged_userns=1
+  # by default. The test pair is the entire regression guard: the
+  # negative step proves the restriction is active (rootless bwrap
+  # fails without the profile), and the positive step proves the
+  # profile lifts it. Without both, a green result means nothing
+  # because the environment might be quietly permissive.
+  apparmor-smoke:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    needs: [unit]
+    if: github.event_name != 'merge_group' && github.event_name != 'push' && (inputs.job == '' || inputs.job == 'apparmor-smoke')
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Install bubblewrap + apparmor utils
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends bubblewrap apparmor apparmor-utils
+      - name: Build and install blockyard to /usr/local/bin
+        run: |
+          go build -o /tmp/blockyard ./cmd/blockyard
+          sudo install -m 755 /tmp/blockyard /usr/local/bin/blockyard
+      - name: Assert baseline — profile unloaded, rootless bwrap blocked
+        run: |
+          sudo useradd -m -u 2000 blockyard-runner
+          sysctl_value=$(sysctl -n kernel.apparmor_restrict_unprivileged_userns)
+          if [ "$sysctl_value" != "1" ]; then
+            echo "sysctl kernel.apparmor_restrict_unprivileged_userns=$sysctl_value (expected 1 on the runner)"
+            exit 1
+          fi
+          # Expected to fail: no profile grants userns, sysctl=1 blocks.
+          if sudo -u blockyard-runner /usr/local/bin/blockyard bwrap-smoke; then
+            echo "FAIL: rootless bwrap succeeded without the profile — test is not exercising the restriction"
+            exit 1
+          fi
+      - name: Load profile, assert rootless bwrap unblocked
+        run: |
+          sudo install -m 644 internal/apparmor/blockyard /etc/apparmor.d/blockyard
+          sudo apparmor_parser -r /etc/apparmor.d/blockyard
+          if ! sudo aa-status | grep -q 'blockyard'; then
+            echo "profile did not load"
+            sudo aa-status
+            exit 1
+          fi
+          sudo -u blockyard-runner /usr/local/bin/blockyard bwrap-smoke
 
   coverage:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,6 +222,18 @@ jobs:
           name: seccomp-outer-json
           path: internal/seccomp/blockyard-outer.json
           retention-days: 1
+      # AppArmor profile — same release channel as the seccomp
+      # profiles. Renamed to `blockyard-apparmor` so the published
+      # filename is unambiguous (the source filename `blockyard`
+      # alone would collide with the server binary on the release
+      # page).
+      - name: Stage AppArmor profile with release filename
+        run: cp internal/apparmor/blockyard /tmp/blockyard-apparmor
+      - uses: actions/upload-artifact@v7
+        with:
+          name: apparmor-profile
+          path: /tmp/blockyard-apparmor
+          retention-days: 1
 
   binaries:
     needs: tests
@@ -303,6 +315,10 @@ jobs:
         with:
           name: seccomp-outer-json
           path: .
+      - uses: actions/download-artifact@v8
+        with:
+          name: apparmor-profile
+          path: .
 
       - uses: softprops/action-gh-release@v3
         with:
@@ -312,3 +328,4 @@ jobs:
             by-*
             blockyard-bwrap-seccomp.bpf
             blockyard-outer.json
+            blockyard-apparmor

--- a/cmd/blockyard/main.go
+++ b/cmd/blockyard/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strings"
@@ -75,11 +76,43 @@ func runProbe(args []string) error {
 	return nil
 }
 
+// runBwrapSmoke exec's `bwrap --unshare-user --ro-bind / / -- /bin/true`
+// and returns the run error. Used by the standalone apparmor-smoke CI
+// job and by operators who want to verify that a production host's
+// AppArmor profile actually unblocks rootless bwrap. Intentionally
+// tiny — no config parsing, no logging setup.
+func runBwrapSmoke(args []string) error {
+	fs := flag.NewFlagSet("bwrap-smoke", flag.ContinueOnError)
+	bwrapPath := fs.String("bwrap", "bwrap", "path to bwrap")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	cmd := exec.Command(*bwrapPath, //nolint:gosec // G204: operator-supplied smoke-test path
+		"--unshare-user",
+		"--ro-bind", "/", "/",
+		"--", "/bin/true")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
 func main() {
 	// `blockyard probe ...` short-circuits before flag.Parse() so its
 	// own FlagSet handles the args. Used by process.checkWorkerEgress.
 	if len(os.Args) > 1 && os.Args[1] == "probe" {
 		if err := runProbe(os.Args[2:]); err != nil {
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
+	// `blockyard bwrap-smoke` runs a minimal rootless bwrap invocation
+	// and exits 0 on success. Used by the apparmor-smoke CI job and by
+	// operators verifying that a loaded AppArmor profile unblocks
+	// rootless userns on Ubuntu 23.10+.
+	if len(os.Args) > 1 && os.Args[1] == "bwrap-smoke" {
+		if err := runBwrapSmoke(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 		os.Exit(0)

--- a/cmd/blockyard/main_test.go
+++ b/cmd/blockyard/main_test.go
@@ -56,3 +56,24 @@ func TestRunProbeRejectsUnknownFlag(t *testing.T) {
 		t.Error("expected parse error for unknown flag")
 	}
 }
+
+// TestRunBwrapSmokeMissingBinary — bwrap path is "/nonexistent" so
+// exec fails. The function must surface the error (not swallow it);
+// the standalone apparmor-smoke CI job relies on a non-zero exit
+// for the negative assertion.
+func TestRunBwrapSmokeMissingBinary(t *testing.T) {
+	err := runBwrapSmoke([]string{"--bwrap", "/nonexistent/bwrap"})
+	if err == nil {
+		t.Error("expected error when bwrap binary is missing")
+	}
+}
+
+// TestRunBwrapSmokeUnknownFlag — fresh FlagSet enforces the
+// interface; unknown flag should surface as a parse error without
+// triggering an exec.
+func TestRunBwrapSmokeUnknownFlag(t *testing.T) {
+	err := runBwrapSmoke([]string{"--bogus"})
+	if err == nil {
+		t.Error("expected parse error for unknown flag")
+	}
+}

--- a/cmd/by/admin.go
+++ b/cmd/by/admin.go
@@ -5,12 +5,14 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/cynkra/blockyard/internal/apiclient"
+	"github.com/cynkra/blockyard/internal/apparmor"
 	"github.com/cynkra/blockyard/internal/seccomp"
 )
 
@@ -25,8 +27,82 @@ func adminCmd() *cobra.Command {
 		adminRollbackCmd(),
 		adminStatusCmd(),
 		adminInstallSeccompCmd(),
+		adminInstallApparmorCmd(),
 	)
 	return cmd
+}
+
+func adminInstallApparmorCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "install-apparmor",
+		Short: "Write the blockyard AppArmor profile to disk",
+		Long: `Write the embedded AppArmor profile to a target path so
+operators on AppArmor-enforcing hosts (Ubuntu 23.10+ by default) can
+load it with 'sudo apparmor_parser -r <target>'. The profile grants
+the 'userns' permission narrowly to blockyard and its subprocesses,
+enabling rootless bwrap to create its sandbox user namespace without
+disabling kernel.apparmor_restrict_unprivileged_userns host-wide.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			target, _ := cmd.Flags().GetString("target")
+			if target == "" {
+				target = apparmor.DefaultInstallPath
+			}
+			if err := installApparmorProfile(target); err != nil {
+				return err
+			}
+			fmt.Printf("Wrote AppArmor profile to %s\n", target)
+			if err := validateApparmorProfile(target); err != nil {
+				// Non-fatal: surface the parse error and guidance, but
+				// the file is already written — operators can inspect
+				// it or try a different AppArmor version.
+				fmt.Fprintf(os.Stderr,
+					"Warning: apparmor_parser rejected the profile: %v\n"+
+						"On AppArmor versions without the 'userns' rule, use "+
+						"sysctl kernel.apparmor_restrict_unprivileged_userns=0 "+
+						"as a host-wide fallback instead.\n", err)
+				return nil
+			}
+			fmt.Println("Load with: sudo apparmor_parser -r " + target)
+			return nil
+		},
+	}
+	cmd.Flags().String("target", "",
+		`output path (default: /etc/apparmor.d/blockyard)`)
+	return cmd
+}
+
+// installApparmorProfile writes the embedded profile to the target
+// path, creating parent directories as needed. Extracted for
+// testability.
+func installApparmorProfile(target string) error {
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil { //nolint:gosec // G301: non-secret config dir
+		return fmt.Errorf("create parent directory: %w", err)
+	}
+	if err := os.WriteFile(target, apparmor.Profile, 0o644); err != nil { //nolint:gosec // G306: non-secret config file
+		return fmt.Errorf("write profile: %w", err)
+	}
+	return nil
+}
+
+// validateApparmorProfile runs apparmor_parser in syntax-check mode
+// (-Q skip-kernel-load, -T skip-cache) to catch version-specific
+// parse failures at install time. This fully exercises the grammar
+// and binary-policy generation without touching the kernel or the
+// on-disk parser cache. Missing apparmor_parser is not an error: the
+// host simply isn't configured for AppArmor and the load step is a
+// no-op anyway.
+func validateApparmorProfile(target string) error {
+	parser, err := exec.LookPath("apparmor_parser")
+	if err != nil {
+		return nil
+	}
+	out, err := exec.Command(parser, "-QT", target).CombinedOutput() //nolint:gosec // G204: parser is from LookPath
+	if err != nil {
+		return fmt.Errorf("%s: %w (output: %s)",
+			parser, err, strings.TrimSpace(string(out)))
+	}
+	return nil
 }
 
 func adminInstallSeccompCmd() *cobra.Command {

--- a/cmd/by/admin_test.go
+++ b/cmd/by/admin_test.go
@@ -1,7 +1,13 @@
 package main
 
 import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
+
+	"github.com/cynkra/blockyard/internal/apparmor"
 )
 
 func TestAdminCmdStructure(t *testing.T) {
@@ -45,5 +51,42 @@ func TestAdminStatusCmdFlags(t *testing.T) {
 	cmd := adminStatusCmd()
 	if f := cmd.Flags().Lookup("json"); f == nil {
 		t.Error("missing --json flag")
+	}
+}
+
+// TestInstallApparmorProfileWritesEmbed guards the core install path:
+// the target file must contain exactly apparmor.Profile. A wrong-bytes
+// regression here would ship operators a profile that silently disagrees
+// with what got shipped in the release asset and the Docker image.
+// The helper also mkdir-p's the parent — missing parent is the most
+// likely real failure and kept here so the test covers it.
+func TestInstallApparmorProfileWritesEmbed(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "nested", "dir", "blockyard")
+	if err := installApparmorProfile(target); err != nil {
+		t.Fatalf("installApparmorProfile: %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if !bytes.Equal(got, apparmor.Profile) {
+		t.Errorf("installed %d bytes, want %d (embed mismatch)",
+			len(got), len(apparmor.Profile))
+	}
+}
+
+// TestValidateApparmorProfileMissingParserIsNoop — hosts without
+// apparmor_parser (Fedora, Arch, RHEL, minikube COS, etc.) must not
+// surface a failure from `install-apparmor`. The command still writes
+// the file; the validation step is a best-effort courtesy. Probe by
+// overriding PATH to a dir that doesn't contain apparmor_parser.
+func TestValidateApparmorProfileMissingParserIsNoop(t *testing.T) {
+	if _, err := exec.LookPath("apparmor_parser"); err == nil {
+		// On a host with the parser, LookPath will find it via PATH.
+		// Override PATH so our LookPath call misses.
+		t.Setenv("PATH", t.TempDir())
+	}
+	if err := validateApparmorProfile("/nonexistent/does-not-matter"); err != nil {
+		t.Errorf("expected nil on missing apparmor_parser, got %v", err)
 	}
 }

--- a/cmd/by/admin_test.go
+++ b/cmd/by/admin_test.go
@@ -17,7 +17,7 @@ func TestAdminCmdStructure(t *testing.T) {
 	for _, sub := range cmd.Commands() {
 		subs[sub.Use] = true
 	}
-	for _, want := range []string{"update", "rollback", "status"} {
+	for _, want := range []string{"update", "rollback", "status", "install-seccomp", "install-apparmor"} {
 		if !subs[want] {
 			t.Errorf("missing subcommand %q", want)
 		}

--- a/docker/server-everything.Dockerfile
+++ b/docker/server-everything.Dockerfile
@@ -106,6 +106,10 @@ COPY --from=builder /by-builder /usr/local/lib/blockyard/by-builder
 COPY blockyard.toml /etc/blockyard/blockyard.toml
 COPY --from=seccomp-compiler /blockyard-bwrap-seccomp.bpf /etc/blockyard/seccomp.bpf
 COPY internal/seccomp/blockyard-outer.json /etc/blockyard/seccomp.json
+# AppArmor profile — extracted by operators on Ubuntu 23.10+ hosts
+# to lift kernel.apparmor_restrict_unprivileged_userns for blockyard
+# without disabling the restriction host-wide. See phase 3-9.
+COPY internal/apparmor/blockyard /etc/blockyard/apparmor/blockyard
 
 # Extras hook. See server-process.Dockerfile for the full comment
 # and docs/content/docs/guides/process-backend-container.md for

--- a/docker/server-process.Dockerfile
+++ b/docker/server-process.Dockerfile
@@ -133,6 +133,10 @@ COPY --from=seccomp-compiler /blockyard-bwrap-seccomp.bpf /etc/blockyard/seccomp
 # --entrypoint cat IMAGE /etc/blockyard/seccomp.json` can extract
 # a copy.
 COPY internal/seccomp/blockyard-outer.json /etc/blockyard/seccomp.json
+# AppArmor profile — extracted by operators on Ubuntu 23.10+ hosts
+# to lift kernel.apparmor_restrict_unprivileged_userns for blockyard
+# without disabling the restriction host-wide. See phase 3-9.
+COPY internal/apparmor/blockyard /etc/blockyard/apparmor/blockyard
 
 # Extras hook. The default is a no-op; operators override by
 # bind-mounting their own script to /etc/blockyard/extras.sh to

--- a/docs/content/docs/guides/backend-security.md
+++ b/docs/content/docs/guides/backend-security.md
@@ -92,7 +92,7 @@ once on the process backend.
 
 Picking the process backend is the start of the work, not the end. The
 backend provides the per-worker sandbox; the operator provides the
-network and resource boundaries around it. Three controls matter.
+network and resource boundaries around it. Four controls matter.
 
 ### 1. Prefer containerized mode
 
@@ -111,64 +111,148 @@ for the image layout, the custom seccomp profile Docker needs to allow
 deployment runs with no `--privileged`, no `--cap-add SYS_ADMIN`, and
 no Docker socket mount.
 
-### 2. Install a destination-scoped egress firewall
+### 2. Load the AppArmor profile on Ubuntu 23.10+
 
-Workers share the host network stack, so the only way to keep them away
-from sensitive destinations is an egress firewall outside the sandbox.
+Ubuntu 23.10 and later ship `kernel.apparmor_restrict_unprivileged_userns=1`
+by default, which intercepts any non-root `unshare(CLONE_NEWUSER)` unless
+the caller runs under an AppArmor profile granting the `userns` permission.
+Without a profile, rootless `bwrap` cannot create its sandbox at all —
+this affects every isolation layer, not just layer 6.
+
+Blockyard ships a narrow AppArmor profile that grants `userns` to
+blockyard and its subprocesses only:
+
+```sh
+sudo by admin install-apparmor
+sudo apparmor_parser -r /etc/apparmor.d/blockyard
+```
+
+The profile does **not** confine blockyard itself — blockyard is the
+trusted component; the workers it spawns are confined by bwrap's
+capability drop, seccomp, and bind-mount restrictions, not by
+AppArmor. The alternative,
+`sysctl kernel.apparmor_restrict_unprivileged_userns=0`, disables the
+restriction host-wide for every unprivileged process; the profile is
+the narrow equivalent.
+
+Other supported distros (Debian, Fedora, RHEL, Arch, GKE's COS,
+minikube's default node OS) either don't ship this sysctl or have it
+disabled. No profile needed.
+
+### 3. Install a destination-scoped egress firewall
+
+Workers share the host network stack, so the only way to keep them
+away from sensitive destinations is an egress firewall outside the
+sandbox. Blockyard supports two independent iptables matches for
+worker traffic; which one fits depends on how blockyard is deployed:
+
+| Deployment | Mechanism | iptables match |
+|---|---|---|
+| Containerized root (default) | fork+setuid per worker | `-m owner --uid-owner` / `--gid-owner` |
+| Native non-root or rootless container, with cgroup-v2 delegation | workers subcgroup | `-m cgroup --path <cgroup>/workers` |
+| Rootless container without cgroup delegation, or restricted k8s pod | neither available | use the Docker backend |
+
+The two mechanisms are orthogonal. Root deployments can use either or
+both; non-root deployments get the cgroup path only. A `--userns` +
+`newuidmap` alternative for non-root was investigated and rejected
+during phase 3-9 drafting (blocked on an upstream bwrap bug — see
+[phase-3-9.md](https://github.com/cynkra/blockyard/blob/main/docs/design/v3/phase-3-9.md)).
+
+#### Root deployments: `-m owner`
+
 Blockyard assigns each running worker a unique host UID from
 `[process] worker_uid_range_start..worker_uid_range_end` (default
-60000–60999), and a shared `worker_gid` (default 65534, `nogroup`). This
-gives iptables an `owner` match to key rules on.
+60000–60999), and a shared `worker_gid` (default 65534, `nogroup`).
+The spawn path fork+setuid's each worker into its host UID before
+`exec(bwrap)`, so the worker's socket creator is visible to
+`-m owner`.
 
 ```sh
 # Allow blockyard's own egress to internal services.
 iptables -A OUTPUT -m owner --uid-owner blockyard -j ACCEPT
 
-# Block worker access to specific internal destinations. The worker GID
-# is the match; the destination address narrows the rule.
+# Block worker access to specific internal destinations. The worker
+# GID is the match; the destination address narrows the rule.
 iptables -A OUTPUT -m owner --gid-owner 65534 -d 169.254.169.254 -j REJECT
 iptables -A OUTPUT -m owner --gid-owner 65534 -d <redis-ip>      -j REJECT
-iptables -A OUTPUT -m owner --gid-owner 65534 -d <vault-ip>    -j REJECT
+iptables -A OUTPUT -m owner --gid-owner 65534 -d <vault-ip>      -j REJECT
 iptables -A OUTPUT -m owner --gid-owner 65534 -d <database-ip>   -j REJECT
 ```
 
-The rules are **destination-scoped, not blanket**. A rule like
-`iptables -A OUTPUT -m owner --gid-owner 65534 -j REJECT` would also cut
-off the open internet — but workers legitimately need to fetch data,
-call external APIs, and download models. Enumerate the specific internal
-endpoints you want to protect and scope each rule to them.
+The preflight check `bwrap_host_uid_mapping` confirms at startup that
+fork+setuid is wiring host-visible worker IDs. A non-root deployment
+cannot produce them and the check steers you to the cgroup path
+instead.
 
-Blockyard's preflight actively verifies these rules at startup by
-spawning a probe under the worker UID/GID and attempting TCP connections
-to the same internal endpoints. A reachable cloud metadata endpoint is
-reported as an error; reachable Redis, vault, or database endpoints
-are reported as warnings. The probe never tests the open internet —
-workers are expected to reach it.
+#### Any deployment with cgroup-v2 delegation: `-m cgroup --path`
 
-#### Host UID mapping is load-bearing
+When blockyard's cgroup-v2 subtree is delegated (systemd:
+`Delegate=yes`), blockyard moves each worker's PID tree into a
+`workers/` subcgroup and operators match that path with
+`iptables -m cgroup --path`. Works for both root and non-root
+blockyard; independent of the UID mapping entirely.
 
-`iptables -m owner` matches on the *host-side* UID/GID of the process
-creating the socket, not on the namespace-local UID inside the sandbox.
-For bubblewrap's `--uid`/`--gid` flags to produce host-visible IDs, one
-of these must hold:
+Prerequisites:
 
-- **Blockyard runs as root** (typical containerized mode, where
-  blockyard is PID 1 root inside a container). bwrap inherits root and
-  can set up any uid_map.
-- **bwrap is setuid root on the host** (`sudo chmod u+s /usr/bin/bwrap`
-  if the distro package doesn't ship it that way). Required for native
-  non-root deployments.
+- cgroup-v2 unified hierarchy (`grep cgroup2 /proc/mounts`).
+- `xt_cgroup` netfilter module loaded (`sudo modprobe xt_cgroup`;
+  add to `/etc/modules-load.d/` for persistence).
+- systemd service unit with `Delegate=yes`.
 
-If neither condition holds, workers still start — but they all run
-under blockyard's own host UID, and the operator's iptables rules
-silently match nothing. Blockyard's preflight catches this at startup
-by spawning a bwrap probe with a distinct sandbox UID and checking
-whether the child's host-side `/proc/<pid>/status` reports the
-requested UID. If it reports an error here, your iptables rules will
-not work until you add the setuid bit (or switch to running blockyard
-as root).
+The cgroup path depends on where systemd placed the service. The
+`cgroup_delegation` preflight reports the path at startup so you
+don't have to guess:
 
-### 3. Apply resource limits outside the sandbox
+```sh
+CGPATH=system.slice/blockyard.service/workers
+iptables -A OUTPUT -m cgroup --path "$CGPATH" -d 169.254.169.254 -j REJECT
+iptables -A OUTPUT -m cgroup --path "$CGPATH" -d <redis-ip>      -j REJECT
+iptables -A OUTPUT -m cgroup --path "$CGPATH" -d <vault-ip>      -j REJECT
+```
+
+See the native guide's
+[cgroup-v2 section](/docs/guides/process-backend/#per-worker-egress-via-cgroup-v2-delegation)
+for the full systemd unit template.
+
+#### Rules are destination-scoped, not blanket
+
+Whichever match you use, rules must name the internal endpoints you
+want blocked. A blanket `-m owner --gid-owner 65534 -j REJECT` or
+`-m cgroup --path <path> -j REJECT` also cuts off the open internet
+— and workers legitimately need it (CRAN, package downloads, model
+APIs, `httr` calls).
+
+#### Preflight catches the common footguns
+
+Blockyard runs several checks at startup so misconfiguration surfaces
+before the first user session hits it:
+
+- `worker_egress` — spawns a probe under the worker UID/GID (enrolled
+  into the workers cgroup when delegation is available) and attempts
+  TCP connections to cloud metadata, Redis, vault, and the database.
+  Reachable metadata → Error; reachable internal services → Warning.
+  The probe never tests the open internet.
+- `cloud_metadata` — TCP-connects from blockyard's own process to
+  `169.254.169.254:80`. Reachable → Error, because any host-network
+  process (including a compromised worker) can reach it too. Set
+  `[process] skip_metadata_check = true` only when blockyard itself
+  legitimately needs metadata access (e.g. using the VM's IAM role
+  for S3 storage); opting in accepts that a compromised worker can
+  read instance credentials.
+- `redis_auth` — sends an unauthenticated `PING` to the configured
+  Redis. `+PONG` → Error ("any host-network process can modify
+  session state"); `-NOAUTH` → OK. `rediss://` URLs short-circuit to
+  Info because a plain-TCP probe against a TLS server is not
+  meaningful.
+- `cgroup_delegation` — reports whether delegation is available, the
+  path workers are moved into, and whether the `xt_cgroup` module is
+  loaded (without it, `-m cgroup --path` rules fail to install).
+- `bwrap_host_uid_mapping` — on root deployments, confirms
+  fork+setuid produces host-visible worker IDs. On non-root
+  deployments, reports the gap as Info and points at cgroup
+  delegation or the Docker backend.
+
+### 4. Apply resource limits outside the sandbox
 
 The process backend does not enforce per-worker CPU, memory, or PID
 limits. Any limit must be applied at a layer above the sandbox:

--- a/docs/content/docs/guides/process-backend-container.md
+++ b/docs/content/docs/guides/process-backend-container.md
@@ -292,6 +292,44 @@ Blockyard's preflight runs the same worker-egress probe in
 containerized mode. Review the startup logs for warnings about
 reachable internal services.
 
+## Rootless containers
+
+Running blockyard as a non-root user inside a container (or on k8s
+with a `runAsNonRoot: true` pod spec) changes the egress isolation
+picture. The six-layer model from
+[backends.md](/docs/design/backends/#deployment-mode--isolation-layer-matrix)
+reduces to:
+
+- **Layers 1–5** (filesystem, PID, capabilities, seccomp, in-sandbox
+  UIDs) hold regardless.
+- **Layer 6 via `-m owner` is unavailable.** The fork+setuid path
+  that produces per-worker host kuids requires CAP_SETUID.
+- **Layer 6 via cgroup-v2 delegation is available only** if the
+  container runtime grants a delegated cgroup subtree *inside the
+  container* (not default). In that case, install
+  `iptables -m cgroup --path <cgpath>/workers` rules on the host or
+  in a network-admin sidecar.
+- **AppArmor on Ubuntu 23.10+:** extract and load the profile on the
+  host (not inside the container) so it applies to the container's
+  blockyard process:
+
+  ```bash
+  docker run --rm --entrypoint cat \
+      ghcr.io/cynkra/blockyard-process:${VERSION} \
+      /etc/blockyard/apparmor/blockyard | sudo tee /etc/apparmor.d/blockyard
+  sudo apparmor_parser -r /etc/apparmor.d/blockyard
+  ```
+
+  The profile attaches by path (`/usr/{bin,local/bin}/blockyard`), so
+  the container's blockyard binary needs to match one of those paths
+  for enforcement to apply.
+
+For deployments that need per-worker egress isolation but land on a
+rootless-container surface without cgroup delegation, the Docker
+backend is the supported path — it gives each worker its own
+network namespace and per-worker bridge, independent of host
+iptables mechanics.
+
 ## Rolling updates in containerized mode
 
 `by admin update` returns `501 Not Implemented` when blockyard runs

--- a/docs/content/docs/guides/process-backend.md
+++ b/docs/content/docs/guides/process-backend.md
@@ -68,24 +68,59 @@ echo "kernel.unprivileged_userns_clone = 1" | sudo tee /etc/sysctl.d/99-blockyar
 sudo sysctl --system
 ```
 
-### bwrap setuid requirement (Debian 12+/Ubuntu 24.04+)
+### Worker egress isolation options
 
-Debian 12 and Ubuntu 24.04 ship `bwrap` as a regular (non-setuid)
-binary. With user namespaces enabled, bwrap *can* still enter a new
-namespace, but `--uid`/`--gid` no longer produce a host-visible UID —
-and the egress firewall relies on host-side UIDs to work. Blockyard's
-preflight detects this and refuses to start; the fix is:
+Per-worker egress filtering (layer 6 in the isolation model — see
+[backends.md](/docs/design/backends/#deployment-mode--isolation-layer-matrix))
+depends on how blockyard is deployed:
+
+- **Root blockyard (containerized deployments):** the spawn path
+  fork+setuid's each worker into a distinct host UID before
+  `exec(bwrap)`, so operator `iptables -m owner --uid-owner` rules
+  match worker traffic.
+- **Non-root blockyard (native or unprivileged containers):** the
+  fork+setuid path fails without CAP_SETUID. Reach layer 6 via
+  [cgroup-v2 delegation](#per-worker-egress-via-cgroup-v2-delegation)
+  and `iptables -m cgroup --path` rules instead.
+- **k8s / restricted containers:** when neither path is available,
+  use the Docker backend for per-worker network namespaces.
+
+On Ubuntu 23.10+ the kernel's AppArmor restriction on unprivileged
+user namespaces
+(`kernel.apparmor_restrict_unprivileged_userns=1`) intercepts any
+non-root `unshare(CLONE_NEWUSER)` unless the caller runs under a
+profile granting `userns`. Blockyard ships a narrow profile — see
+[AppArmor profile](#apparmor-profile-ubuntu-2310).
+
+### AppArmor profile (Ubuntu 23.10+)
+
+Extract the shipped profile and load it:
 
 ```bash
-sudo chmod u+s /usr/bin/bwrap
+by admin install-apparmor
+sudo apparmor_parser -r /etc/apparmor.d/blockyard
 ```
 
-This is the same configuration Fedora/RHEL ship by default. The other
-option is to run blockyard as root, which inherits `CAP_SYS_ADMIN` and
-bypasses the restriction — the containerized image does this.
+Or, from a built image:
 
-See [Host UID mapping is load-bearing](/docs/guides/backend-security/#host-uid-mapping-is-load-bearing)
-in the backend security guide for the full explanation.
+```bash
+docker run --rm --entrypoint cat \
+    ghcr.io/cynkra/blockyard-process:${VERSION} \
+    /etc/blockyard/apparmor/blockyard | sudo tee /etc/apparmor.d/blockyard
+sudo apparmor_parser -r /etc/apparmor.d/blockyard
+```
+
+The profile grants the `userns` permission narrowly to blockyard and
+its subprocesses (`bwrap`, the `bwrap-exec` shim, the worker R
+interpreter) so rootless bwrap can create its sandbox user namespace.
+It does **not** confine blockyard itself — blockyard is the trusted
+component here; the workers it spawns are confined by bwrap's
+capability drop, seccomp, and bind-mount restrictions, not by
+AppArmor.
+
+The alternative, `sysctl kernel.apparmor_restrict_unprivileged_userns=0`,
+disables the restriction host-wide for every unprivileged process.
+The profile is the narrow equivalent.
 
 ## Install blockyard
 
@@ -193,7 +228,26 @@ Redis/vault/database endpoints are reported as warnings.
 > that makes `-m owner` actually match, see
 > [Backend Security](/docs/guides/backend-security/#2-install-a-destination-scoped-egress-firewall).
 
-## systemd unit
+## Per-worker egress via cgroup-v2 delegation
+
+For non-root deployments (and as an alternative to `-m owner` for
+root deployments), blockyard moves each worker's PID into a delegated
+cgroup-v2 subtree so operators can match worker traffic with
+`iptables -m cgroup --path <path>/workers`. The preflight check
+`cgroup_delegation` reports at startup whether this mechanism is
+available on the host.
+
+Prerequisites:
+
+- Host is on cgroup-v2 unified hierarchy
+  (`grep cgroup2 /proc/mounts` shows a line).
+- The `xt_cgroup` netfilter module is loaded
+  (`lsmod | grep xt_cgroup`, or `sudo modprobe xt_cgroup`; add to
+  `/etc/modules-load.d/` for persistence).
+- blockyard's cgroup is delegated. With systemd, add `Delegate=yes`
+  to the service unit (see below).
+
+### systemd unit with cgroup delegation
 
 `/etc/systemd/system/blockyard.service`:
 
@@ -210,6 +264,11 @@ Group=blockyard
 ExecStart=/usr/local/bin/blockyard --config /etc/blockyard/blockyard.toml
 Restart=on-failure
 RestartSec=5s
+
+# Delegate blockyard's cgroup-v2 subtree to the service, so blockyard
+# can create a `workers/` subcgroup and enroll each worker PID into
+# it. `iptables -m cgroup --path` rules then match worker traffic.
+Delegate=yes
 
 # Shared ceilings — per-worker cgroup limits are not enforced by the
 # process backend. These apply to the entire blockyard service unit
@@ -231,6 +290,25 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now blockyard
 sudo systemctl status blockyard
 ```
+
+With `Delegate=yes` in place, the startup preflight reports the
+delegated path in `cgroup_delegation`. Install iptables rules
+matching that path — typically
+`system.slice/blockyard.service/workers`:
+
+```bash
+CGPATH=system.slice/blockyard.service/workers
+sudo iptables -A OUTPUT -m cgroup --path "$CGPATH" \
+    -d 169.254.169.254 -j REJECT
+sudo iptables -A OUTPUT -m cgroup --path "$CGPATH" \
+    -d <redis-ip>   -j REJECT
+sudo iptables -A OUTPUT -m cgroup --path "$CGPATH" \
+    -d <openbao-ip> -j REJECT
+```
+
+If the `xt_cgroup` module is missing, the preflight escalates
+`cgroup_delegation` to WARNING and iptables will fail rule
+installation at runtime with "No chain/target/match by that name".
 
 ## Reverse proxy for rolling updates
 

--- a/docs/content/docs/reference/cli.md
+++ b/docs/content/docs/reference/cli.md
@@ -497,6 +497,35 @@ writes the profile to disk. No authentication required. See
 [Process Backend (Containerized)](/docs/guides/process-backend-container/)
 for the full extraction workflow.
 
+### `by admin install-apparmor`
+
+Write the embedded AppArmor profile to disk. Used on Ubuntu 23.10+
+hosts where `kernel.apparmor_restrict_unprivileged_userns=1` blocks
+rootless `unshare(CLONE_NEWUSER)` — the profile grants `userns`
+narrowly to blockyard and its subprocesses so rootless bwrap can
+create its sandbox user namespace without disabling the restriction
+host-wide. Profile is embedded in the `by` binary.
+
+```bash
+sudo by admin install-apparmor
+sudo by admin install-apparmor --target /etc/apparmor.d/blockyard
+sudo apparmor_parser -r /etc/apparmor.d/blockyard   # load it
+```
+
+| Flag              | Description                                            |
+| ----------------- | ------------------------------------------------------ |
+| `--target <path>` | Output path (default: `/etc/apparmor.d/blockyard`)    |
+
+If `apparmor_parser` is available on the host, the command runs a
+syntax check (`apparmor_parser -QT`) on the written file and prints
+the parser's error as a warning when the profile is rejected — useful
+on AppArmor versions without the `userns` rule. The file is still
+written on a failed check; operators can inspect it or fall back to
+`sysctl kernel.apparmor_restrict_unprivileged_userns=0`. This command
+does not talk to a running blockyard server. See
+[Process Backend (Native)](/docs/guides/process-backend/#apparmor-profile-ubuntu-2310)
+for the full setup.
+
 ---
 
 ## User administration

--- a/docs/content/docs/reference/config.md
+++ b/docs/content/docs/reference/config.md
@@ -120,6 +120,7 @@ port_range_end         = 10999
 worker_uid_range_start = 60000
 worker_uid_range_end   = 60999
 worker_gid             = 65534
+# skip_metadata_check    = false
 ```
 
 | Field | Type | Default | Required | Description |
@@ -132,6 +133,7 @@ worker_gid             = 65534
 | `worker_uid_range_start` | `integer` | `60000` | No | First host UID assigned to worker sandboxes (inclusive). Must be sized to at least the port range. |
 | `worker_uid_range_end` | `integer` | `60999` | No | Last host UID assigned to worker sandboxes (inclusive). |
 | `worker_gid` | `integer` | `65534` | No | Shared host GID for all workers. Used as the match key for iptables owner-match egress rules. |
+| `skip_metadata_check` | `boolean` | `false` | No | Suppress the `cloud_metadata` preflight check, which fails startup with Error when `169.254.169.254:80` is reachable from blockyard itself (and therefore from every worker). Set to `true` only when blockyard legitimately needs cloud metadata access (e.g., using the VM's IAM role for S3 storage); opting in accepts that a compromised worker can read instance credentials. |
 
 > [!WARNING]
 > Per-worker resource limits (`server.default_memory_limit`,

--- a/docs/design/backends.md
+++ b/docs/design/backends.md
@@ -264,6 +264,39 @@ containers.
 | Network | **Not provided.** Workers share the host (or container) network stack. | None |
 | Resources | **Not provided.** No per-worker CPU, memory, or PID limits. The outer container's cgroup limits act as a shared ceiling (containerized mode only). | Shared ceiling only |
 
+### Deployment mode × isolation layer matrix
+
+The six-layer isolation model breaks down differently per deployment
+mode. Layers 1–5 (bwrap-native) hold regardless of how blockyard is
+deployed; layer 6 (per-worker egress) depends on whether blockyard
+can produce distinct host identities for each worker, and on whether
+cgroup-v2 delegation is available.
+
+| Layer                         | Mechanism                             | Root | Rootless | k8s pod |
+|-------------------------------|---------------------------------------|------|----------|---------|
+| 1 Filesystem view             | bwrap --ro-bind + --tmpfs             | ✓    | ✓        | ✓       |
+| 2 PID namespace               | bwrap --unshare-pid                   | ✓    | ✓        | ✓       |
+| 3 Capabilities                | bwrap --cap-drop ALL                  | ✓    | ✓        | ✓       |
+| 4 Seccomp                     | bwrap --seccomp                       | ✓    | ✓        | ✓       |
+| 5 In-sandbox UIDs             | bwrap --uid                           | ✓    | ✓        | ✓       |
+| 6 Per-worker host kuid        | fork+setuid+exec(bwrap), --uid W      | ✓    | ✗        | n/a     |
+| 6' Per-worker cgroup (v2)     | cgroup subtree + iptables -m cgroup   | ✓    | ✓¹       | n/a²    |
+| 7 Per-worker network namespace| (not used; Docker backend instead)    | —    | —        | —       |
+
+¹ Requires cgroup-v2 delegation (systemd: `Delegate=yes`).
+² Restricted k8s pods lack CAP_NET_ADMIN for host-iptables-in-pod
+  rules and typically don't get a delegated cgroup subtree inside
+  the pod; use the Docker backend's per-worker network namespaces
+  for per-worker egress instead.
+
+Layer 6 and 6' are two independent paths to the same goal: matching
+worker-only egress at the kernel netfilter layer. Root deployments
+can use either or both. Non-root deployments get 6' only; the
+fork+setuid path needed for 6 fails without CAP_SETUID, and a
+`--userns + newuidmap` workaround was investigated during phase 3-9
+drafting and rejected (blocked on an upstream bwrap bug, see
+`phase-3-9.md`).
+
 ### What's intentionally not included
 
 **Network isolation** and **per-worker resource limits** are omitted from

--- a/docs/design/v3/phase-3-7.md
+++ b/docs/design/v3/phase-3-7.md
@@ -97,8 +97,10 @@ can be integrated later.
    `sandbox_uid caller_uid 1`, so the sandboxed child's kuid in
    init_userns equals blockyard's own UID and iptables owner-match
    does not fire. Verified at startup by
-   `checkBwrapHostUIDMapping` (see deliverable #8); native non-root
-   deployments get the newuidmap-based path in phase 3-9.
+   `checkBwrapHostUIDMapping` (see deliverable #8); non-root
+   deployments reach layer 6 via cgroup-v2 delegation in phase 3-9
+   (the `--userns + newuidmap` path was investigated and rejected on
+   an upstream bwrap bug — see `phase-3-9.md`).
 10. **`blockyard probe` subcommand** — small TCP-connectivity probe
     used by `checkWorkerEgress`. Dispatched early in `main.go` based
     on `os.Args[1]`. ~30 lines, no external tools required, runs
@@ -419,18 +421,21 @@ blockyard as root and letting the spawn path fork+setuid into
   without CAP_SETUID, so the spawn path skips the Credential. bwrap
   runs as the caller's UID and writes `uid caller_uid 1` — a
   non-identity map. Workers appear as blockyard's own UID in
-  init_userns and iptables owner-match rules do not fire, even if
-  bwrap is setuid-root (setuid-bwrap moves the bwrap monitor's UID
-  but does not change the uid_map format). **Phase 3-9** will add
-  a `--userns` + `newuidmap` path so native non-root deployments
-  can map to subuid ranges and regain identity-style kuid values in
-  init_userns.
+  init_userns and iptables owner-match rules do not fire. **Phase
+  3-9** delivers layer-6 egress filtering for this deployment mode
+  via cgroup-v2 delegation (operators install
+  `iptables -m cgroup --path <cgpath>/workers` rules instead of
+  `-m owner`). A `--userns + newuidmap` alternative was investigated
+  and rejected on an upstream bwrap bug; see `phase-3-9.md` for the
+  full discussion.
 
 `process.RunPreflight` catches non-root deployments explicitly via
 `checkBwrapHostUIDMapping` (step 7): when `os.Getuid() != 0` it
-returns `Error` and points operators at the remediation paths (run
-as root, use the Docker backend, wait for phase 3-9, or set
-`server.skip_preflight=true` to run without egress isolation).
+returns `Info` (not Error — the `-m owner` path is inherently
+inapplicable in non-root mode, not broken) and points operators at
+the remediation paths (run as root for `-m owner`, enable cgroup-v2
+delegation for `-m cgroup`, or use the Docker backend). Phase 3-9
+added `checkCgroupDelegation` alongside to report the cgroup path.
 
 The UID range must be at least as large as the port range, since each
 worker consumes one port and one UID. Defaults: 60000-60999 (1000
@@ -652,8 +657,13 @@ import (
 // affecting blockyard or blocking the open internet.
 //
 // For the host UID/GID to actually take effect (so iptables owner
-// match works), blockyard must run as root or bwrap must be setuid.
-// Verified at startup by checkBwrapHostUIDMapping.
+// match works), blockyard must run as root — the spawn path then
+// fork+setuid's the child to (uid, gid) before exec(bwrap). setuid
+// bwrap on the host is NOT a substitute: it moves the bwrap
+// monitor's UID but does not change the uid_map format, so the
+// sandboxed child's kuid stays at blockyard's UID (see phase-3-9.md
+// for why setuid-bwrap was retired as a documented mode). Verified
+// at startup by checkBwrapHostUIDMapping.
 func bwrapArgs(cfg *config.ProcessConfig, spec backend.WorkerSpec, port, uid, gid int) []string {
     args := []string{
         // Namespace isolation
@@ -1955,10 +1965,12 @@ func checkUserNamespaces() preflight.Result {
 // Uid/Gid lines do not match what we asked for, bwrap is running in
 // unprivileged-userns mode and the mapping is local-only.
 //
-// Remediation: run blockyard as root (typical containerized mode) or
-// install bwrap setuid on the host (`chmod u+s /usr/bin/bwrap`, or
-// equivalent via setcap). On Debian 12+/Ubuntu 24.04+ bwrap is no
-// longer shipped setuid by default.
+// Remediation: run blockyard as root (typical containerized mode)
+// for the `-m owner` path, reach for cgroup-v2 delegation
+// (`iptables -m cgroup --path`, delivered in phase 3-9), or use the
+// Docker backend for per-worker network namespaces. setuid bwrap
+// was investigated and retired — it does not change the uid_map
+// format and does not deliver per-worker host kuids.
 func checkBwrapHostUIDMapping(cfg *config.ProcessConfig) preflight.Result {
     const name = "bwrap_host_uid_mapping"
 
@@ -2065,9 +2077,10 @@ func checkBwrapHostUIDMapping(cfg *config.ProcessConfig) preflight.Result {
                 "bwrap --uid/--gid do not affect the host view of the child: "+
                     "requested uid=%d gid=%d, host /proc sees uid=%d gid=%d. "+
                     "The operator's iptables --uid-owner/--gid-owner rules will not match "+
-                    "worker traffic in this configuration. Either run blockyard as root "+
-                    "(typical containerized deployment) or install bwrap setuid on the host "+
-                    "(`sudo chmod u+s %s`). See backends.md for details.",
+                    "worker traffic in this configuration. Run blockyard as root "+
+                    "(typical containerized deployment) for the -m owner path, or use "+
+                    "phase-3-9's cgroup-v2 delegation (iptables -m cgroup --path). "+
+                    "setuid bwrap is NOT a substitute; see backends.md. (bwrap at %s.)",
                 probeUID, probeGID, realHostUID, realHostGID, cfg.BwrapPath,
             ),
             Category: "process",
@@ -2374,7 +2387,7 @@ mentioned above. This is acceptable for the use case: scale-to-zero
 deployments expect cold starts, and internal-only deployments have
 infrequent rolling updates.
 
-### Step 9: Phase 3-9 (zygote workers) forward compatibility
+### Step 9: v4 zygote-worker forward compatibility
 
 v4 adds multi-process containers and (conditionally) a zygote worker
 model, both of which need a control channel between blockyard and each
@@ -2841,14 +2854,16 @@ func TestWorkerResourceUsageLiveWorker(t *testing.T) {
 // build tag with the external integration tests above so a single
 // `-tags process_test` flag runs the whole suite.
 //
-// The test is strict per deployment mode: when bwrap can write a
-// host-effective uid_map (root caller or setuid bwrap) the check must
-// return OK; when bwrap can spawn but cannot write a foreign uid_map
-// (unprivileged caller without setuid) the check MUST return Error
-// and the message must name the requested vs observed UID. Both modes
-// are valid CI configurations and we want to catch regressions in
-// either one. See `detectBwrapMode` / `probeBwrapModeInternal` for
-// the three-way probe (unavailable / no-host-map / host-mapped).
+// The test is strict per deployment mode: when the spawn path can
+// produce a host-effective uid_map (root blockyard fork+setuids the
+// child before exec(bwrap)) the check must return OK; when bwrap
+// can spawn but cannot write a foreign uid_map (non-root blockyard)
+// the check must return Info. Phase 3-9 dropped the severity from
+// Error to Info on the non-root branch because the `-m owner`
+// mechanism is inherently inapplicable, not broken; non-root
+// deployments reach layer 6 via cgroup-v2 delegation instead.
+// Setuid bwrap is no longer a valid deployment mode — it doesn't
+// change the uid_map format.
 func TestCheckBwrapHostUIDMapping(t *testing.T) {
     mode := probeBwrapModeInternal(t)
     if mode == "unavailable" {
@@ -3010,11 +3025,13 @@ func TestCheckBwrapHostUIDMapping(t *testing.T) {
    the forked child setuid's into the worker UID/GID before
    `exec(bwrap)`. Non-root blockyard cannot do this (the kernel
    rejects setuid without CAP_SETUID); the
-   `checkBwrapHostUIDMapping` preflight check detects `os.Getuid() != 0`
-   and returns `Error` with a pointer to the phase-3-9
-   `--userns`+`newuidmap` follow-up, the Docker backend, or
-   `server.skip_preflight=true` for operators willing to run without
-   egress isolation.
+   `checkBwrapHostUIDMapping` preflight check detects
+   `os.Getuid() != 0` and returns `Info` pointing operators at
+   phase-3-9's cgroup-v2 delegation path (`iptables -m cgroup --path`
+   rules, orthogonal to UID mechanics) or the Docker backend as
+   alternatives. Severity was dropped from Error to Info in phase 3-9
+   because the `-m owner` mechanism is inherently inapplicable in
+   non-root mode, not broken.
 
    **Limitations.** This model gives worker-vs-host-services
    isolation but not cross-worker isolation: two workers in the same

--- a/docs/design/v3/phase-3-9.md
+++ b/docs/design/v3/phase-3-9.md
@@ -205,10 +205,13 @@ mechanics; phase 3-9 only adds around them.
     matches and the probe reaches targets that real workers cannot.
     The fix threads `*cgroupManager` through `RunPreflight` and
     `probeReachable`, and after `cmd.Start()` the probe path calls
-    `cgroups.Enroll(cmd.Process.Pid)` before `cmd.Wait()`. The
-    race between `Start` and `Enroll` is bounded by bwrap's
-    namespace/mount setup (~10–50 ms) vs. the enroll write (~1 ms),
-    so the probe's first `connect()` lands after enrollment. When
+    `cgroups.EnrollTree(cmd.Process.Pid)` before `cmd.Wait()`.
+    EnrollTree — not Enroll — because cgroup-v2 `cgroup.procs`
+    moves only the single tgid written; bwrap's inner sandbox
+    fork is a separate tgid that stays in its fork-time cgroup
+    unless we also move it. The walk polls
+    `/proc/<pid>/task/<tid>/children` briefly (≤100 ms, early
+    termination on stable rounds) to catch that descendant. When
     delegation is unavailable the probe behaves identically to the
     phase-3-7 code path (no-op enroll).
 
@@ -565,18 +568,62 @@ func ensureWorkersSubcgroup(cgRoot string) (string, error) {
 }
 ```
 
-Enrollment:
+Enrollment. `Enroll(pid)` is the single-PID primitive that writes
+`pid` to `<workers>/cgroup.procs`. Best-effort: a write failure logs
+a warning and continues, because the worker is functionally correct
+without the move — only the cgroup-based iptables rule fails to
+match.
+
+`EnrollTree(pid)` is the primary entry point for callers spawning
+bwrap. cgroup-v2's `cgroup.procs` moves only the single tgid
+written; descendants forked before the write stay in their
+fork-time cgroup. bwrap's spawn path does an inner fork to enter
+the pidns (the sandbox tgid is separate from `cmd.Process.Pid`), so
+enrolling only the monitor would leave the real worker outside
+`workers/` and outside operator iptables rules. `EnrollTree`
+enrolls the monitor, then polls
+`/proc/<pid>/task/<tid>/children` for descendants, enrolling each
+one; stops early after a few stable rounds, and bounds the total
+wait at ~100 ms.
 
 ```go
-// Enroll moves pid into the workers subcgroup. Best-effort: a
-// write failure logs a warning and continues. The spawn path must
-// tolerate cgroup move failures because the worker is functionally
-// correct without the move — only the cgroup-based iptables rule
-// fails to match, which is already the non-root layer-6 gap.
 func (m *cgroupManager) Enroll(pid int) {
-    if m.workersPath == "" {
+    if m == nil || m.workersPath == "" {
         return
     }
+    m.enroll(pid)
+}
+
+func (m *cgroupManager) EnrollTree(pid int) {
+    if m == nil || m.workersPath == "" {
+        return
+    }
+    m.enroll(pid)
+    seen := map[int]bool{pid: true}
+    deadline := time.Now().Add(enrollTreeMaxPoll)
+    stable := 0
+    for time.Now().Before(deadline) {
+        added := 0
+        for _, child := range collectDescendants(pid) {
+            if !seen[child] {
+                seen[child] = true
+                m.enroll(child)
+                added++
+            }
+        }
+        if added == 0 {
+            stable++
+            if stable >= enrollTreeStableRounds {
+                return
+            }
+        } else {
+            stable = 0
+        }
+        time.Sleep(enrollTreePollInterval)
+    }
+}
+
+func (m *cgroupManager) enroll(pid int) {
     procsFile := filepath.Join(m.workersPath, "cgroup.procs")
     if err := os.WriteFile(procsFile, []byte(strconv.Itoa(pid)), 0); err != nil {
         slog.Warn("process backend: cgroup enroll failed",
@@ -590,7 +637,7 @@ Spawn-path integration in `process.go`:
 ```go
 // Inside (*ProcessBackend).Spawn, just after cmd.Start succeeds
 // and before the wait goroutine is unblocked via proceed.
-b.cgroups.Enroll(cmd.Process.Pid)
+b.cgroups.EnrollTree(cmd.Process.Pid)
 ```
 
 The cgroup manager is a field on `ProcessBackend`, initialised in
@@ -784,7 +831,8 @@ func checkCgroupDelegation(b *ProcessBackend) preflight.Result {
             Message: "cgroup-v2 delegation unavailable. Per-worker egress " +
                 "isolation via `iptables -m cgroup --path` is not available " +
                 "on this host. Root deployments can use `iptables -m owner " +
-                "--gid-owner` rules on the per-worker host kuids instead. " +
+                "--gid-owner <worker_gid>` rules on the shared worker GID " +
+                "instead (see worker_egress for the default recipe). " +
                 "For non-root deployments wanting per-worker egress: enable " +
                 "cgroup delegation (systemd: Delegate=yes on the unit) or " +
                 "use the Docker backend.",
@@ -850,7 +898,7 @@ func probeReachable(
     if err := cmd.Start(); err != nil {
         return false
     }
-    cgroups.Enroll(cmd.Process.Pid) // no-op when delegation unavailable
+    cgroups.EnrollTree(cmd.Process.Pid) // no-op when delegation unavailable
     return cmd.Wait() == nil
 }
 ```
@@ -997,7 +1045,6 @@ guide) gains a "Per-worker egress on non-root hosts" section:
   ```
   [Service]
   Delegate=yes
-  DelegateSubgroup=workers
   User=blockyard
   ExecStart=/usr/bin/blockyard --config /etc/blockyard/blockyard.toml
   ```

--- a/internal/apparmor/apparmor.go
+++ b/internal/apparmor/apparmor.go
@@ -1,0 +1,24 @@
+// Package apparmor exposes the shipped AppArmor profile as an
+// embedded byte slice so the `by admin install-apparmor` CLI
+// subcommand can drop it on operators' disks without requiring
+// network access.
+//
+// The profile grants the `userns` permission narrowly to blockyard
+// and its subprocesses so rootless bwrap can create its sandbox user
+// namespace on hosts where `kernel.apparmor_restrict_unprivileged_userns=1`
+// (Ubuntu 23.10+ default). Operators load it with
+// `sudo apparmor_parser -r /etc/apparmor.d/blockyard`.
+package apparmor
+
+import _ "embed"
+
+// Profile is the shipped AppArmor profile source. Embedded as bytes
+// so the CLI can write it to disk; operators load it with
+// `apparmor_parser -r`.
+//
+//go:embed blockyard
+var Profile []byte
+
+// DefaultInstallPath is where `apparmor_parser -r` expects the
+// profile on Ubuntu/Debian systems.
+const DefaultInstallPath = "/etc/apparmor.d/blockyard"

--- a/internal/apparmor/apparmor_test.go
+++ b/internal/apparmor/apparmor_test.go
@@ -1,0 +1,39 @@
+package apparmor
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestEmbedMatchesFile guards against the embed drifting from the
+// on-disk profile source. Anyone editing blockyard can rebuild and
+// ship the new bytes; anyone editing this Go package without touching
+// the profile would break the shipped behaviour silently without this.
+func TestEmbedMatchesFile(t *testing.T) {
+	onDisk, err := os.ReadFile("blockyard")
+	if err != nil {
+		t.Fatalf("read profile source: %v", err)
+	}
+	if !bytes.Equal(onDisk, Profile) {
+		t.Error("embedded Profile does not match on-disk blockyard")
+	}
+}
+
+// TestProfileHasUsernsRule is the single load-bearing property of the
+// profile — without the `userns,` rule there's no point shipping it.
+func TestProfileHasUsernsRule(t *testing.T) {
+	if !strings.Contains(string(Profile), "userns,") {
+		t.Error("profile missing 'userns,' rule — the whole point of shipping this profile")
+	}
+}
+
+// TestDefaultInstallPath pins the conventional AppArmor profile
+// directory; changing it would break `sudo apparmor_parser -r <path>`
+// for every operator following the docs.
+func TestDefaultInstallPath(t *testing.T) {
+	if DefaultInstallPath != "/etc/apparmor.d/blockyard" {
+		t.Errorf("DefaultInstallPath = %q, want /etc/apparmor.d/blockyard", DefaultInstallPath)
+	}
+}

--- a/internal/apparmor/blockyard
+++ b/internal/apparmor/blockyard
@@ -1,0 +1,50 @@
+include <tunables/global>
+
+# Purpose: grant the `userns` permission to blockyard and its
+# subprocesses, narrowly, so rootless bwrap can create its sandbox
+# user namespace on hosts where kernel.apparmor_restrict_unprivileged_userns=1
+# (Ubuntu 23.10+ default). This profile does NOT confine blockyard
+# itself — the rules below are deliberately broad (all capabilities,
+# all paths, network, mount, ptrace) because blockyard is the trusted
+# component in this architecture; the workers it spawns are the
+# untrusted ones, and they are confined by bwrap's capability drop,
+# seccomp, and bind-mount restrictions, not by AppArmor. Site-specific
+# profiles wanting tighter confinement of blockyard should layer on
+# top of this one.
+
+profile blockyard /usr/{bin,local/bin}/blockyard
+         flags=(attach_disconnected, mediate_deleted) {
+
+    include <abstractions/base>
+
+    # The load-bearing grant this profile exists for.
+    userns,
+
+    # Core filesystem access — blockyard reads its config, writes
+    # bundle storage, opens /proc and /sys for preflight checks, etc.
+    # We intentionally grant broad filesystem access rather than
+    # enumerate paths: tightening is an operator-hardening exercise
+    # and belongs in a site-specific profile, not the default we
+    # ship.
+    / r,
+    /** mrwklix,
+
+    capability,
+    network,
+    signal,
+    dbus,
+    mount,
+    umount,
+    pivot_root,
+    ptrace,
+
+    # Subprocess transitions — blockyard exec's itself (bwrap-exec
+    # shim, probe subcommand), bwrap, and the worker R interpreter.
+    # `ix` inherits the profile; the bwrap child's internal
+    # `unshare(CLONE_NEWUSER)` then runs under this profile and sees
+    # the `userns` grant.
+    /usr/{bin,local/bin}/blockyard ix,
+    /usr/bin/bwrap ix,
+    /usr/{bin,local/bin}/R* ix,  # matches R, Rscript, Rdevel, …
+    /opt/R/*/bin/R* ix,          # rig-managed R installations
+}

--- a/internal/backend/docker/preflight.go
+++ b/internal/backend/docker/preflight.go
@@ -81,6 +81,7 @@ func runDockerChecks(ctx context.Context, d *DockerBackend, deps PreflightDeps) 
 		// still run non-container checks.
 		r.Add(checkHardLink(deps.StorePath))
 		r.Add(checkMetadataBlocking(d.serverID))
+		r.Add(preflight.CheckRedisAuth(d.fullCfg.Redis))
 		return r
 	}
 
@@ -93,6 +94,7 @@ func runDockerChecks(ctx context.Context, d *DockerBackend, deps PreflightDeps) 
 	r.Add(checkHardLink(deps.StorePath))
 	r.Add(checkMetadataBlocking(d.serverID))
 	r.Add(checkRedisOnServiceNetwork(ctx, d, deps))
+	r.Add(preflight.CheckRedisAuth(d.fullCfg.Redis))
 
 	return r
 }

--- a/internal/backend/process/bwrap.go
+++ b/internal/backend/process/bwrap.go
@@ -43,9 +43,12 @@ func bwrapSysProcAttr() *syscall.SysProcAttr {
 // worker traffic.
 //
 // Non-root blockyard: bwrap runs directly. Setuid to a foreign UID
-// fails without CAP_SETUID, and checkBwrapHostUIDMapping has already
-// flagged this deployment as unsupported for egress isolation until
-// phase 3-9 ships --userns + newuidmap.
+// fails without CAP_SETUID, so the `-m owner` path is inherently
+// inapplicable in this deployment mode. Phase 3-9 added cgroup-v2
+// delegation as an orthogonal layer-6 mechanism (see cgroup.go and
+// checkCgroupDelegation); a `--userns + newuidmap` path was
+// investigated and rejected on an upstream bwrap bug, see
+// docs/design/v3/phase-3-9.md.
 //
 // The bwrap path is always resolved to an absolute path via $PATH
 // before being passed on: the shim path uses syscall.Exec which does

--- a/internal/backend/process/cgroup.go
+++ b/internal/backend/process/cgroup.go
@@ -1,0 +1,114 @@
+package process
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// cgroupManager coordinates cgroup-v2 delegation for the process
+// backend. When the host delegates a v2 subtree to blockyard, the
+// manager creates `<delegated>/workers/` and exposes Enroll(pid) for
+// the spawn path to move each worker into it. When delegation is
+// unavailable, manager.workersPath is empty and Enroll is a no-op.
+type cgroupManager struct {
+	workersPath string // "" when delegation unavailable
+}
+
+// newCgroupManager probes for cgroup-v2 delegation and, on success,
+// creates the workers subcgroup. A detection error is non-fatal:
+// blockyard starts without delegation and the layer-6 preflight
+// reports the gap.
+func newCgroupManager() (*cgroupManager, error) {
+	root, err := detectCgroupDelegation()
+	if err != nil {
+		return &cgroupManager{}, err
+	}
+	if root == "" {
+		return &cgroupManager{}, nil
+	}
+	workers, err := ensureWorkersSubcgroup(root)
+	if err != nil {
+		return &cgroupManager{}, err
+	}
+	return &cgroupManager{workersPath: workers}, nil
+}
+
+// detectCgroupDelegation reads /proc/self/cgroup, verifies the
+// unified hierarchy, and tests write access on blockyard's own
+// cgroup by creating and removing a sentinel subdirectory. Returns
+// the absolute path to blockyard's cgroup on success, "" on any
+// detection or permission failure.
+//
+// The probe is deliberately conservative: any error (missing
+// cgroup-v2, cgroup namespaced away, read-only mount, permission
+// denied on mkdir) yields "" and the fallback path. Misreporting
+// delegation-available when it isn't would surface as noisy cgroup
+// write errors on every spawn, so we err on the side of reporting
+// unavailable.
+func detectCgroupDelegation() (string, error) {
+	data, err := os.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		return "", fmt.Errorf("read /proc/self/cgroup: %w", err)
+	}
+	text := strings.TrimRight(string(data), "\n")
+	// cgroup-v2 unified: single line "0::/<path>".
+	// cgroup-v1 hybrid: multiple lines with controllers; skip.
+	if strings.Contains(text, "\n") {
+		return "", nil
+	}
+	if !strings.HasPrefix(text, "0::") {
+		return "", nil
+	}
+	cgPath := strings.TrimPrefix(text, "0::")
+	fullPath := filepath.Join("/sys/fs/cgroup", cgPath)
+
+	probe := filepath.Join(fullPath, ".blockyard-delegation-probe")
+	if err := os.Mkdir(probe, 0o755); err != nil { //nolint:gosec // G301: transient test dir, cleaned below
+		if errors.Is(err, os.ErrPermission) {
+			return "", nil
+		}
+		return "", fmt.Errorf("probe subcgroup: %w", err)
+	}
+	_ = os.Remove(probe)
+	return fullPath, nil
+}
+
+// ensureWorkersSubcgroup creates <cgRoot>/workers/. Idempotent.
+//
+// Resource controllers (cpu/memory/io) are deliberately not enabled
+// on cgRoot's subtree_control. The iptables `-m cgroup --path` match
+// only reads cgroup.procs membership, and enabling controllers at
+// cgRoot would violate cgroup-v2's "no internal processes" rule
+// because blockyard itself is a process at cgRoot (both blockyard
+// and workers/ sit at the same level). Per-worker resource limits
+// stay out of scope — see phase 3-7 decision #6.
+func ensureWorkersSubcgroup(cgRoot string) (string, error) {
+	workers := filepath.Join(cgRoot, "workers")
+	if err := os.MkdirAll(workers, 0o755); err != nil { //nolint:gosec // G301: delegated cgroup dir
+		return "", fmt.Errorf("mkdir workers subcgroup: %w", err)
+	}
+	return workers, nil
+}
+
+// Enroll moves pid into the workers subcgroup. Best-effort: a write
+// failure logs a warning and continues. The spawn path must tolerate
+// cgroup move failures because the worker is functionally correct
+// without the move — only the cgroup-based iptables rule fails to
+// match, which is already the non-root layer-6 gap.
+//
+// Safe on a nil receiver and on a manager with no delegated subtree.
+func (m *cgroupManager) Enroll(pid int) {
+	if m == nil || m.workersPath == "" {
+		return
+	}
+	procsFile := filepath.Join(m.workersPath, "cgroup.procs")
+	if err := os.WriteFile(procsFile, []byte(strconv.Itoa(pid)), 0); err != nil {
+		slog.Warn("process backend: cgroup enroll failed",
+			"pid", pid, "path", m.workersPath, "err", err)
+	}
+}

--- a/internal/backend/process/cgroup.go
+++ b/internal/backend/process/cgroup.go
@@ -74,7 +74,7 @@ func detectCgroupDelegation() (string, error) {
 		}
 		return "", fmt.Errorf("probe subcgroup: %w", err)
 	}
-	_ = os.Remove(probe)
+	_ = os.Remove(probe) //nolint:gosec // G703: path rooted at /sys/fs/cgroup + cgroup from /proc/self/cgroup
 	return fullPath, nil
 }
 

--- a/internal/backend/process/cgroup.go
+++ b/internal/backend/process/cgroup.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // cgroupManager coordinates cgroup-v2 delegation for the process
@@ -101,14 +102,79 @@ func ensureWorkersSubcgroup(cgRoot string) (string, error) {
 // without the move — only the cgroup-based iptables rule fails to
 // match, which is already the non-root layer-6 gap.
 //
+// Single-PID: descendants forked before the write stay in their
+// original cgroup (cgroup-v2 cgroup.procs only moves the thread
+// group whose PID is written). Callers that need the whole worker
+// tree — which is every caller spawning bwrap — should use
+// EnrollTree instead.
+//
 // Safe on a nil receiver and on a manager with no delegated subtree.
 func (m *cgroupManager) Enroll(pid int) {
 	if m == nil || m.workersPath == "" {
 		return
 	}
+	m.enroll(pid)
+}
+
+// EnrollTree enrolls pid and any descendants into the workers
+// subcgroup. Required for the bwrap spawn path because cgroup-v2
+// cgroup.procs only moves the single tgid written — bwrap's inner
+// fork(s) produce descendant tgids that stay in their fork-time
+// cgroup unless we catch them explicitly. The walk polls
+// /proc/<pid>/task/<tid>/children briefly since bwrap's first fork
+// typically lands 10–50 ms after exec and may not be visible at
+// our first look.
+//
+// Polling stops early after enrollTreeStableRounds iterations
+// without new descendants (typical fast path: ~20 ms) and always
+// stops at enrollTreeMaxPoll (worst case: ~100 ms). Best-effort:
+// see Enroll for the severity rationale.
+//
+// Safe on a nil receiver and on a manager with no delegated subtree.
+func (m *cgroupManager) EnrollTree(pid int) {
+	if m == nil || m.workersPath == "" {
+		return
+	}
+	m.enroll(pid)
+
+	seen := map[int]bool{pid: true}
+	deadline := time.Now().Add(enrollTreeMaxPoll)
+	stable := 0
+	for time.Now().Before(deadline) {
+		added := 0
+		for _, child := range collectDescendants(pid) {
+			if !seen[child] {
+				seen[child] = true
+				m.enroll(child)
+				added++
+			}
+		}
+		if added == 0 {
+			stable++
+			if stable >= enrollTreeStableRounds {
+				return
+			}
+		} else {
+			stable = 0
+		}
+		time.Sleep(enrollTreePollInterval)
+	}
+}
+
+// enroll writes one PID to cgroup.procs. Shared primitive used by
+// both Enroll and EnrollTree.
+func (m *cgroupManager) enroll(pid int) {
 	procsFile := filepath.Join(m.workersPath, "cgroup.procs")
 	if err := os.WriteFile(procsFile, []byte(strconv.Itoa(pid)), 0); err != nil {
 		slog.Warn("process backend: cgroup enroll failed",
 			"pid", pid, "path", m.workersPath, "err", err)
 	}
 }
+
+// EnrollTree tuning. Exposed as package-level consts so tests can
+// temporarily shorten them.
+const (
+	enrollTreePollInterval  = 5 * time.Millisecond
+	enrollTreeMaxPoll       = 100 * time.Millisecond
+	enrollTreeStableRounds  = 3
+)

--- a/internal/backend/process/cgroup_test.go
+++ b/internal/backend/process/cgroup_test.go
@@ -20,6 +20,16 @@ func TestEnrollNoOpWhenUnavailable(t *testing.T) {
 	(&cgroupManager{workersPath: ""}).Enroll(1)
 }
 
+// TestEnrollTreeNoOpWhenUnavailable. Same contract as Enroll: nil
+// and empty-workersPath receivers must not panic. EnrollTree also
+// must not block spawn on nil-receiver paths; the body is guarded
+// before any polling loop.
+func TestEnrollTreeNoOpWhenUnavailable(t *testing.T) {
+	(*cgroupManager)(nil).EnrollTree(1)
+	(&cgroupManager{}).EnrollTree(1)
+	(&cgroupManager{workersPath: ""}).EnrollTree(1)
+}
+
 // TestEnsureWorkersSubcgroupIdempotent. Spawn paths and restarts
 // hit ensureWorkersSubcgroup repeatedly; a double-mkdir must not
 // fail. Uses a temp dir as a stand-in for the delegated cgroup

--- a/internal/backend/process/cgroup_test.go
+++ b/internal/backend/process/cgroup_test.go
@@ -1,0 +1,113 @@
+package process
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestEnrollNoOpWhenUnavailable. The cgroup manager must be safe to
+// call with an empty workersPath and on a nil receiver — the spawn
+// path invokes Enroll unconditionally and the cgroup-unavailable
+// case is the common one on many production hosts. A panic here
+// would break worker spawn; a log-and-continue keeps layer 6 as a
+// pure enhancement.
+func TestEnrollNoOpWhenUnavailable(t *testing.T) {
+	(*cgroupManager)(nil).Enroll(1)
+	(&cgroupManager{}).Enroll(1)
+	(&cgroupManager{workersPath: ""}).Enroll(1)
+}
+
+// TestEnsureWorkersSubcgroupIdempotent. Spawn paths and restarts
+// hit ensureWorkersSubcgroup repeatedly; a double-mkdir must not
+// fail. Uses a temp dir as a stand-in for the delegated cgroup
+// root — ensureWorkersSubcgroup does nothing cgroup-specific, it
+// just mkdir-p's the `workers/` subdirectory.
+func TestEnsureWorkersSubcgroupIdempotent(t *testing.T) {
+	root := t.TempDir()
+	w1, err := ensureWorkersSubcgroup(root)
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	w2, err := ensureWorkersSubcgroup(root)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if w1 != w2 {
+		t.Errorf("inconsistent path: %q vs %q", w1, w2)
+	}
+	if filepath.Base(w1) != "workers" {
+		t.Errorf("expected path ending in /workers, got %q", w1)
+	}
+	info, err := os.Stat(w1)
+	if err != nil {
+		t.Fatalf("stat %q: %v", w1, err)
+	}
+	if !info.IsDir() {
+		t.Errorf("%q is not a directory", w1)
+	}
+}
+
+// TestEnrollWritesPIDToProcsFile. The real kernel cgroup.procs file
+// ignores mode bits and magically moves PIDs; a regular file in a
+// temp directory accepts arbitrary writes. Good enough to confirm
+// we write to <workers>/cgroup.procs with the pid as ASCII. A
+// deeper test would need a real delegated cgroup and root, both
+// out of scope for unit tests.
+func TestEnrollWritesPIDToProcsFile(t *testing.T) {
+	workers := t.TempDir()
+	procs := filepath.Join(workers, "cgroup.procs")
+	if err := os.WriteFile(procs, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := &cgroupManager{workersPath: workers}
+	m.Enroll(4242)
+	got, err := os.ReadFile(procs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(got)) != strconv.Itoa(4242) {
+		t.Errorf("cgroup.procs content = %q, want %q", got, "4242")
+	}
+}
+
+// TestEnrollSurvivesMissingProcsFile. The write can fail in many
+// real-world ways — read-only mount, cgroup removed under us,
+// permissions. Enroll is best-effort: a failure logs a warning but
+// must not panic or cause the caller to fail.
+func TestEnrollSurvivesMissingProcsFile(t *testing.T) {
+	m := &cgroupManager{workersPath: "/nonexistent/cgroup/workers"}
+	m.Enroll(1234)
+}
+
+// TestDetectCgroupDelegationV1Hybrid. On cgroup-v1 hybrid hosts
+// /proc/self/cgroup has multiple lines (one per controller). The
+// detector must reject this and return "" so blockyard falls back
+// to flat-cgroup behaviour — v1 doesn't have a usable delegated
+// subtree for our purposes. Uses a writable file in place of
+// /proc/self/cgroup by stubbing out the reader? No — the function
+// reads /proc/self/cgroup directly. On a cgroup-v2-only test host
+// this test is trivially a no-op; we still want to exercise the
+// function end-to-end at least once.
+func TestDetectCgroupDelegationDoesNotPanic(t *testing.T) {
+	// Run on whatever the test host is. The function has three
+	// return paths: ("", nil) for "not delegated", (path, nil) for
+	// "delegated and writable", ("", err) for IO errors. Any of the
+	// three is acceptable; we're guarding against panics / type
+	// confusion / uncaught errors.
+	_, _ = detectCgroupDelegation()
+}
+
+// TestNewCgroupManagerSafe. Startup calls newCgroupManager()
+// unconditionally. A nil return would break the Spawn path (the
+// receiver would be nil and methods would be called), so the
+// contract is: always returns a non-nil *cgroupManager, even on
+// detection error.
+func TestNewCgroupManagerSafe(t *testing.T) {
+	m, _ := newCgroupManager()
+	if m == nil {
+		t.Error("newCgroupManager returned nil; must always return non-nil")
+	}
+}

--- a/internal/backend/process/preflight.go
+++ b/internal/backend/process/preflight.go
@@ -2,8 +2,10 @@ package process
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -24,7 +26,11 @@ import (
 // effective). If a prerequisite fails we still run the later checks
 // — they'll fail too, and emitting all failures at once is more
 // useful than bailing at the first.
-func RunPreflight(cfg *config.ProcessConfig, fullCfg *config.Config) *preflight.Report {
+//
+// cgroups is the optional cgroup-v2 delegation manager; nil is safe
+// and tests pass nil directly. The manager feeds checkCgroupDelegation
+// and the worker-egress probe's cgroup enrollment.
+func RunPreflight(cfg *config.ProcessConfig, fullCfg *config.Config, cgroups *cgroupManager) *preflight.Report {
 	r := &preflight.Report{RanAt: time.Now().UTC()}
 	r.Add(checkBwrap(cfg))
 	r.Add(checkRBinary(cfg))
@@ -34,7 +40,10 @@ func RunPreflight(cfg *config.ProcessConfig, fullCfg *config.Config) *preflight.
 	r.Add(checkResourceLimits(&fullCfg.Server))
 	r.Add(checkSeccompProfile(cfg))
 	r.Add(checkBwrapHostUIDMapping(cfg))
-	r.Add(checkWorkerEgress(cfg, fullCfg))
+	r.Add(checkCloudMetadataReachable(cfg))
+	r.Add(preflight.CheckRedisAuth(fullCfg.Redis))
+	r.Add(checkCgroupDelegation(cgroups))
+	r.Add(checkWorkerEgress(cfg, fullCfg, cgroups))
 	return r
 }
 
@@ -206,29 +215,28 @@ func checkUserNamespacesAt(path string) preflight.Result {
 // sandboxed grandchild through --info-fd.
 //
 // When blockyard is non-root, setuid(W) is rejected by the kernel, so
-// bwrap's uid_map still maps sandbox_uid to blockyard's own uid; the
-// sandboxed child appears as blockyard in init_userns and operator
-// iptables owner-match rules do not fire. The check fails explicitly
-// and points operators at the remediation paths: run as root
-// (containerized deployment), use the Docker backend, or wait for
-// phase 3-9's --userns + newuidmap path which will give native
-// non-root deployments identity uid_maps without needing root.
+// bwrap's uid_map still maps sandbox_uid to blockyard's own uid. The
+// `-m owner` mechanism is inherently inapplicable in that mode (not
+// broken), and blocking startup was wrong — operators reach layer 6
+// via cgroup-v2 delegation instead. The non-root branch reports Info
+// with the alternatives; checkCgroupDelegation reports the cgroup
+// path availability.
 func checkBwrapHostUIDMapping(cfg *config.ProcessConfig) preflight.Result {
 	const name = "bwrap_host_uid_mapping"
 
 	if os.Getuid() != 0 {
 		return preflight.Result{
 			Name:     name,
-			Severity: preflight.SeverityError,
-			Message: "worker egress isolation requires blockyard to run as root " +
-				"(typical containerized deployment); non-root blockyard cannot setuid " +
-				"the bwrap child, so the uid_map bwrap writes maps the sandbox UID to " +
-				"blockyard's own host UID and operator iptables --uid-owner/--gid-owner " +
-				"rules do not match worker traffic. Remediations: run blockyard as root, " +
-				"use the Docker backend for per-worker network namespaces, or wait for " +
-				"phase 3-9 which adds a --userns + newuidmap path for native non-root " +
-				"deployments. Set server.skip_preflight=true to run anyway with no egress " +
-				"isolation.",
+			Severity: preflight.SeverityInfo,
+			Message: "non-root blockyard cannot produce per-worker host kuids " +
+				"via fork+setuid, so `iptables -m owner --uid-owner` rules do " +
+				"not match worker traffic. This is inherent to non-root mode, " +
+				"not a failure: workers still have filesystem, PID, capability, " +
+				"seccomp, and in-sandbox UID isolation (layers 1-5), and " +
+				"per-worker egress (layer 6) is available via cgroup-v2 " +
+				"delegation — see cgroup_delegation. Alternatives: run as root " +
+				"(containerized deployment) for the `-m owner` path, or use the " +
+				"Docker backend for per-worker network namespaces.",
 			Category: "process",
 		}
 	}
@@ -442,7 +450,7 @@ func checkPortRange(cfg *config.ProcessConfig) preflight.Result {
 // The probe binary is the same blockyard binary, invoked with
 // `blockyard probe --tcp host:port`. It exits 0 on successful TCP
 // connect, 1 on failure. No external tools required.
-func checkWorkerEgress(cfg *config.ProcessConfig, fullCfg *config.Config) preflight.Result {
+func checkWorkerEgress(cfg *config.ProcessConfig, fullCfg *config.Config, cgroups *cgroupManager) preflight.Result {
 	type target struct {
 		name     string
 		addr     string
@@ -474,7 +482,7 @@ func checkWorkerEgress(cfg *config.ProcessConfig, fullCfg *config.Config) prefli
 	var reachable, blocked []string
 	var critical bool
 	for _, t := range targets {
-		if probeReachableFn(cfg, probeUID, probeGID, t.addr) {
+		if probeReachableFn(cfg, cgroups, probeUID, probeGID, t.addr) {
 			reachable = append(reachable, fmt.Sprintf("%s (%s)", t.name, t.addr))
 			if t.critical {
 				critical = true
@@ -522,7 +530,16 @@ var probeReachableFn = probeReachable
 // target TCP address is reachable. Returns false on probe error
 // (treated as "not reachable" — fail-safe for the warning, not for
 // security).
-func probeReachable(cfg *config.ProcessConfig, uid, gid int, target string) bool {
+//
+// cgroups (optional) enrolls the probe into the delegated
+// `workers/` subcgroup before its first connect(), so operator
+// `iptables -m cgroup --path workers` rules match the probe the
+// same way they'd match a real worker. Without this, the probe
+// stays in blockyard's own cgroup and would reach targets that
+// real workers cannot. A bounded race exists between cmd.Start
+// and the enroll write, but bwrap's namespace/mount setup
+// (~10–50 ms) swamps the enroll write (~1 ms).
+func probeReachable(cfg *config.ProcessConfig, cgroups *cgroupManager, uid, gid int, target string) bool {
 	self, err := os.Executable()
 	if err != nil {
 		return false
@@ -547,5 +564,129 @@ func probeReachable(cfg *config.ProcessConfig, uid, gid int, target string) bool
 	}
 	cmd := exec.Command(prog, argv...) //nolint:gosec // G204
 	cmd.SysProcAttr = bwrapSysProcAttr()
-	return cmd.Run() == nil // exit 0 = connect succeeded
+	if err := cmd.Start(); err != nil {
+		return false
+	}
+	cgroups.Enroll(cmd.Process.Pid) // no-op when delegation unavailable
+	return cmd.Wait() == nil        // exit 0 = connect succeeded
+}
+
+// checkCloudMetadataReachable attempts a TCP connect to the link-local
+// cloud metadata endpoint from blockyard's own process (not from
+// inside a bwrap sandbox). Workers share the host network in the
+// process backend, so if blockyard can reach the endpoint, so can
+// every worker — and a compromised worker can steal the VM's IAM
+// credentials. Reachable is treated as SeverityError prompting the
+// operator to install a host-wide block rule or use a token-scoped
+// metadata service (IMDSv2 / Workload Identity).
+//
+// Skipped when `[process] skip_metadata_check = true`. The escape
+// hatch is for the rare deployment where blockyard legitimately needs
+// metadata access (e.g. running on a VM whose IAM role is used by
+// blockyard itself for S3 storage); operators who opt in also accept
+// the worker-compromise implication.
+func checkCloudMetadataReachable(cfg *config.ProcessConfig) preflight.Result {
+	const name = "cloud_metadata"
+	if cfg.SkipMetadataCheck {
+		return preflight.Result{
+			Name:     name,
+			Severity: preflight.SeverityInfo,
+			Message:  "cloud metadata check skipped by [process] skip_metadata_check",
+			Category: "process",
+		}
+	}
+	d := net.Dialer{Timeout: 2 * time.Second}
+	conn, err := d.Dial("tcp", "169.254.169.254:80")
+	if err != nil {
+		return preflight.Result{
+			Name:     name,
+			Severity: preflight.SeverityOK,
+			Message:  "cloud metadata endpoint not reachable from blockyard",
+			Category: "process",
+		}
+	}
+	_ = conn.Close()
+	return preflight.Result{
+		Name:     name,
+		Severity: preflight.SeverityError,
+		Message: "cloud metadata endpoint (169.254.169.254) is reachable from blockyard. " +
+			"A compromised worker can steal this VM's IAM credentials. " +
+			"Block it with `iptables -A OUTPUT -d 169.254.169.254 -j REJECT`, " +
+			"enable IMDSv2 (EC2) or Workload Identity (GCP/AKS), " +
+			"or run on a VM without an attached instance role. " +
+			"Set [process] skip_metadata_check = true to suppress this check.",
+		Category: "process",
+	}
+}
+
+// checkCgroupDelegation reports whether cgroup-v2 delegation is
+// available and the workers subcgroup was created. When available,
+// also probes for the xt_cgroup netfilter module and escalates the
+// severity to Warning if missing — operators installing
+// `iptables -m cgroup --path` rules would otherwise hit a cryptic
+// "No chain/target/match by that name" at rule-install time.
+//
+// nil cgroups is treated as "unavailable" so tests that construct a
+// fake Preflight without initializing cgroup detection still get a
+// well-formed result.
+func checkCgroupDelegation(cgroups *cgroupManager) preflight.Result {
+	const name = "cgroup_delegation"
+	if cgroups == nil || cgroups.workersPath == "" {
+		return preflight.Result{
+			Name:     name,
+			Severity: preflight.SeverityInfo,
+			Message: "cgroup-v2 delegation unavailable. Per-worker egress " +
+				"isolation via `iptables -m cgroup --path` is not available " +
+				"on this host. Root deployments can use `iptables -m owner " +
+				"--gid-owner` rules on the per-worker host kuids instead. " +
+				"For non-root deployments wanting per-worker egress: enable " +
+				"cgroup delegation (systemd: Delegate=yes on the unit) or " +
+				"use the Docker backend.",
+			Category: "process",
+		}
+	}
+	xtCgroup := xtCgroupAvailable()
+	cgRoot := filepath.Dir(cgroups.workersPath)
+	cgMatchPath := strings.TrimPrefix(cgroups.workersPath, "/sys/fs/cgroup/")
+	msg := fmt.Sprintf(
+		"cgroup-v2 delegation available at %q; workers moved into %q. "+
+			"Install a rule like `iptables -A OUTPUT -m cgroup --path %s -d <service-ip> -j REJECT` "+
+			"to block worker access to internal services.",
+		cgRoot, cgroups.workersPath, cgMatchPath,
+	)
+	if !xtCgroup {
+		return preflight.Result{
+			Name:     name,
+			Severity: preflight.SeverityWarning,
+			Message: msg + " WARNING: the xt_cgroup netfilter module does " +
+				"not appear to be loaded (no match in /proc/net/ip_tables_matches); " +
+				"`iptables -m cgroup` rules will fail to install. Run " +
+				"`sudo modprobe xt_cgroup` or add it to /etc/modules-load.d/.",
+			Category: "process",
+		}
+	}
+	return preflight.Result{
+		Name:     name,
+		Severity: preflight.SeverityOK,
+		Message:  msg,
+		Category: "process",
+	}
+}
+
+// xtCgroupAvailable reports whether the xt_cgroup netfilter match is
+// loaded. /proc/net/ip_tables_matches lists builtin+loaded matches,
+// one per line. Returns true on any read error so we don't emit a
+// false warning on hosts where the file isn't accessible (rootless
+// containers, odd /proc mounts).
+func xtCgroupAvailable() bool {
+	data, err := os.ReadFile("/proc/net/ip_tables_matches")
+	if err != nil {
+		return true
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "cgroup" {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/backend/process/preflight.go
+++ b/internal/backend/process/preflight.go
@@ -531,14 +531,14 @@ var probeReachableFn = probeReachable
 // (treated as "not reachable" — fail-safe for the warning, not for
 // security).
 //
-// cgroups (optional) enrolls the probe into the delegated
+// cgroups (optional) enrolls the probe tree into the delegated
 // `workers/` subcgroup before its first connect(), so operator
 // `iptables -m cgroup --path workers` rules match the probe the
-// same way they'd match a real worker. Without this, the probe
-// stays in blockyard's own cgroup and would reach targets that
-// real workers cannot. A bounded race exists between cmd.Start
-// and the enroll write, but bwrap's namespace/mount setup
-// (~10–50 ms) swamps the enroll write (~1 ms).
+// same way they'd match a real worker. EnrollTree walks descendants
+// because bwrap's inner sandbox fork is a separate tgid from
+// cmd.Process.Pid; enrolling only the monitor would leave the
+// actual probe in blockyard's own cgroup. Without this, the probe
+// would reach targets that real workers cannot.
 func probeReachable(cfg *config.ProcessConfig, cgroups *cgroupManager, uid, gid int, target string) bool {
 	self, err := os.Executable()
 	if err != nil {
@@ -567,8 +567,8 @@ func probeReachable(cfg *config.ProcessConfig, cgroups *cgroupManager, uid, gid 
 	if err := cmd.Start(); err != nil {
 		return false
 	}
-	cgroups.Enroll(cmd.Process.Pid) // no-op when delegation unavailable
-	return cmd.Wait() == nil        // exit 0 = connect succeeded
+	cgroups.EnrollTree(cmd.Process.Pid) // no-op when delegation unavailable
+	return cmd.Wait() == nil            // exit 0 = connect succeeded
 }
 
 // checkCloudMetadataReachable attempts a TCP connect to the link-local
@@ -638,7 +638,8 @@ func checkCgroupDelegation(cgroups *cgroupManager) preflight.Result {
 			Message: "cgroup-v2 delegation unavailable. Per-worker egress " +
 				"isolation via `iptables -m cgroup --path` is not available " +
 				"on this host. Root deployments can use `iptables -m owner " +
-				"--gid-owner` rules on the per-worker host kuids instead. " +
+				"--gid-owner <worker_gid>` rules on the shared worker GID " +
+				"instead (see worker_egress for the default recipe). " +
 				"For non-root deployments wanting per-worker egress: enable " +
 				"cgroup delegation (systemd: Delegate=yes on the unit) or " +
 				"use the Docker backend.",

--- a/internal/backend/process/preflight_internal_test.go
+++ b/internal/backend/process/preflight_internal_test.go
@@ -20,15 +20,14 @@ import (
 // `package process`; the external integration tests stay in
 // `package process_test`.
 //
-// The check's contract since #305: host-effective worker UIDs require
-// blockyard to run as root so the spawn path can fork+setuid(W) before
-// exec(bwrap), giving bwrap caller_uid == sandbox_uid and therefore an
-// identity uid_map. When blockyard is root the check returns OK; when
-// it is non-root (CI's `setuid` and `unprivileged` matrices, Debian
-// 12+/Ubuntu 24.04+ native deployments) the check returns Error and
-// the message must reference the phase-3-9 newuidmap follow-up so
-// operators have a remediation path beyond "run as root or use
-// Docker".
+// The check's contract since #305 + phase 3-9: host-effective worker
+// UIDs require blockyard to run as root so the spawn path can
+// fork+setuid(W) before exec(bwrap). When blockyard is root the check
+// returns OK; when it is non-root (CI's `unprivileged` matrix, Debian
+// 12+/Ubuntu 24.04+ native deployments) the check returns Info
+// steering operators toward cgroup-v2 delegation or the Docker
+// backend — severity dropped from Error to Info in phase 3-9 because
+// the `-m owner` mechanism is inherently inapplicable, not broken.
 func TestCheckBwrapHostUIDMapping(t *testing.T) {
 	if _, err := exec.LookPath("bwrap"); err != nil {
 		t.Skip("bwrap not available")
@@ -49,15 +48,16 @@ func TestCheckBwrapHostUIDMapping(t *testing.T) {
 		}
 		return
 	}
-	if result.Severity != preflight.SeverityError {
-		t.Errorf("non-root blockyard: severity = %v, want Error; message: %s", result.Severity, result.Message)
+	if result.Severity != preflight.SeverityInfo {
+		t.Errorf("non-root blockyard: severity = %v, want Info; message: %s", result.Severity, result.Message)
 	}
-	// The message must flag the deployment-mode constraint and point
-	// at the phase-3-9 remediation, otherwise operators have no
-	// actionable next step beyond "Docker backend".
-	for _, want := range []string{"root", "phase 3-9"} {
+	// The message must name the non-root mode, point at cgroup-v2
+	// delegation, and mention the Docker backend as the alternative
+	// path — otherwise operators don't know which remediation fits
+	// their deployment.
+	for _, want := range []string{"non-root", "cgroup", "Docker backend"} {
 		if !strings.Contains(result.Message, want) {
-			t.Errorf("error message missing %q: %s", want, result.Message)
+			t.Errorf("info message missing %q: %s", want, result.Message)
 		}
 	}
 }

--- a/internal/backend/process/preflight_unit_test.go
+++ b/internal/backend/process/preflight_unit_test.go
@@ -10,6 +10,74 @@ import (
 	"github.com/cynkra/blockyard/internal/preflight"
 )
 
+// TestCheckCloudMetadataSkip — when the operator opts out via
+// skip_metadata_check, the result is Info and nothing dials.
+func TestCheckCloudMetadataSkip(t *testing.T) {
+	cfg := &config.ProcessConfig{SkipMetadataCheck: true}
+	res := checkCloudMetadataReachable(cfg)
+	if res.Severity != preflight.SeverityInfo {
+		t.Errorf("severity = %v, want Info", res.Severity)
+	}
+	if !strings.Contains(res.Message, "skipped") {
+		t.Errorf("message should say skipped: %q", res.Message)
+	}
+}
+
+// TestCheckCloudMetadataUnreachable — in normal CI / dev
+// environments 169.254.169.254 is not reachable. The check returns
+// OK. On an EC2/GCE instance this test would flip to Error, which
+// is the correct production behaviour but not observable here.
+// Skipping when unreachable would mask the real assertion; instead
+// we accept either OK or Error (any other severity is a bug).
+func TestCheckCloudMetadataNormalHostShape(t *testing.T) {
+	cfg := &config.ProcessConfig{}
+	res := checkCloudMetadataReachable(cfg)
+	switch res.Severity {
+	case preflight.SeverityOK, preflight.SeverityError:
+		// both are valid; depends on test host
+	default:
+		t.Errorf("unexpected severity %v: %q", res.Severity, res.Message)
+	}
+}
+
+// TestCheckCgroupDelegationNil — nil manager reports unavailable.
+// This is the common case on hosts without cgroup-v2 delegation
+// (the default on most non-systemd configurations).
+func TestCheckCgroupDelegationNil(t *testing.T) {
+	res := checkCgroupDelegation(nil)
+	if res.Severity != preflight.SeverityInfo {
+		t.Errorf("nil: severity = %v, want Info", res.Severity)
+	}
+	if !strings.Contains(res.Message, "unavailable") {
+		t.Errorf("message should say unavailable: %q", res.Message)
+	}
+}
+
+// TestCheckCgroupDelegationEmpty — manager with no workersPath is
+// equivalent to nil (detection found nothing to delegate).
+func TestCheckCgroupDelegationEmpty(t *testing.T) {
+	res := checkCgroupDelegation(&cgroupManager{})
+	if res.Severity != preflight.SeverityInfo {
+		t.Errorf("empty: severity = %v, want Info", res.Severity)
+	}
+}
+
+// TestCheckCgroupDelegationAvailableMentionsPath — when delegation
+// succeeds, the OK/Warning result must surface the cgroup path so
+// operators can plug it into an iptables rule without guessing.
+func TestCheckCgroupDelegationAvailableMentionsPath(t *testing.T) {
+	m := &cgroupManager{workersPath: "/sys/fs/cgroup/system.slice/blockyard.service/workers"}
+	res := checkCgroupDelegation(m)
+	// Result may be OK or Warning depending on xt_cgroup availability
+	// on the test host; the path must appear either way.
+	if !strings.Contains(res.Message, "blockyard.service/workers") {
+		t.Errorf("message should include the workers path: %q", res.Message)
+	}
+	if !strings.Contains(res.Message, "iptables -A OUTPUT -m cgroup --path") {
+		t.Errorf("message should include the iptables recipe: %q", res.Message)
+	}
+}
+
 // TestCheckBwrap covers all three branches of checkBwrap. /bin/echo
 // stands in for a working bwrap: it's on PATH and prints something
 // for --version; /bin/false is present but exits non-zero. The real
@@ -310,10 +378,10 @@ func TestCheckWorkerEgressAggregation(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			probeReachableFn = func(_ *config.ProcessConfig, _ int, _ int, target string) bool {
+			probeReachableFn = func(_ *config.ProcessConfig, _ *cgroupManager, _ int, _ int, target string) bool {
 				return tc.reachable[target]
 			}
-			res := checkWorkerEgress(cfg, fullCfg)
+			res := checkWorkerEgress(cfg, fullCfg, nil)
 			if res.Severity != tc.wantSeverity {
 				t.Errorf("severity = %v, want %v; message: %q",
 					res.Severity, tc.wantSeverity, res.Message)
@@ -334,11 +402,11 @@ func TestCheckWorkerEgressNoOptionalTargets(t *testing.T) {
 	t.Cleanup(func() { probeReachableFn = restore })
 
 	var targets []string
-	probeReachableFn = func(_ *config.ProcessConfig, _ int, _ int, target string) bool {
+	probeReachableFn = func(_ *config.ProcessConfig, _ *cgroupManager, _ int, _ int, target string) bool {
 		targets = append(targets, target)
 		return false // metadata blocked → OK
 	}
-	res := checkWorkerEgress(cfg, fullCfg)
+	res := checkWorkerEgress(cfg, fullCfg, nil)
 	if res.Severity != preflight.SeverityOK {
 		t.Errorf("severity = %v, want OK", res.Severity)
 	}
@@ -362,7 +430,7 @@ func TestRunPreflightPopulatesReport(t *testing.T) {
 		WorkerGID:      65534,
 	}
 	fullCfg := &config.Config{Process: cfg}
-	report := RunPreflight(cfg, fullCfg)
+	report := RunPreflight(cfg, fullCfg, nil)
 	if report == nil {
 		t.Fatal("expected non-nil report")
 		return // unreachable; satisfies staticcheck SA5011
@@ -376,6 +444,9 @@ func TestRunPreflightPopulatesReport(t *testing.T) {
 		"seccomp_profile":        false,
 		"bwrap_host_uid_mapping": false,
 		"worker_egress":          false,
+		"cloud_metadata":         false,
+		"redis_auth":             false,
+		"cgroup_delegation":      false,
 	}
 	for _, r := range report.Results {
 		if _, ok := expected[r.Name]; ok {

--- a/internal/backend/process/process.go
+++ b/internal/backend/process/process.go
@@ -443,12 +443,15 @@ func (b *ProcessBackend) Spawn(_ context.Context, spec backend.WorkerSpec) error
 		return fmt.Errorf("process backend: start bwrap: %w", err)
 	}
 
-	// Move the worker into the delegated cgroup-v2 `workers/` subtree
-	// so operator `iptables -m cgroup --path <path>/workers` rules
-	// match its egress traffic. No-op when delegation is unavailable.
-	// Must run before `proceed` so the Enroll write happens before
-	// the wait goroutine reaps the child.
-	b.cgroups.Enroll(cmd.Process.Pid)
+	// Move the worker tree into the delegated cgroup-v2 `workers/`
+	// subtree so operator `iptables -m cgroup --path <path>/workers`
+	// rules match its egress traffic. EnrollTree (not Enroll) because
+	// cgroup.procs only moves the single tgid written, and bwrap's
+	// inner sandbox fork produces a separate tgid we also need to
+	// catch. No-op when delegation is unavailable. Must run before
+	// `proceed` so the writes happen before the wait goroutine reaps
+	// the child.
+	b.cgroups.EnrollTree(cmd.Process.Pid)
 
 	// Ingest stdout and stderr concurrently into the shared log buffer.
 	// Two goroutines, not io.MultiReader — MultiReader reads sequentially

--- a/internal/backend/process/process.go
+++ b/internal/backend/process/process.go
@@ -443,6 +443,21 @@ func (b *ProcessBackend) Spawn(_ context.Context, spec backend.WorkerSpec) error
 		return fmt.Errorf("process backend: start bwrap: %w", err)
 	}
 
+	// Ingest stdout and stderr concurrently into the shared log buffer.
+	// Two goroutines, not io.MultiReader — MultiReader reads sequentially
+	// (stdout to EOF before stderr), which would suppress stderr for the
+	// entire worker lifetime.
+	//
+	// Must start BEFORE EnrollTree. EnrollTree can block for up to
+	// ~100 ms on delegated hosts while polling for descendants; a
+	// short-lived worker (e.g. R --version in the integration smoke
+	// test) can fork+print+exit during that window. If ingest hasn't
+	// started when cmd.Wait closes the pipes (via close(proceed)
+	// below), the buffered output is lost. Launching ingest first
+	// lets it drain the pipe concurrently with EnrollTree's poll.
+	go logs.ingest(stdout)
+	go logs.ingest(stderr)
+
 	// Move the worker tree into the delegated cgroup-v2 `workers/`
 	// subtree so operator `iptables -m cgroup --path <path>/workers`
 	// rules match its egress traffic. EnrollTree (not Enroll) because
@@ -452,13 +467,6 @@ func (b *ProcessBackend) Spawn(_ context.Context, spec backend.WorkerSpec) error
 	// `proceed` so the writes happen before the wait goroutine reaps
 	// the child.
 	b.cgroups.EnrollTree(cmd.Process.Pid)
-
-	// Ingest stdout and stderr concurrently into the shared log buffer.
-	// Two goroutines, not io.MultiReader — MultiReader reads sequentially
-	// (stdout to EOF before stderr), which would suppress stderr for the
-	// entire worker lifetime.
-	go logs.ingest(stdout)
-	go logs.ingest(stderr)
 
 	b.mu.Lock()
 	b.workers[spec.WorkerID] = &workerProc{

--- a/internal/backend/process/process.go
+++ b/internal/backend/process/process.go
@@ -53,6 +53,7 @@ type ProcessBackend struct {
 	fullCfg *config.Config        // held for Preflight() — needs Redis/vault/DB addrs and Server.DefaultMemoryLimit/CPULimit
 	ports   portAllocator
 	uids    uidAllocator
+	cgroups *cgroupManager // nil-safe; no-op when cgroup-v2 delegation is unavailable
 
 	mu      sync.Mutex
 	workers map[string]*workerProc // keyed by worker ID
@@ -88,11 +89,21 @@ func New(fullCfg *config.Config, rc *redisstate.Client, db *sqlx.DB) (*ProcessBa
 
 	ports, uids := selectAllocators(fullCfg, rc, db)
 
+	cgMgr, err := newCgroupManager()
+	if err != nil {
+		// Detection error is informational only — falls back to flat
+		// cgroup behaviour. checkCgroupDelegation reports the chosen
+		// mode at startup.
+		slog.Info("process backend: cgroup delegation probe failed, falling back to flat cgroup",
+			"err", err)
+	}
+
 	return &ProcessBackend{
 		cfg:     cfg,
 		fullCfg: fullCfg,
 		ports:   ports,
 		uids:    uids,
+		cgroups: cgMgr,
 		workers: make(map[string]*workerProc),
 	}, nil
 }
@@ -183,7 +194,7 @@ func ensureBundleMountPoint(path string) error {
 
 // Preflight implements backend.Backend by delegating to RunPreflight.
 func (b *ProcessBackend) Preflight(_ context.Context) (*preflight.Report, error) {
-	return RunPreflight(b.cfg, b.fullCfg), nil
+	return RunPreflight(b.cfg, b.fullCfg, b.cgroups), nil
 }
 
 func (b *ProcessBackend) CheckRVersion(version string) error {
@@ -431,6 +442,13 @@ func (b *ProcessBackend) Spawn(_ context.Context, spec backend.WorkerSpec) error
 		releaseSlots()
 		return fmt.Errorf("process backend: start bwrap: %w", err)
 	}
+
+	// Move the worker into the delegated cgroup-v2 `workers/` subtree
+	// so operator `iptables -m cgroup --path <path>/workers` rules
+	// match its egress traffic. No-op when delegation is unavailable.
+	// Must run before `proceed` so the Enroll write happens before
+	// the wait goroutine reaps the child.
+	b.cgroups.Enroll(cmd.Process.Pid)
 
 	// Ingest stdout and stderr concurrently into the shared log buffer.
 	// Two goroutines, not io.MultiReader — MultiReader reads sequentially

--- a/internal/backend/process/process_integration_test.go
+++ b/internal/backend/process/process_integration_test.go
@@ -30,8 +30,8 @@ import (
 //
 //   - bwrapHostMapped: blockyard is root, fork+setuid path works.
 //   - bwrapNoHostMap: blockyard is non-root; iptables owner-match
-//     isolation is unavailable until phase 3-9 lands --userns +
-//     newuidmap.
+//     is inherently inapplicable in this mode (layer 6 reached via
+//     cgroup-v2 delegation instead; see phase-3-9.md).
 //   - bwrapUnavailable: bwrap is missing or can't create a user
 //     namespace at all; every process_test integration test skips.
 type bwrapMode int
@@ -443,18 +443,25 @@ func TestCgroupEnrollment(t *testing.T) {
 	}
 	_ = addr
 
-	// Give the spawn path a moment to cmd.Start + Enroll.
-	time.Sleep(100 * time.Millisecond)
+	// EnrollTree synchronously polls for descendants up to ~100 ms,
+	// then Spawn returns. A small grace buffer here absorbs any
+	// remaining bwrap fork latency on a slow CI host.
+	time.Sleep(200 * time.Millisecond)
 
 	procs, err := os.ReadFile(filepath.Join(cgRoot, "workers", "cgroup.procs"))
 	if err != nil {
 		t.Fatalf("read workers/cgroup.procs: %v", err)
 	}
-	// cgroup.procs may be empty if enrollment failed silently —
-	// best-effort, warns-only. We still want to catch the common
-	// case where it succeeded.
+	pids := strings.Fields(string(procs))
 	fmt.Printf("workers/cgroup.procs:\n%s\n", string(procs))
-	if len(strings.TrimSpace(string(procs))) == 0 {
-		t.Log("cgroup enrollment produced no entries; likely delegation was not effective in this environment")
+	// Two PIDs is the phase-3-9 guarantee: the bwrap monitor (via
+	// the initial Enroll) plus at least one descendant (bwrap's
+	// inner sandbox tgid, via EnrollTree's descendant walk). A
+	// single entry would mean we're back to the pre-fix behaviour
+	// where the real worker's traffic isn't captured by
+	// `iptables -m cgroup --path workers` rules.
+	if len(pids) < 2 {
+		t.Errorf("workers/cgroup.procs has %d PIDs, want >= 2 (monitor + sandbox); contents: %q",
+			len(pids), string(procs))
 	}
 }

--- a/internal/backend/process/process_integration_test.go
+++ b/internal/backend/process/process_integration_test.go
@@ -4,6 +4,7 @@ package process_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -92,14 +93,18 @@ func requireBwrap(t *testing.T) {
 // root (fork+setuid before exec(bwrap) → identity uid_map). Non-root
 // blockyard keeps sandboxed children at blockyard's own kuid, which
 // makes any test that depends on per-worker host identity
-// meaningless.
+// meaningless. Phase 3-9 decided against a `--userns + newuidmap`
+// path for non-root (see docs/design/v3/phase-3-9.md, blocked on an
+// upstream bwrap bug) and delivers layer 6 via cgroup-v2 delegation
+// instead, so this constraint is permanent for tests that need
+// per-worker host UIDs.
 func requireHostUIDMapping(t *testing.T) {
 	t.Helper()
 	switch detectBwrapMode(t) {
 	case bwrapUnavailable:
 		t.Skip("bwrap not available")
 	case bwrapNoHostMap:
-		t.Skip("non-root blockyard: spawn path cannot produce identity uid_map until phase 3-9 ships --userns+newuidmap")
+		t.Skip("non-root blockyard: spawn path cannot produce identity uid_map (per-worker host kuid is root-only; non-root deployments reach layer 6 via cgroup-v2 delegation)")
 	}
 }
 
@@ -372,5 +377,84 @@ func TestRSmokeBoot(t *testing.T) {
 	joined := strings.Join(lines, "\n")
 	if !strings.Contains(joined, "R version") {
 		t.Errorf("expected output to contain 'R version', got:\n%s", joined)
+	}
+}
+
+// TestCgroupEnrollment exercises the phase-3-9 cgroup-v2 delegation
+// path end-to-end: spawn a worker, observe its PID in the
+// `workers/` subcgroup's cgroup.procs. Skipped unless detection
+// succeeded on the test host (the --privileged CI container may
+// not have a writable unified hierarchy, and native dev boxes that
+// aren't systemd-delegated won't either).
+func TestCgroupEnrollment(t *testing.T) {
+	requireHostUIDMapping(t)
+
+	// Probe /proc/self/cgroup for a v2 unified layout with write
+	// access. Same logic as detectCgroupDelegation but duplicated
+	// here because the integration test lives outside the package.
+	data, err := os.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		t.Skipf("read /proc/self/cgroup: %v", err)
+	}
+	text := strings.TrimRight(string(data), "\n")
+	if strings.Contains(text, "\n") || !strings.HasPrefix(text, "0::") {
+		t.Skip("not a cgroup-v2 unified hierarchy; skipping enrollment test")
+	}
+	cgRoot := filepath.Join("/sys/fs/cgroup", strings.TrimPrefix(text, "0::"))
+	probe := filepath.Join(cgRoot, ".blockyard-integration-probe")
+	if err := os.Mkdir(probe, 0o755); err != nil {
+		t.Skipf("cgroup subtree not writable (delegation unavailable): %v", err)
+	}
+	_ = os.Remove(probe)
+
+	cfg := &config.Config{
+		Server:  config.ServerConfig{Backend: "process"},
+		Storage: config.StorageConfig{BundleWorkerPath: "/tmp/app"},
+		Process: &config.ProcessConfig{
+			BwrapPath:      "bwrap",
+			RPath:          "/bin/sleep",
+			PortRangeStart: 19500,
+			PortRangeEnd:   19599,
+			WorkerUIDStart: 69500,
+			WorkerUIDEnd:   69599,
+			WorkerGID:      65534,
+		},
+	}
+	be, err := process.New(cfg, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	spec := backend.WorkerSpec{
+		WorkerID:    "cgroup-enroll",
+		BundlePath:  workerAccessibleTempDir(t),
+		WorkerMount: "/tmp/app",
+		Cmd:         []string{"/bin/sleep", "30"},
+	}
+	if err := be.Spawn(ctx, spec); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	defer be.Stop(ctx, spec.WorkerID)
+
+	addr, err := be.Addr(ctx, spec.WorkerID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = addr
+
+	// Give the spawn path a moment to cmd.Start + Enroll.
+	time.Sleep(100 * time.Millisecond)
+
+	procs, err := os.ReadFile(filepath.Join(cgRoot, "workers", "cgroup.procs"))
+	if err != nil {
+		t.Fatalf("read workers/cgroup.procs: %v", err)
+	}
+	// cgroup.procs may be empty if enrollment failed silently —
+	// best-effort, warns-only. We still want to catch the common
+	// case where it succeeded.
+	fmt.Printf("workers/cgroup.procs:\n%s\n", string(procs))
+	if len(strings.TrimSpace(string(procs))) == 0 {
+		t.Log("cgroup enrollment produced no entries; likely delegation was not effective in this environment")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,6 +114,15 @@ type ProcessConfig struct {
 	WorkerUIDStart int    `toml:"worker_uid_range_start"` // first host UID for workers (inclusive)
 	WorkerUIDEnd   int    `toml:"worker_uid_range_end"`   // last host UID for workers (inclusive)
 	WorkerGID      int    `toml:"worker_gid"`             // shared host GID for all workers (used by egress firewall rules)
+
+	// SkipMetadataCheck suppresses the cloud-metadata reachability
+	// preflight check. Default false: the check is meant to flag the
+	// "workers can reach 169.254.169.254 and steal IAM creds" footgun
+	// on VMs with an attached instance role. Set true only when
+	// blockyard itself legitimately needs metadata access (e.g.
+	// IRSA-style auth against S3); operators who opt in also accept
+	// the worker-compromise implication.
+	SkipMetadataCheck bool `toml:"skip_metadata_check"`
 }
 
 type DockerConfig struct {

--- a/internal/preflight/redis_auth.go
+++ b/internal/preflight/redis_auth.go
@@ -1,0 +1,103 @@
+package preflight
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/cynkra/blockyard/internal/config"
+)
+
+// CheckRedisAuth dials the configured Redis URL without AUTH, sends
+// a PING, and classifies the reply. Applies across backends —
+// unauth'd Redis is a footgun whether workers live in a Docker
+// network namespace, a bwrap sandbox, or a host-network process.
+//
+// Severities:
+//   - SeverityOK: Redis replies `-NOAUTH` (authentication required).
+//   - SeverityError: Redis replies `+PONG` (auth not required).
+//   - SeverityInfo: TLS Redis (`rediss://` — plain-TCP probe skipped),
+//     Redis not reachable, generic unexpected reply. Surfaced as Info
+//     so the operator investigates rather than getting a silent OK.
+//
+// Called explicitly from both backends' RunPreflight so both coverage
+// modes benefit from the same check. Two call sites are small enough
+// not to warrant a registry abstraction; revisit if a third backend
+// ships.
+func CheckRedisAuth(cfg *config.RedisConfig) Result {
+	const name = "redis_auth"
+	if cfg == nil || cfg.URL == "" {
+		return Result{
+			Name: name, Severity: SeverityOK,
+			Message: "Redis not configured", Category: "redis",
+		}
+	}
+	if strings.HasPrefix(strings.ToLower(cfg.URL), "rediss://") {
+		// Plain-TCP probe against a TLS-only server would write
+		// garbage at the TLS handshake layer and get no useful reply.
+		// Skip rather than report spurious "unexpected reply".
+		return Result{
+			Name: name, Severity: SeverityInfo,
+			Message:  "TLS Redis (rediss://); plain-TCP auth probe skipped",
+			Category: "redis",
+		}
+	}
+	hp := TCPAddrFromRedisURL(cfg.URL)
+	if hp == "" {
+		return Result{
+			Name: name, Severity: SeverityInfo,
+			Message:  "Redis URL not parseable for auth probe",
+			Category: "redis",
+		}
+	}
+	d := net.Dialer{Timeout: 2 * time.Second}
+	conn, err := d.Dial("tcp", hp)
+	if err != nil {
+		return Result{
+			Name: name, Severity: SeverityInfo,
+			Message:  "Redis not reachable from blockyard for auth probe",
+			Category: "redis",
+		}
+	}
+	defer conn.Close()
+	if _, err := conn.Write([]byte("*1\r\n$4\r\nPING\r\n")); err != nil {
+		return Result{
+			Name: name, Severity: SeverityInfo,
+			Message:  fmt.Sprintf("Redis PING failed: %v", err),
+			Category: "redis",
+		}
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(1 * time.Second))
+	buf := make([]byte, 128)
+	n, _ := conn.Read(buf)
+	reply := string(buf[:n])
+	switch {
+	case strings.HasPrefix(reply, "+PONG"):
+		return Result{
+			Name: name, Severity: SeverityError,
+			Message: "Redis accepts commands without authentication. " +
+				"Any host-network process (including compromised workers) can " +
+				"read/modify session state, flush the registry, or DoS the service. " +
+				"Configure `requirepass` in redis.conf or enable ACLs.",
+			Category: "redis",
+		}
+	case strings.HasPrefix(reply, "-NOAUTH"):
+		return Result{
+			Name: name, Severity: SeverityOK,
+			Message: "Redis requires authentication", Category: "redis",
+		}
+	default:
+		// Generic `-ERR ...` (MAXCLIENTS, protocol errors), an empty
+		// reply, or surprise `-WRONGPASS` / `-NOPERM` from ACL servers
+		// that shouldn't fire for an unauthenticated PING. Surface as
+		// Info so the operator investigates rather than getting a
+		// false OK.
+		return Result{
+			Name: name, Severity: SeverityInfo,
+			Message: fmt.Sprintf(
+				"Redis responded with unexpected reply to unauthenticated PING: %q", reply),
+			Category: "redis",
+		}
+	}
+}

--- a/internal/preflight/redis_auth_test.go
+++ b/internal/preflight/redis_auth_test.go
@@ -1,0 +1,152 @@
+package preflight
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/cynkra/blockyard/internal/config"
+)
+
+// TestCheckRedisAuthEmptyConfig — no Redis configured at all; check
+// should short-circuit OK without dialing anywhere.
+func TestCheckRedisAuthEmptyConfig(t *testing.T) {
+	res := CheckRedisAuth(nil)
+	if res.Severity != SeverityOK {
+		t.Errorf("nil config: severity = %v, want OK", res.Severity)
+	}
+	res = CheckRedisAuth(&config.RedisConfig{URL: ""})
+	if res.Severity != SeverityOK {
+		t.Errorf("empty URL: severity = %v, want OK", res.Severity)
+	}
+}
+
+// TestCheckRedisAuthTLS — rediss:// short-circuits to Info without
+// dialing. A plain-TCP probe against a TLS server would write
+// garbage at the handshake layer and get an unhelpful reply.
+func TestCheckRedisAuthTLS(t *testing.T) {
+	res := CheckRedisAuth(&config.RedisConfig{URL: "rediss://redis.example:6379"})
+	if res.Severity != SeverityInfo {
+		t.Errorf("rediss: severity = %v, want Info", res.Severity)
+	}
+	if !strings.Contains(res.Message, "TLS") {
+		t.Errorf("message should mention TLS: %q", res.Message)
+	}
+}
+
+// TestCheckRedisAuthParseFail — malformed URL reports Info, not a
+// spurious OK that would mask a real config mistake.
+func TestCheckRedisAuthParseFail(t *testing.T) {
+	res := CheckRedisAuth(&config.RedisConfig{URL: "http://oops:6379"})
+	// http:// is accepted by url.Parse but TCPAddrFromRedisURL just
+	// extracts host:port; this test confirms the path is safe.
+	if res.Severity != SeverityError && res.Severity != SeverityInfo {
+		// Actually this will dial http://oops:6379 — which fails DNS.
+		// Depending on how fast DNS resolves, we might see Info
+		// ("not reachable"). Any severity is acceptable except OK
+		// (we never reached a real PONG).
+	}
+	if res.Severity == SeverityOK {
+		t.Errorf("malformed URL should not produce OK; got: %q", res.Message)
+	}
+}
+
+// TestCheckRedisAuthUnreachable — unreachable target reports Info
+// (reachability is surfaced by checkRedisOnServiceNetwork, not this
+// check).
+func TestCheckRedisAuthUnreachable(t *testing.T) {
+	// 127.0.0.1:1 is privileged and typically unused; dial fails fast.
+	res := CheckRedisAuth(&config.RedisConfig{URL: "redis://127.0.0.1:1"})
+	if res.Severity != SeverityInfo {
+		t.Errorf("unreachable: severity = %v, want Info; message: %q",
+			res.Severity, res.Message)
+	}
+	if !strings.Contains(res.Message, "not reachable") {
+		t.Errorf("message should say not reachable: %q", res.Message)
+	}
+}
+
+// fakeRedis is a minimal TCP server that returns a fixed reply to
+// the first RESP PING it reads. Each test wires up its own server,
+// points CheckRedisAuth at it, and asserts the classification.
+type fakeRedis struct {
+	ln    net.Listener
+	reply []byte
+}
+
+func newFakeRedis(t *testing.T, reply string) *fakeRedis {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fr := &fakeRedis{ln: ln, reply: []byte(reply)}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				// Drain whatever the client sends; don't care what it is.
+				_, _ = io.CopyN(io.Discard, c, int64(len("*1\r\n$4\r\nPING\r\n")))
+				_, _ = c.Write([]byte(reply))
+			}(conn)
+		}
+	}()
+	t.Cleanup(func() { _ = ln.Close() })
+	return fr
+}
+
+func (fr *fakeRedis) url() string {
+	_, port, _ := net.SplitHostPort(fr.ln.Addr().String())
+	return fmt.Sprintf("redis://127.0.0.1:%s", port)
+}
+
+func TestCheckRedisAuthPong(t *testing.T) {
+	fr := newFakeRedis(t, "+PONG\r\n")
+	res := CheckRedisAuth(&config.RedisConfig{URL: fr.url()})
+	if res.Severity != SeverityError {
+		t.Errorf("+PONG: severity = %v, want Error; message: %q",
+			res.Severity, res.Message)
+	}
+	if !strings.Contains(res.Message, "without authentication") {
+		t.Errorf("Error message should name the footgun: %q", res.Message)
+	}
+}
+
+func TestCheckRedisAuthNoauth(t *testing.T) {
+	fr := newFakeRedis(t, "-NOAUTH Authentication required.\r\n")
+	res := CheckRedisAuth(&config.RedisConfig{URL: fr.url()})
+	if res.Severity != SeverityOK {
+		t.Errorf("-NOAUTH: severity = %v, want OK; message: %q",
+			res.Severity, res.Message)
+	}
+}
+
+func TestCheckRedisAuthGenericError(t *testing.T) {
+	fr := newFakeRedis(t, "-ERR max number of clients reached\r\n")
+	res := CheckRedisAuth(&config.RedisConfig{URL: fr.url()})
+	if res.Severity != SeverityInfo {
+		t.Errorf("-ERR: severity = %v, want Info; message: %q",
+			res.Severity, res.Message)
+	}
+	if !strings.Contains(res.Message, "unexpected reply") {
+		t.Errorf("Info message should say unexpected reply: %q", res.Message)
+	}
+}
+
+// TestCheckRedisAuthEmptyReply — a server that closes without
+// responding (e.g. a TLS-only server rejecting plain-TCP bytes).
+// Surfaced as Info with the raw reply visible to the operator.
+func TestCheckRedisAuthEmptyReply(t *testing.T) {
+	fr := newFakeRedis(t, "")
+	res := CheckRedisAuth(&config.RedisConfig{URL: fr.url()})
+	if res.Severity != SeverityInfo {
+		t.Errorf("empty reply: severity = %v, want Info; message: %q",
+			res.Severity, res.Message)
+	}
+}

--- a/internal/preflight/redis_auth_test.go
+++ b/internal/preflight/redis_auth_test.go
@@ -36,20 +36,14 @@ func TestCheckRedisAuthTLS(t *testing.T) {
 	}
 }
 
-// TestCheckRedisAuthParseFail — malformed URL reports Info, not a
-// spurious OK that would mask a real config mistake.
+// TestCheckRedisAuthParseFail — a URL that TCPAddrFromRedisURL
+// cannot extract a host:port from must report Info, not a spurious
+// OK that would mask a real config mistake. Uses a raw control
+// character, which url.Parse rejects outright.
 func TestCheckRedisAuthParseFail(t *testing.T) {
-	res := CheckRedisAuth(&config.RedisConfig{URL: "http://oops:6379"})
-	// http:// is accepted by url.Parse but TCPAddrFromRedisURL just
-	// extracts host:port; this test confirms the path is safe.
-	if res.Severity != SeverityError && res.Severity != SeverityInfo {
-		// Actually this will dial http://oops:6379 — which fails DNS.
-		// Depending on how fast DNS resolves, we might see Info
-		// ("not reachable"). Any severity is acceptable except OK
-		// (we never reached a real PONG).
-	}
+	res := CheckRedisAuth(&config.RedisConfig{URL: "redis://\x7f:6379"})
 	if res.Severity == SeverityOK {
-		t.Errorf("malformed URL should not produce OK; got: %q", res.Message)
+		t.Errorf("unparseable URL should not produce OK; got: %q", res.Message)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Ships an AppArmor profile (`internal/apparmor/blockyard`) and `by admin install-apparmor` CLI so Ubuntu 23.10+ hosts lift `apparmor_restrict_unprivileged_userns` narrowly for blockyard instead of disabling it host-wide.
- Adds cgroup-v2 delegation for non-root layer-6 egress: workers move into a `workers/` subcgroup and operators filter with `iptables -m cgroup --path`. Works for both root and non-root deployments, no userns gymnastics.
- New preflight checks: `cloud_metadata` (blockyard-reachable → Error), `redis_auth` (cross-backend, unauth'd PONG → Error), `cgroup_delegation` (reports path + warns if `xt_cgroup` missing). `checkBwrapHostUIDMapping` non-root branch drops Error → Info; the `-m owner` mechanism is inapplicable, not broken.
- Retires the CI `setuid` process-matrix leg (mis-documented, never delivered per-worker host kuids). Adds a standalone `apparmor-smoke` VM job that verifies the profile unblocks rootless bwrap with the negative/positive assertion pair.
- Ships the profile as a `blockyard-apparmor` release asset and COPYs it into the bwrap-capable Docker variants; `blockyard bwrap-smoke` subcommand supports operator verification.
- Operator docs updated: `by admin install-apparmor` in the CLI reference, `[process] skip_metadata_check` in the config reference, and the `backend-security.md` hardening guide rewritten around the `-m owner` vs `-m cgroup --path` choice plus the five new preflight checks (dropping the stale setuid-bwrap guidance).