### PR TITLE
fix(docker): authenticate SDK image pulls against registry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.37.0
 	github.com/coder/websocket v1.8.14
 	github.com/coreos/go-oidc/v3 v3.18.0
+	github.com/distribution/reference v0.6.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/httprate v0.15.0
 	github.com/go-jose/go-jose/v4 v4.1.4
@@ -41,7 +42,6 @@ require (
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.7.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/internal/backend/docker/docker.go
+++ b/internal/backend/docker/docker.go
@@ -15,14 +15,15 @@ import (
 	"sync"
 	"time"
 
+	"github.com/moby/moby/api/pkg/stdcopy"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/network"
-	"github.com/moby/moby/api/pkg/stdcopy"
 	"github.com/moby/moby/client"
 
 	"github.com/cynkra/blockyard/internal/backend"
 	"github.com/cynkra/blockyard/internal/config"
+	"github.com/cynkra/blockyard/internal/dockerauth"
 	"github.com/cynkra/blockyard/internal/units"
 )
 
@@ -82,7 +83,7 @@ const (
 // DockerBackend implements backend.Backend using the Docker Engine API.
 type DockerBackend struct {
 	client           dockerClient
-	serverID         string // own container ID; empty = native mode
+	serverID         string               // own container ID; empty = native mode
 	config           *config.DockerConfig // shortcut for fullCfg.Docker
 	fullCfg          *config.Config       // full config; needed for Server.DefaultMemoryLimit/CPULimit and the redis URL the preflight builder reads
 	bundleServerPath string               // root for the by-builder cache and pkg-store
@@ -108,7 +109,7 @@ type DockerBackend struct {
 func New(ctx context.Context, fullCfg *config.Config, bundleServerPath, serverVersion string) (*DockerBackend, error) {
 	cfg := &fullCfg.Docker
 	cli, err := client.New(
-		client.WithHost("unix://"+cfg.Socket),
+		client.WithHost("unix://" + cfg.Socket),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("docker client: %w", err)
@@ -278,7 +279,11 @@ func (d *DockerBackend) ensureImage(ctx context.Context, img string) error {
 	}
 
 	slog.Info("pulling image", "image", img)
-	pullResp, err := d.client.ImagePull(ctx, img, client.ImagePullOptions{})
+	auth, err := dockerauth.RegistryAuthFor(img)
+	if err != nil {
+		slog.Warn("registry auth lookup failed, pulling anonymously", "image", img, "error", err)
+	}
+	pullResp, err := d.client.ImagePull(ctx, img, client.ImagePullOptions{RegistryAuth: auth})
 	if err != nil {
 		return fmt.Errorf("pull image %s: %w", img, err)
 	}

--- a/internal/backend/docker/preflight.go
+++ b/internal/backend/docker/preflight.go
@@ -18,6 +18,7 @@ import (
 	"github.com/moby/moby/client"
 
 	"github.com/cynkra/blockyard/internal/buildercache"
+	"github.com/cynkra/blockyard/internal/dockerauth"
 	"github.com/cynkra/blockyard/internal/preflight"
 )
 
@@ -427,7 +428,11 @@ func ensurePreflightImage(ctx context.Context, cli *client.Client, img string) e
 	}
 
 	slog.Info("preflight: pulling image", "image", img)
-	pullResp, err := cli.ImagePull(ctx, img, client.ImagePullOptions{})
+	auth, err := dockerauth.RegistryAuthFor(img)
+	if err != nil {
+		slog.Warn("preflight: registry auth lookup failed, pulling anonymously", "image", img, "error", err)
+	}
+	pullResp, err := cli.ImagePull(ctx, img, client.ImagePullOptions{RegistryAuth: auth})
 	if err != nil {
 		return fmt.Errorf("pull %s: %w", img, err)
 	}

--- a/internal/dockerauth/dockerauth.go
+++ b/internal/dockerauth/dockerauth.go
@@ -1,0 +1,130 @@
+// Package dockerauth resolves Docker registry credentials from the
+// user's ~/.docker/config.json so that Go SDK callers can authenticate
+// image pulls. The Docker daemon does not auto-enrich SDK requests
+// with the CLI's credentials — each caller supplies its own
+// X-Registry-Auth header — so SDK pulls go out anonymous unless we
+// thread the auth through ourselves.
+package dockerauth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/distribution/reference"
+	"github.com/moby/moby/api/types/registry"
+)
+
+// dockerHubHost is the canonical domain returned by reference.Domain
+// for unqualified images such as "alpine:3.23".
+const dockerHubHost = "docker.io"
+
+// dockerHubLegacyKey is the historical index URL the Docker CLI writes
+// under "auths" for Docker Hub credentials.
+const dockerHubLegacyKey = "https://index.docker.io/v1/"
+
+// RegistryAuthFor returns the base64url-encoded RegistryAuth string to
+// pass as client.ImagePullOptions{RegistryAuth: ...} so the daemon
+// forwards credentials to the registry when pulling ref.
+//
+// Returns ("", nil) when no credentials are configured for the ref's
+// domain (anonymous pull) or when the config file is absent. Returns
+// an error only for malformed refs or a corrupt config file.
+func RegistryAuthFor(ref string) (string, error) {
+	named, err := reference.ParseNormalizedNamed(ref)
+	if err != nil {
+		return "", fmt.Errorf("parse reference %q: %w", ref, err)
+	}
+	return registryAuthForDomain(reference.Domain(named), configPath())
+}
+
+func registryAuthForDomain(domain, path string) (string, error) {
+	entry, ok, err := lookupAuth(domain, path)
+	if err != nil || !ok {
+		return "", err
+	}
+
+	cfg := registry.AuthConfig{
+		IdentityToken: entry.IdentityToken,
+		ServerAddress: domain,
+	}
+	if entry.Auth != "" {
+		user, pass, err := decodeAuth(entry.Auth)
+		if err != nil {
+			return "", err
+		}
+		cfg.Username = user
+		cfg.Password = pass
+	}
+
+	buf, err := json.Marshal(cfg)
+	if err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(buf), nil
+}
+
+type dockerConfigAuth struct {
+	Auth          string `json:"auth"`
+	IdentityToken string `json:"identitytoken,omitempty"`
+}
+
+type dockerConfig struct {
+	Auths map[string]dockerConfigAuth `json:"auths"`
+}
+
+func lookupAuth(domain, path string) (dockerConfigAuth, bool, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return dockerConfigAuth{}, false, nil
+	}
+	if err != nil {
+		return dockerConfigAuth{}, false, fmt.Errorf("read %s: %w", path, err)
+	}
+	var cfg dockerConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return dockerConfigAuth{}, false, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	keys := []string{domain}
+	if domain == dockerHubHost {
+		keys = append(keys, dockerHubLegacyKey, "index.docker.io")
+	}
+	for _, k := range keys {
+		if e, ok := cfg.Auths[k]; ok && (e.Auth != "" || e.IdentityToken != "") {
+			return e, true, nil
+		}
+	}
+	return dockerConfigAuth{}, false, nil
+}
+
+func configPath() string {
+	if p := os.Getenv("DOCKER_CONFIG"); p != "" {
+		return filepath.Join(p, "config.json")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".docker", "config.json")
+	}
+	return filepath.Join(home, ".docker", "config.json")
+}
+
+func decodeAuth(s string) (string, string, error) {
+	raw, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		raw, err = base64.URLEncoding.DecodeString(s)
+		if err != nil {
+			return "", "", fmt.Errorf("decode auth: %w", err)
+		}
+	}
+	user, pass, ok := strings.Cut(string(raw), ":")
+	if !ok {
+		return "", "", fmt.Errorf("invalid auth: expected user:pass")
+	}
+	return user, pass, nil
+}

--- a/internal/dockerauth/dockerauth.go
+++ b/internal/dockerauth/dockerauth.go
@@ -62,7 +62,7 @@ func registryAuthForDomain(domain, path string) (string, error) {
 		cfg.Password = pass
 	}
 
-	buf, err := json.Marshal(cfg)
+	buf, err := json.Marshal(cfg) //nolint:gosec // G117: serializing credentials is the point — the daemon needs X-Registry-Auth
 	if err != nil {
 		return "", err
 	}
@@ -79,7 +79,7 @@ type dockerConfig struct {
 }
 
 func lookupAuth(domain, path string) (dockerConfigAuth, bool, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //nolint:gosec // G304: documented DOCKER_CONFIG path, same contract Docker CLI honours
 	if errors.Is(err, fs.ErrNotExist) {
 		return dockerConfigAuth{}, false, nil
 	}

--- a/internal/dockerauth/dockerauth_test.go
+++ b/internal/dockerauth/dockerauth_test.go
@@ -1,0 +1,164 @@
+package dockerauth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/moby/moby/api/types/registry"
+)
+
+func writeConfig(t *testing.T, dir string, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func decodeRegistryAuth(t *testing.T, s string) registry.AuthConfig {
+	t.Helper()
+	raw, err := base64.URLEncoding.DecodeString(s)
+	if err != nil {
+		t.Fatalf("decode RegistryAuth: %v", err)
+	}
+	var cfg registry.AuthConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("unmarshal AuthConfig: %v", err)
+	}
+	return cfg
+}
+
+func TestRegistryAuthFor_DockerHubLegacyKey(t *testing.T) {
+	dir := t.TempDir()
+	// "alice:s3cret" under the legacy index URL the CLI writes.
+	writeConfig(t, dir, `{
+	  "auths": {
+	    "https://index.docker.io/v1/": {"auth": "YWxpY2U6czNjcmV0"}
+	  }
+	}`)
+	t.Setenv("DOCKER_CONFIG", dir)
+
+	got, err := RegistryAuthFor("alpine:3.23")
+	if err != nil {
+		t.Fatalf("RegistryAuthFor: %v", err)
+	}
+	if got == "" {
+		t.Fatal("expected non-empty RegistryAuth for docker.io image")
+	}
+	cfg := decodeRegistryAuth(t, got)
+	if cfg.Username != "alice" || cfg.Password != "s3cret" {
+		t.Errorf("got username=%q password=%q, want alice/s3cret", cfg.Username, cfg.Password)
+	}
+}
+
+func TestRegistryAuthFor_ExplicitDockerIoDomain(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, `{
+	  "auths": {
+	    "docker.io": {"auth": "Ym9iOnRva2Vu"}
+	  }
+	}`)
+	t.Setenv("DOCKER_CONFIG", dir)
+
+	got, err := RegistryAuthFor("docker.io/library/postgres:16")
+	if err != nil {
+		t.Fatalf("RegistryAuthFor: %v", err)
+	}
+	cfg := decodeRegistryAuth(t, got)
+	if cfg.Username != "bob" || cfg.Password != "token" {
+		t.Errorf("got %q/%q, want bob/token", cfg.Username, cfg.Password)
+	}
+}
+
+func TestRegistryAuthFor_OtherRegistry(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, `{
+	  "auths": {
+	    "ghcr.io": {"auth": "Z2g6cGF0"}
+	  }
+	}`)
+	t.Setenv("DOCKER_CONFIG", dir)
+
+	got, err := RegistryAuthFor("ghcr.io/cynkra/blockyard:latest")
+	if err != nil {
+		t.Fatalf("RegistryAuthFor: %v", err)
+	}
+	cfg := decodeRegistryAuth(t, got)
+	if cfg.Username != "gh" || cfg.Password != "pat" {
+		t.Errorf("got %q/%q, want gh/pat", cfg.Username, cfg.Password)
+	}
+	if cfg.ServerAddress != "ghcr.io" {
+		t.Errorf("ServerAddress = %q, want ghcr.io", cfg.ServerAddress)
+	}
+}
+
+func TestRegistryAuthFor_NoMatchReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, `{
+	  "auths": {
+	    "ghcr.io": {"auth": "Z2g6cGF0"}
+	  }
+	}`)
+	t.Setenv("DOCKER_CONFIG", dir)
+
+	got, err := RegistryAuthFor("alpine:3.23")
+	if err != nil {
+		t.Fatalf("RegistryAuthFor: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty auth for unmatched domain, got %q", got)
+	}
+}
+
+func TestRegistryAuthFor_MissingConfig(t *testing.T) {
+	dir := t.TempDir() // empty
+	t.Setenv("DOCKER_CONFIG", dir)
+
+	got, err := RegistryAuthFor("alpine:3.23")
+	if err != nil {
+		t.Fatalf("RegistryAuthFor: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty auth when config is missing, got %q", got)
+	}
+}
+
+func TestRegistryAuthFor_IdentityTokenOnly(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, `{
+	  "auths": {
+	    "ghcr.io": {"identitytoken": "opaque-refresh-token"}
+	  }
+	}`)
+	t.Setenv("DOCKER_CONFIG", dir)
+
+	got, err := RegistryAuthFor("ghcr.io/foo/bar:1")
+	if err != nil {
+		t.Fatalf("RegistryAuthFor: %v", err)
+	}
+	cfg := decodeRegistryAuth(t, got)
+	if cfg.IdentityToken != "opaque-refresh-token" {
+		t.Errorf("IdentityToken = %q, want opaque-refresh-token", cfg.IdentityToken)
+	}
+	if cfg.Username != "" || cfg.Password != "" {
+		t.Errorf("expected no username/password, got %q/%q", cfg.Username, cfg.Password)
+	}
+}
+
+func TestRegistryAuthFor_MalformedRef(t *testing.T) {
+	if _, err := RegistryAuthFor("::not a ref::"); err == nil {
+		t.Fatal("expected error for malformed ref, got nil")
+	}
+}
+
+func TestRegistryAuthFor_CorruptConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, `{not json`)
+	t.Setenv("DOCKER_CONFIG", dir)
+
+	if _, err := RegistryAuthFor("alpine:3.23"); err == nil {
+		t.Fatal("expected error for corrupt config, got nil")
+	}
+}

