### PR TITLE
ci(misc): tighten coverage gates and add patch threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,7 +544,7 @@ jobs:
           go run ./cmd/coverage-check \
             -profile=merged.out \
             -min-total=75 \
-            -min-patch=70 \
+            -min-patch=75 \
             -patch-base="origin/$BASE" \
             -ignore='internal/testutil/**' \
             -ignore='internal/preflight/docker_checks.go'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,21 +522,20 @@ jobs:
     if: github.event_name != 'merge_group' && github.event_name != 'push' && inputs.job == ''
     needs: [unit, cli, docker, idp, openbao, pak, process, redis, ui]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
       - uses: actions/download-artifact@v8
         with:
           pattern: coverage-*
           merge-multiple: true
-      - name: Enforce 80% coverage threshold
+      - name: Merge coverage profiles
         run: |
           head -1 coverage-unit.out > merged.out
           tail -n +2 -q coverage-*.out | sort -k1,2 -k3,3rn | awk '{k=$1" "$2} !seen[k]++' >> merged.out
-          TOTAL=$(go tool cover -func=merged.out | grep ^total: | awk '{print $3}' | tr -d '%')
-          echo "Total coverage: ${TOTAL}%"
-          if [ "$(echo "$TOTAL < 80" | bc -l)" -eq 1 ]; then
-            echo "::error::Coverage ${TOTAL}% is below 80% threshold"
-            exit 1
-          fi
+      # Counts partial lines (some blocks hit, some not) as misses so
+      # this gate stays a lower bound on codecov's displayed number.
+      # `go tool cover -func` would treat any count>0 block as covered
+      # and drift above codecov.
+      - name: Check test coverage threshold
+        uses: vladopajic/go-test-coverage@v2.18.4
+        with:
+          profile: merged.out
+          threshold-total: 75

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,6 +522,13 @@ jobs:
     if: github.event_name != 'merge_group' && github.event_name != 'push' && inputs.job == ''
     needs: [unit, cli, docker, idp, openbao, pak, process, redis, ui]
     steps:
+      - uses: actions/checkout@v6
+        with:
+          # Patch coverage diff needs enough history to reach the PR base.
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
       - uses: actions/download-artifact@v8
         with:
           pattern: coverage-*
@@ -530,12 +537,14 @@ jobs:
         run: |
           head -1 coverage-unit.out > merged.out
           tail -n +2 -q coverage-*.out | sort -k1,2 -k3,3rn | awk '{k=$1" "$2} !seen[k]++' >> merged.out
-      # Counts partial lines (some blocks hit, some not) as misses so
-      # this gate stays a lower bound on codecov's displayed number.
-      # `go tool cover -func` would treat any count>0 block as covered
-      # and drift above codecov.
-      - name: Check test coverage threshold
-        uses: vladopajic/go-test-coverage@v2.18.4
-        with:
-          profile: merged.out
-          threshold-total: 75
+      - name: Check coverage thresholds
+        run: |
+          BASE="${GITHUB_BASE_REF:-main}"
+          git fetch --no-tags origin "$BASE"
+          go run ./cmd/coverage-check \
+            -profile=merged.out \
+            -min-total=75 \
+            -min-patch=70 \
+            -patch-base="origin/$BASE" \
+            -ignore='internal/testutil/**' \
+            -ignore='internal/preflight/docker_checks.go'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,3 +18,26 @@ add any needed tools to `.devcontainer/Dockerfile` and rebuild.
 The Go module cache is mounted as a Docker volume (see `devcontainer.json`).
 Go, gopls, and delve are pre-installed in the image. The Go version is
 defined in `go.mod` (single source of truth).
+
+## Commit conventions
+
+Commits use `<type>(<scope>): <subject>`. Types: `feat`, `fix`, `docs`,
+`ci`, `build`, `refactor`, `test`, `chore`.
+
+Scopes (pick one; use `misc` if none fits):
+
+- `proxy` — `internal/api`, `internal/proxy`, `internal/server`,
+  routing, WebSocket, handlers
+- `ui` — `internal/ui`, admin templates, CSS, frontend behavior
+- `auth` — `internal/auth`, `internal/authz`, `internal/session`, OIDC
+- `cli` — `cmd/by`, `cmd/by-builder`
+- `db` — `internal/db`, migrations, storage drivers
+- `docker` — `internal/backend/docker`, the Docker backend
+- `process` — `internal/backend/process`, `internal/orchestrator`,
+  spawn, cgroup/sandbox
+- `telemetry` — `internal/telemetry`, observability
+- `deps` — dependency bumps (dependabot-owned)
+- `misc` — cross-cutting; no single area fits
+
+Subject: under 70 characters, imperative mood, no trailing period.
+The `codecov.yml` component map mirrors this list.