--- a/internal/orchestrator/clone_docker.go
+++ b/internal/orchestrator/clone_docker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 
+	"github.com/cynkra/blockyard/internal/dockerauth"
 	"github.com/cynkra/blockyard/internal/task"
 )
 
@@ -26,6 +27,7 @@ type dockerClient interface {
 	ContainerStop(ctx context.Context, containerID string, options client.ContainerStopOptions) (client.ContainerStopResult, error)
 	ContainerRemove(ctx context.Context, containerID string, options client.ContainerRemoveOptions) (client.ContainerRemoveResult, error)
 	ContainerWait(ctx context.Context, containerID string, options client.ContainerWaitOptions) client.ContainerWaitResult
+	ImageInspect(ctx context.Context, imageID string, opts ...client.ImageInspectOption) (client.ImageInspectResult, error)
 	ImagePull(ctx context.Context, refStr string, options client.ImagePullOptions) (client.ImagePullResponse, error)
 }
 
@@ -74,10 +76,10 @@ func newDockerFactoryForTest(c dockerClient, serverID string, listenPort func() 
 // inspect-retry loop, so the field is safe to read without further
 // lookups.
 type dockerInstance struct {
-	id       string
-	addr     string
-	docker   dockerClient
-	log      *slog.Logger
+	id     string
+	addr   string
+	docker dockerClient
+	log    *slog.Logger
 }
 
 func (d *dockerInstance) ID() string   { return d.id }
@@ -262,9 +264,19 @@ func (f *dockerServerFactory) cloneConfig(
 	}, nil
 }
 
-// pullImage pulls the given image via the Docker API.
+// pullImage pulls the given image via the Docker API. Skips the pull
+// when the image is already present locally; the registry-side freshness
+// check that ImagePull would issue otherwise counts against Docker Hub's
+// anonymous rate limit even on cache hits.
 func (f *dockerServerFactory) pullImage(ctx context.Context, ref string) error {
-	resp, err := f.docker.ImagePull(ctx, ref, client.ImagePullOptions{})
+	if _, err := f.docker.ImageInspect(ctx, ref); err == nil {
+		return nil
+	}
+	auth, err := dockerauth.RegistryAuthFor(ref)
+	if err != nil {
+		f.log.Warn("registry auth lookup failed, pulling anonymously", "image", ref, "error", err)
+	}
+	resp, err := f.docker.ImagePull(ctx, ref, client.ImagePullOptions{RegistryAuth: auth})
 	if err != nil {
 		return err
 	}

--- a/internal/orchestrator/clone_docker_test.go
+++ b/internal/orchestrator/clone_docker_test.go
@@ -18,13 +18,14 @@ import (
 // --- mock Docker client ---
 
 type mockDocker struct {
-	inspectFn func(ctx context.Context, id string, opts client.ContainerInspectOptions) (client.ContainerInspectResult, error)
-	createFn  func(ctx context.Context, opts client.ContainerCreateOptions) (client.ContainerCreateResult, error)
-	startFn   func(ctx context.Context, id string, opts client.ContainerStartOptions) (client.ContainerStartResult, error)
-	stopFn    func(ctx context.Context, id string, opts client.ContainerStopOptions) (client.ContainerStopResult, error)
-	removeFn  func(ctx context.Context, id string, opts client.ContainerRemoveOptions) (client.ContainerRemoveResult, error)
-	waitFn    func(ctx context.Context, id string, opts client.ContainerWaitOptions) client.ContainerWaitResult
-	pullFn    func(ctx context.Context, ref string, opts client.ImagePullOptions) (client.ImagePullResponse, error)
+	inspectFn      func(ctx context.Context, id string, opts client.ContainerInspectOptions) (client.ContainerInspectResult, error)
+	createFn       func(ctx context.Context, opts client.ContainerCreateOptions) (client.ContainerCreateResult, error)
+	startFn        func(ctx context.Context, id string, opts client.ContainerStartOptions) (client.ContainerStartResult, error)
+	stopFn         func(ctx context.Context, id string, opts client.ContainerStopOptions) (client.ContainerStopResult, error)
+	removeFn       func(ctx context.Context, id string, opts client.ContainerRemoveOptions) (client.ContainerRemoveResult, error)
+	waitFn         func(ctx context.Context, id string, opts client.ContainerWaitOptions) client.ContainerWaitResult
+	pullFn         func(ctx context.Context, ref string, opts client.ImagePullOptions) (client.ImagePullResponse, error)
+	imageInspectFn func(ctx context.Context, id string, opts ...client.ImageInspectOption) (client.ImageInspectResult, error)
 }
 
 func (m *mockDocker) ContainerInspect(ctx context.Context, id string, opts client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
@@ -78,6 +79,18 @@ func (m *mockDocker) ImagePull(_ context.Context, _ string, _ client.ImagePullOp
 	return mockPullResponse{ReadCloser: io.NopCloser(&emptyReader{})}, nil
 }
 
+func (m *mockDocker) ImageInspect(ctx context.Context, id string, opts ...client.ImageInspectOption) (client.ImageInspectResult, error) {
+	if m.imageInspectFn != nil {
+		return m.imageInspectFn(ctx, id, opts...)
+	}
+	return client.ImageInspectResult{}, errNotFound{}
+}
+
+type errNotFound struct{}
+
+func (errNotFound) Error() string  { return "image not found" }
+func (errNotFound) NotFound() bool { return true }
+
 type mockPullResponse struct {
 	io.ReadCloser
 }
@@ -121,6 +134,52 @@ func mustParsePort(s string) network.Port {
 		panic(err)
 	}
 	return p
+}
+
+// ---------------------------------------------------------------------------
+// pullImage
+// ---------------------------------------------------------------------------
+
+func TestPullImageSkipsWhenPresent(t *testing.T) {
+	var pullCalled bool
+	docker := &mockDocker{
+		imageInspectFn: func(_ context.Context, _ string, _ ...client.ImageInspectOption) (client.ImageInspectResult, error) {
+			return client.ImageInspectResult{}, nil
+		},
+		pullFn: func(_ context.Context, _ string, _ client.ImagePullOptions) (client.ImagePullResponse, error) {
+			pullCalled = true
+			return mockPullResponse{ReadCloser: io.NopCloser(&emptyReader{})}, nil
+		},
+	}
+	f := newDockerFactoryForTest(docker, "self-id", func() string { return "8080" })
+
+	if err := f.pullImage(context.Background(), "ghcr.io/cynkra/blockyard:1.0.0"); err != nil {
+		t.Fatalf("pullImage: %v", err)
+	}
+	if pullCalled {
+		t.Error("ImagePull must not be called when image is present locally")
+	}
+}
+
+func TestPullImagePullsWhenAbsent(t *testing.T) {
+	var pullCalled bool
+	docker := &mockDocker{
+		imageInspectFn: func(_ context.Context, _ string, _ ...client.ImageInspectOption) (client.ImageInspectResult, error) {
+			return client.ImageInspectResult{}, errNotFound{}
+		},
+		pullFn: func(_ context.Context, _ string, _ client.ImagePullOptions) (client.ImagePullResponse, error) {
+			pullCalled = true
+			return mockPullResponse{ReadCloser: io.NopCloser(&emptyReader{})}, nil
+		},
+	}
+	f := newDockerFactoryForTest(docker, "self-id", func() string { return "8080" })
+
+	if err := f.pullImage(context.Background(), "ghcr.io/cynkra/blockyard:1.0.0"); err != nil {
+		t.Fatalf("pullImage: %v", err)
+	}
+	if !pullCalled {
+		t.Error("ImagePull must be called when image is absent locally")
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -219,7 +278,7 @@ func TestCloneConfigNilNetworkSettings(t *testing.T) {
 	docker := &mockDocker{
 		inspectFn: func(context.Context, string, client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
 			return client.ContainerInspectResult{Container: container.InspectResponse{
-				Config:   &container.Config{Image: "old:1.0", Env: []string{}},
+				Config:     &container.Config{Image: "old:1.0", Env: []string{}},
 				HostConfig: &container.HostConfig{},
 			}}, nil
 		},


### PR DESCRIPTION
## Summary
- Added `internal/dockerauth` which reads `~/.docker/config.json` (honouring `DOCKER_CONFIG`) and returns a base64url-encoded `X-Registry-Auth` for a given image reference.
- Wired it into the three SDK `ImagePull` sites — `backend/docker.ensureImage`, `backend/docker.ensurePreflightImage`, and `orchestrator.dockerServerFactory.pullImage` — so pulls no longer go out anonymous against Docker Hub.
- Added inspect-before-pull to the orchestrator pull path (the other two already had it) to skip the manifest GET entirely when the tag is already cached.

Fixes #326