--- a/cmd/coverage-check/main.go
+++ b/cmd/coverage-check/main.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"golang.org/x/tools/cover"
@@ -114,7 +115,7 @@ var hunkRE = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@`)
 // relative to base. Only .go files are included; *_test.go is
 // excluded.
 func gitAddedLines(base string) (map[string]map[int]bool, error) {
-	cmd := exec.Command("git", "diff", "-U0", "--no-color", base+"...HEAD")
+	cmd := exec.Command("git", "diff", "-U0", "--no-color", base+"...HEAD") //nolint:gosec // G204: base is a CI-controlled git ref (e.g. origin/main)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("git diff %s...HEAD: %w", base, err)
@@ -145,7 +146,11 @@ func gitAddedLines(base string) (map[string]map[int]bool, error) {
 			if m == nil {
 				continue
 			}
-			fmt.Sscanf(m[1], "%d", &curLine)
+			n, err := strconv.Atoi(m[1])
+			if err != nil {
+				continue
+			}
+			curLine = n
 		case curFile != "" && strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++"):
 			added[curFile][curLine] = true
 			curLine++

--- a/cmd/coverage-check/main.go
+++ b/cmd/coverage-check/main.go
@@ -1,0 +1,261 @@
+// coverage-check enforces coverage thresholds on a Go coverage profile.
+//
+// Reports total coverage and, optionally, patch coverage against a git
+// base ref. Counts partial lines (multiple blocks on one line, only
+// some hit) as misses — matches codecov's per-line metric so the CI
+// number stays a lower bound on what codecov displays.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"golang.org/x/tools/cover"
+)
+
+const modulePrefix = "github.com/cynkra/blockyard/"
+
+type lineStatus int
+
+const (
+	miss lineStatus = iota
+	partial
+	hit
+)
+
+type fileCov map[int]lineStatus
+
+func buildCoverage(profiles []*cover.Profile) map[string]fileCov {
+	out := map[string]fileCov{}
+	for _, p := range profiles {
+		path := strings.TrimPrefix(p.FileName, modulePrefix)
+		counts := map[int][]int{}
+		for _, b := range p.Blocks {
+			for l := b.StartLine; l <= b.EndLine; l++ {
+				counts[l] = append(counts[l], b.Count)
+			}
+		}
+		status := make(fileCov, len(counts))
+		for l, cs := range counts {
+			h := 0
+			for _, c := range cs {
+				if c > 0 {
+					h++
+				}
+			}
+			switch {
+			case h == len(cs):
+				status[l] = hit
+			case h == 0:
+				status[l] = miss
+			default:
+				status[l] = partial
+			}
+		}
+		out[path] = status
+	}
+	return out
+}
+
+func matchIgnore(path, pattern string) bool {
+	if strings.HasSuffix(pattern, "/**") {
+		return strings.HasPrefix(path, strings.TrimSuffix(pattern, "/**")+"/")
+	}
+	return path == pattern
+}
+
+func applyIgnores(cov map[string]fileCov, ignores []string) {
+	for path := range cov {
+		for _, p := range ignores {
+			if matchIgnore(path, p) {
+				delete(cov, path)
+				break
+			}
+		}
+	}
+}
+
+type totals struct{ hit, miss, partial int }
+
+func (t totals) pct() float64 {
+	den := t.hit + t.miss + t.partial
+	if den == 0 {
+		return 100
+	}
+	return 100 * float64(t.hit) / float64(den)
+}
+
+func sumTotals(cov map[string]fileCov) totals {
+	var t totals
+	for _, f := range cov {
+		for _, s := range f {
+			switch s {
+			case hit:
+				t.hit++
+			case miss:
+				t.miss++
+			case partial:
+				t.partial++
+			}
+		}
+	}
+	return t
+}
+
+var hunkRE = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@`)
+
+// gitAddedLines returns, per file, the line numbers added on HEAD
+// relative to base. Only .go files are included; *_test.go is
+// excluded.
+func gitAddedLines(base string) (map[string]map[int]bool, error) {
+	cmd := exec.Command("git", "diff", "-U0", "--no-color", base+"...HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git diff %s...HEAD: %w", base, err)
+	}
+	added := map[string]map[int]bool{}
+	var curFile string
+	var curLine int
+	sc := bufio.NewScanner(bytes.NewReader(out))
+	sc.Buffer(make([]byte, 64*1024), 8*1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		switch {
+		case strings.HasPrefix(line, "+++ b/"):
+			f := strings.TrimPrefix(line, "+++ b/")
+			if strings.HasSuffix(f, ".go") && !strings.HasSuffix(f, "_test.go") {
+				curFile = f
+				added[curFile] = map[int]bool{}
+			} else {
+				curFile = ""
+			}
+		case strings.HasPrefix(line, "+++ /dev/null"):
+			curFile = ""
+		case strings.HasPrefix(line, "@@"):
+			if curFile == "" {
+				continue
+			}
+			m := hunkRE.FindStringSubmatch(line)
+			if m == nil {
+				continue
+			}
+			fmt.Sscanf(m[1], "%d", &curLine)
+		case curFile != "" && strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++"):
+			added[curFile][curLine] = true
+			curLine++
+		}
+	}
+	return added, sc.Err()
+}
+
+func patchTotals(cov map[string]fileCov, added map[string]map[int]bool, ignores []string) totals {
+	var t totals
+	for path, lines := range added {
+		skip := false
+		for _, p := range ignores {
+			if matchIgnore(path, p) {
+				skip = true
+				break
+			}
+		}
+		if skip {
+			continue
+		}
+		fc, ok := cov[path]
+		if !ok {
+			continue
+		}
+		for l := range lines {
+			s, ok := fc[l]
+			if !ok {
+				continue
+			}
+			switch s {
+			case hit:
+				t.hit++
+			case miss:
+				t.miss++
+			case partial:
+				t.partial++
+			}
+		}
+	}
+	return t
+}
+
+type stringList []string
+
+func (s *stringList) String() string     { return strings.Join(*s, ",") }
+func (s *stringList) Set(v string) error { *s = append(*s, v); return nil }
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "coverage-check: "+format+"\n", args...)
+	os.Exit(2)
+}
+
+func main() {
+	profile := flag.String("profile", "", "coverage profile path (required)")
+	minTotal := flag.Float64("min-total", 0, "total coverage threshold (0 = no check)")
+	minPatch := flag.Float64("min-patch", 0, "patch coverage threshold (0 = no check)")
+	patchBase := flag.String("patch-base", "", "git ref to diff against for patch coverage")
+	var ignore stringList
+	flag.Var(&ignore, "ignore", "path (or prefix/**) to ignore; repeatable")
+	flag.Parse()
+
+	if *profile == "" {
+		die("-profile is required")
+	}
+
+	profiles, err := cover.ParseProfiles(*profile)
+	if err != nil {
+		die("parsing %s: %v", *profile, err)
+	}
+
+	cov := buildCoverage(profiles)
+	applyIgnores(cov, ignore)
+
+	t := sumTotals(cov)
+	pct := t.pct()
+	fmt.Printf("Total coverage: %.2f%% (hit=%d miss=%d partial=%d)\n",
+		pct, t.hit, t.miss, t.partial)
+
+	fail := false
+	if *minTotal > 0 && pct < *minTotal {
+		fmt.Fprintf(os.Stderr,
+			"::error::Total coverage %.2f%% is below %.2f%% threshold\n",
+			pct, *minTotal)
+		fail = true
+	}
+
+	if *patchBase != "" {
+		added, err := gitAddedLines(*patchBase)
+		if err != nil {
+			die("%v", err)
+		}
+		pt := patchTotals(cov, added, ignore)
+		den := pt.hit + pt.miss + pt.partial
+		if den == 0 {
+			fmt.Println("Patch coverage: n/a (no instrumented lines in diff)")
+		} else {
+			ppct := pt.pct()
+			fmt.Printf("Patch coverage: %.2f%% (hit=%d miss=%d partial=%d)\n",
+				ppct, pt.hit, pt.miss, pt.partial)
+			if *minPatch > 0 && ppct < *minPatch {
+				fmt.Fprintf(os.Stderr,
+					"::error::Patch coverage %.2f%% is below %.2f%% threshold\n",
+					ppct, *minPatch)
+				fail = true
+			}
+		}
+	}
+
+	if fail {
+		os.Exit(1)
+	}
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,7 +20,15 @@ flags:
     carryforward: true
   pak:
     carryforward: true
+  redis:
+    carryforward: true
   ui:
+    carryforward: true
+  process-root:
+    carryforward: true
+  process-setuid:
+    carryforward: true
+  process-unprivileged:
     carryforward: true
   examples:
     carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -39,10 +39,9 @@ ignore:
   - "internal/testutil/**"          # test helpers only
   - "internal/preflight/docker_checks.go"  # moved to internal/backend/docker/preflight.go in 207dd28; carryforward keeps the ghost report alive
 
-# Components mostly mirror the commit-message scopes in AGENTS.md but
-# split "process" into a pure-process component and a separate "docker"
-# one, matching the test flag structure (docker_test vs process_test).
-# Paths not covered by any component (internal/config, internal/appname,
+# Components mirror the commit-message scopes in AGENTS.md so coverage
+# attribution follows the same mental model as commits. Paths not
+# covered by any component (internal/config, internal/appname,
 # cmd/coverage-check) still count in the repo total.
 component_management:
   default_rules:

--- a/codecov.yml
+++ b/codecov.yml
@@ -39,11 +39,11 @@ ignore:
   - "internal/testutil/**"          # test helpers only
   - "internal/preflight/docker_checks.go"  # moved to internal/backend/docker/preflight.go in 207dd28; carryforward keeps the ghost report alive
 
-# Components mirror the commit-message scopes in AGENTS.md so coverage
-# attribution follows the same mental model as commits. Paths that
-# don't map to any listed scope (internal/config, internal/appname,
-# cmd/coverage-check) still count in the repo total but aren't
-# attributed to a component.
+# Components mostly mirror the commit-message scopes in AGENTS.md but
+# split "process" into a pure-process component and a separate "docker"
+# one, matching the test flag structure (docker_test vs process_test).
+# Paths not covered by any component (internal/config, internal/appname,
+# cmd/coverage-check) still count in the repo total.
 component_management:
   default_rules:
     statuses:
@@ -88,13 +88,17 @@ component_management:
         - internal/redisstate/**
         - internal/boardstorage/**
         - internal/logstore/**
+    - component_id: docker
+      name: docker
+      paths:
+        - internal/backend/docker/**
     - component_id: process
       name: process
       paths:
         - cmd/blockyard/**
         - cmd/seccomp-compile/**
         - cmd/seccomp-merge/**
-        - internal/backend/**
+        - internal/backend/process/**
         - internal/build/**
         - internal/buildercache/**
         - internal/bundle/**

--- a/codecov.yml
+++ b/codecov.yml
@@ -38,3 +38,79 @@ flags:
 ignore:
   - "internal/testutil/**"          # test helpers only
   - "internal/preflight/docker_checks.go"  # moved to internal/backend/docker/preflight.go in 207dd28; carryforward keeps the ghost report alive
+
+# Components mirror the commit-message scopes in AGENTS.md so coverage
+# attribution follows the same mental model as commits. Paths that
+# don't map to any listed scope (internal/config, internal/appname,
+# cmd/coverage-check) still count in the repo total but aren't
+# attributed to a component.
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        informational: true
+  individual_components:
+    - component_id: proxy
+      name: proxy
+      paths:
+        - internal/api/**
+        - internal/proxy/**
+        - internal/server/**
+        - internal/ops/**
+    - component_id: ui
+      name: ui
+      paths:
+        - internal/ui/**
+        - internal/docs/**
+    - component_id: auth
+      name: auth
+      paths:
+        - internal/auth/**
+        - internal/authz/**
+        - internal/session/**
+        - internal/audit/**
+        - internal/integration/**
+    - component_id: cli
+      name: cli
+      paths:
+        - cmd/by/**
+        - cmd/by-builder/**
+        - internal/apiclient/**
+        - internal/cliconfig/**
+        - internal/deploy/**
+        - internal/update/**
+    - component_id: db
+      name: db
+      paths:
+        - internal/db/**
+        - internal/registry/**
+        - internal/redisstate/**
+        - internal/boardstorage/**
+        - internal/logstore/**
+    - component_id: process
+      name: process
+      paths:
+        - cmd/blockyard/**
+        - cmd/seccomp-compile/**
+        - cmd/seccomp-merge/**
+        - internal/backend/**
+        - internal/build/**
+        - internal/buildercache/**
+        - internal/bundle/**
+        - internal/detect/**
+        - internal/drain/**
+        - internal/manifest/**
+        - internal/mount/**
+        - internal/orchestrator/**
+        - internal/pakcache/**
+        - internal/pkgstore/**
+        - internal/preflight/**
+        - internal/seccomp/**
+        - internal/task/**
+        - internal/units/**
+    - component_id: telemetry
+      name: telemetry
+      paths:
+        - internal/telemetry/**
+        - internal/errorlog/**

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sys v0.43.0
+	golang.org/x/tools v0.42.0
 	modernc.org/sqlite v1.49.1
 )
 
@@ -89,7 +90,6 @@ require (
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
-	golang.org/x/tools v0.42.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/grpc v1.80.0 // indirect


### PR DESCRIPTION
## Summary
- Carry forward all 13 codecov flags (`redis` and the three `process-*` were missing), stopping the ~0.8pp phantom drop on docs-only PRs.
- Replace the `go tool cover -func` / `vladopajic` threshold step with in-tree `cmd/coverage-check` — reads the merged cover profile, counts partial lines as misses (so it tracks codecov's metric), enforces both total and patch thresholds (both 75% to start) against `origin/$BASE_REF`.
- Add `codecov.yml` `component_management` for per-area attribution: `proxy`, `ui`, `auth`, `cli`, `db`, `docker`, `process`, `telemetry`. Docker split out of process so the two backends' coverage moves independently (mirrors the test-flag split).
- Document commit scopes in `AGENTS.md`; `docker` is now a peer of `process` in the scope list and `/commit` skill.
- Follow-ups filed: #326 (docker-hub SDK auth rate-limit), #328-#331 (phase 1-4 coverage work to ratchet toward 80%).