### PR TITLE
test(misc): CLI + pkgstore coverage (phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,8 +577,8 @@ jobs:
           git fetch --no-tags origin "$BASE"
           go run ./cmd/coverage-check \
             -profile=merged.out \
-            -min-total=75 \
-            -min-patch=75 \
+            -min-total=76 \
+            -min-patch=76 \
             -patch-base="origin/$BASE" \
             -ignore='internal/testutil/**' \
             -ignore='internal/preflight/docker_checks.go'

--- a/cmd/by/login_integration_test.go
+++ b/cmd/by/login_integration_test.go
@@ -1,0 +1,205 @@
+//go:build cli_test
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runStdin runs the CLI with piped stdin and without default env vars
+// (login writes its own config). xdgHome overrides XDG_CONFIG_HOME so
+// each test can inspect the resulting config.json in isolation.
+func runStdin(t *testing.T, xdgHome, stdin string, args ...string) result {
+	t.Helper()
+	cmd := exec.Command(byBin, args...)
+	cmd.Env = []string{
+		"HOME=" + t.TempDir(),
+		"XDG_CONFIG_HOME=" + xdgHome,
+		"PATH=" + os.Getenv("PATH"),
+	}
+	if d := os.Getenv("GOCOVERDIR"); d != "" {
+		cmd.Env = append(cmd.Env, "GOCOVERDIR="+d)
+	}
+	cmd.Stdin = strings.NewReader(stdin)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	code := 0
+	if ee, ok := err.(*exec.ExitError); ok {
+		code = ee.ExitCode()
+	} else if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	return result{Stdout: stdout.String(), Stderr: stderr.String(), ExitCode: code}
+}
+
+// extractJSON returns the JSON object embedded in mixed output.
+// login writes prompt text ("Paste your token:", "Opening browser...")
+// to stdout before emitting the JSON blob, so r.jsonMap() on the raw
+// buffer fails. The JSON object is the only '{' in the stream.
+func extractJSON(t *testing.T, s string) map[string]any {
+	t.Helper()
+	i := strings.Index(s, "{")
+	if i < 0 {
+		t.Fatalf("no JSON object in output:\n%s", s)
+	}
+	var v map[string]any
+	if err := json.Unmarshal([]byte(s[i:]), &v); err != nil {
+		t.Fatalf("unmarshal JSON tail: %v\n%s", err, s[i:])
+	}
+	return v
+}
+
+func readConfig(t *testing.T, xdgHome string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(xdgHome, "by", "config.json"))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var v map[string]any
+	if err := json.Unmarshal(data, &v); err != nil {
+		t.Fatalf("unmarshal config: %v\n%s", err, data)
+	}
+	return v
+}
+
+func TestCLI_Login(t *testing.T) {
+	t.Run("server_flag_and_token", func(t *testing.T) {
+		m := newMock(t)
+		m.on("GET", "/api/v1/users/me", 200, map[string]string{
+			"sub": "demo@example.com", "name": "Demo User",
+		})
+
+		xdg := t.TempDir()
+		r := runStdin(t, xdg, "tok-abc\n", "login", "--server", m.URL)
+		assertExit(t, r, 0)
+		assertContains(t, r.Stdout, "Logged in to")
+		assertContains(t, r.Stdout, "Demo User")
+
+		req := m.reqTo("GET", "/api/v1/users/me")
+		if req == nil {
+			t.Fatal("no /users/me request")
+			return
+		}
+		if req.Auth != "Bearer tok-abc" {
+			t.Errorf("auth = %q, want Bearer tok-abc", req.Auth)
+		}
+
+		cfg := readConfig(t, xdg)
+		if cfg["server"] != m.URL {
+			t.Errorf("config server = %v, want %v", cfg["server"], m.URL)
+		}
+		if cfg["token"] != "tok-abc" {
+			t.Errorf("config token = %v, want tok-abc", cfg["token"])
+		}
+	})
+
+	t.Run("interactive_server_prompt", func(t *testing.T) {
+		m := newMock(t)
+		m.on("GET", "/api/v1/users/me", 200, map[string]string{
+			"sub": "demo@example.com", "name": "Demo User",
+		})
+
+		// Both prompts via stdin: server URL (with trailing slash to
+		// exercise the TrimRight), then token.
+		xdg := t.TempDir()
+		r := runStdin(t, xdg, m.URL+"/\ntok-xyz\n", "login")
+		assertExit(t, r, 0)
+		assertContains(t, r.Stdout, "Server URL:")
+		assertContains(t, r.Stdout, "Paste your token:")
+
+		cfg := readConfig(t, xdg)
+		if cfg["server"] != m.URL {
+			t.Errorf("config server = %v, want %v (trailing slash trimmed)", cfg["server"], m.URL)
+		}
+	})
+
+	t.Run("falls_back_to_sub_when_name_empty", func(t *testing.T) {
+		m := newMock(t)
+		m.on("GET", "/api/v1/users/me", 200, map[string]string{
+			"sub": "sub-only@example.com",
+		})
+
+		xdg := t.TempDir()
+		r := runStdin(t, xdg, "tok\n", "login", "--server", m.URL)
+		assertExit(t, r, 0)
+		assertContains(t, r.Stdout, "sub-only@example.com")
+	})
+
+	t.Run("json_output", func(t *testing.T) {
+		m := newMock(t)
+		m.on("GET", "/api/v1/users/me", 200, map[string]string{
+			"sub": "demo@example.com", "name": "Demo User",
+		})
+
+		xdg := t.TempDir()
+		r := runStdin(t, xdg, "tok\n", "login", "--server", m.URL, "--json")
+		assertExit(t, r, 0)
+		j := extractJSON(t, r.Stdout)
+		if j["user"] != "Demo User" {
+			t.Errorf("json user = %v, want Demo User", j["user"])
+		}
+		if j["server"] != m.URL {
+			t.Errorf("json server = %v, want %v", j["server"], m.URL)
+		}
+	})
+
+	t.Run("empty_server_url", func(t *testing.T) {
+		xdg := t.TempDir()
+		// Empty line for server prompt -> error.
+		r := runStdin(t, xdg, "\n", "login")
+		assertExit(t, r, 1)
+		assertContains(t, r.Stderr, "server URL is required")
+	})
+
+	t.Run("empty_token", func(t *testing.T) {
+		m := newMock(t)
+		xdg := t.TempDir()
+		r := runStdin(t, xdg, "\n", "login", "--server", m.URL)
+		assertExit(t, r, 1)
+		assertContains(t, r.Stderr, "token is required")
+	})
+
+	t.Run("auth_failure_text", func(t *testing.T) {
+		m := newMock(t)
+		m.on("GET", "/api/v1/users/me", 401, map[string]string{
+			"error": "unauthorized", "message": "bad token",
+		})
+
+		xdg := t.TempDir()
+		r := runStdin(t, xdg, "bad-tok\n", "login", "--server", m.URL)
+		assertExit(t, r, 1)
+		assertContains(t, r.Stderr, "authentication failed")
+	})
+
+	t.Run("auth_failure_json", func(t *testing.T) {
+		m := newMock(t)
+		m.on("GET", "/api/v1/users/me", 401, map[string]string{
+			"error": "unauthorized", "message": "bad token",
+		})
+
+		xdg := t.TempDir()
+		r := runStdin(t, xdg, "bad-tok\n", "login", "--server", m.URL, "--json")
+		assertExit(t, r, 1)
+		j := extractJSON(t, r.Stdout)
+		if j["error"] != "error" {
+			t.Errorf("json error = %v, want error", j["error"])
+		}
+	})
+
+	t.Run("connection_failure", func(t *testing.T) {
+		// Point at a closed port — apiclient.Get should fail.
+		xdg := t.TempDir()
+		r := runStdin(t, xdg, "tok\n", "login", "--server", "http://127.0.0.1:1")
+		assertExit(t, r, 1)
+		assertContains(t, r.Stderr, "failed to connect to server")
+	})
+}

--- a/cmd/by/selfupdate_test.go
+++ b/cmd/by/selfupdate_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/cynkra/blockyard/internal/update"
@@ -156,5 +157,174 @@ func TestSelfUpdateCmd_AlreadyUpToDate(t *testing.T) {
 
 	if got := out; got != "Already up to date (0.0.3).\n" {
 		t.Errorf("output = %q", got)
+	}
+}
+
+// selfUpdateReleaseHandler routes /releases/latest and /releases/tags/main
+// to a pre-baked release payload. Returns the server; caller must Close.
+func selfUpdateReleaseHandler(t *testing.T, stable, main update.GitHubRelease) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/releases/latest":
+			_ = json.NewEncoder(w).Encode(stable)
+		case "/releases/tags/main":
+			_ = json.NewEncoder(w).Encode(main)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// withVersionAndAPI swaps `version` and `update.APIBase` for the test
+// and restores them on cleanup.
+func withVersionAndAPI(t *testing.T, ver, api string) {
+	t.Helper()
+	oldV, oldA := version, update.APIBase
+	version = ver
+	update.APIBase = api
+	t.Cleanup(func() {
+		version = oldV
+		update.APIBase = oldA
+	})
+}
+
+func TestSelfUpdateCmd_AlreadyUpToDate_JSON(t *testing.T) {
+	srv := selfUpdateReleaseHandler(t,
+		update.GitHubRelease{TagName: "v0.0.3", Name: "0.0.3"},
+		update.GitHubRelease{})
+	defer srv.Close()
+	withVersionAndAPI(t, "0.0.3", srv.URL)
+
+	cmd := selfUpdateCmd()
+	cmd.Flags().Bool("json", true, "")
+	_ = cmd.Flags().Set("json", "true")
+	cmd.SetArgs([]string{})
+
+	out := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal JSON: %v\n%s", err, out)
+	}
+	if got["status"] != "up_to_date" {
+		t.Errorf("status = %v, want up_to_date", got["status"])
+	}
+	if got["current_version"] != "0.0.3" {
+		t.Errorf("current_version = %v, want 0.0.3", got["current_version"])
+	}
+	if got["channel"] != "stable" {
+		t.Errorf("channel = %v, want stable", got["channel"])
+	}
+}
+
+// TestSelfUpdateCmd_MainChannel_UpToDate exercises the "main" channel
+// path (the other arm of the channel switch) without touching the
+// binary-replace logic. The main-tag release carries a fresh SHA each
+// build, so "up to date" requires version == release.Name verbatim.
+func TestSelfUpdateCmd_MainChannel_UpToDate(t *testing.T) {
+	srv := selfUpdateReleaseHandler(t,
+		update.GitHubRelease{},
+		update.GitHubRelease{TagName: "main", Name: "main+abc1234"})
+	defer srv.Close()
+	withVersionAndAPI(t, "main+abc1234", srv.URL)
+
+	cmd := selfUpdateCmd()
+	cmd.SetArgs([]string{"--channel", "main"})
+	out := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if got := out; got != "Already up to date (main+abc1234).\n" {
+		t.Errorf("output = %q", got)
+	}
+}
+
+// TestSelfUpdateCmd_InferChannelFromVersion verifies the auto-inferred
+// channel when --channel is not passed: a SHA-shaped version picks
+// "main" and fetches /releases/tags/main.
+func TestSelfUpdateCmd_InferChannelFromVersion(t *testing.T) {
+	srv := selfUpdateReleaseHandler(t,
+		update.GitHubRelease{},
+		update.GitHubRelease{TagName: "main", Name: "main+deadbee"})
+	defer srv.Close()
+	withVersionAndAPI(t, "main+deadbee", srv.URL)
+
+	cmd := selfUpdateCmd()
+	cmd.SetArgs([]string{})
+	out := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if got := out; got != "Already up to date (main+deadbee).\n" {
+		t.Errorf("output = %q", got)
+	}
+}
+
+// TestSelfUpdateBinaryName_Windows sanity-checks the `.exe` suffix
+// branch of selfUpdateBinaryName. The runtime GOOS can't be switched
+// at test time, so we only assert the suffix invariant; the other leg
+// is exercised by TestSelfUpdateBinaryName on Linux/macOS CI runners.
+func TestSelfUpdateBinaryName_Suffix(t *testing.T) {
+	name := selfUpdateBinaryName()
+	if runtime.GOOS == "windows" && !strings.HasSuffix(name, ".exe") {
+		t.Errorf("expected .exe suffix on Windows, got %q", name)
+	}
+	if runtime.GOOS != "windows" && strings.HasSuffix(name, ".exe") {
+		t.Errorf("unexpected .exe suffix on %s, got %q", runtime.GOOS, name)
+	}
+}
+
+// TestDownloadAsset_HTTPError covers the non-200 response path.
+func TestDownloadAsset_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	dst := filepath.Join(t.TempDir(), "by-test")
+	err := downloadAsset(srv.URL+"/asset", dst)
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error = %v, want 500 in message", err)
+	}
+}
+
+// TestDownloadAsset_BadURL covers the http.NewRequest error path.
+func TestDownloadAsset_BadURL(t *testing.T) {
+	err := downloadAsset("://malformed", filepath.Join(t.TempDir(), "by-test"))
+	if err == nil {
+		t.Fatal("expected error for malformed URL")
+	}
+}
+
+// TestDownloadAsset_UnreachableHost covers the http.DefaultClient.Do
+// failure path (connection refused).
+func TestDownloadAsset_UnreachableHost(t *testing.T) {
+	err := downloadAsset("http://127.0.0.1:1/asset", filepath.Join(t.TempDir(), "by-test"))
+	if err == nil {
+		t.Fatal("expected error for unreachable host")
+	}
+}
+
+// TestDownloadAsset_OpenFails covers the os.OpenFile error path (dst
+// inside a nonexistent dir).
+func TestDownloadAsset_OpenFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("content")) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	err := downloadAsset(srv.URL+"/asset", filepath.Join(t.TempDir(), "nonexistent-dir", "by"))
+	if err == nil {
+		t.Fatal("expected error for unwritable dst")
 	}
 }

--- a/internal/pkgstore/populate_test.go
+++ b/internal/pkgstore/populate_test.go
@@ -266,6 +266,339 @@ func TestPopulateBuild_SkipsRefManifestMatch(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// PopulateRuntime
+// ---------------------------------------------------------------------------
+
+// makeEntry is a terse helper for standard lockfile entries used by the
+// PopulateRuntime tests.
+func makeEntry(pkg, version, sha string) LockfileEntry {
+	return LockfileEntry{
+		Package:  pkg,
+		Version:  version,
+		Type:     "standard",
+		SHA256:   sha,
+		RVersion: "4.5",
+		Platform: "x86_64-pc-linux-gnu",
+	}
+}
+
+// seedStore plants a package tree + configs.json + sidecar into the
+// store so ResolveConfig finds it. linkingTo names the declared
+// LinkingTo deps; linkingToKeys is the expected source-key map for the
+// config hash; emit==true writes the corresponding config entry. When
+// emit==false, the tree exists but no config matches — a store miss.
+func seedStore(
+	t *testing.T, s *Store, pkg, sourceHash string,
+	linkingTo []string, linkingToKeys map[string]string, emit bool,
+) string {
+	t.Helper()
+	configHash := ConfigHash(linkingToKeys)
+	pkgPath := s.Path(pkg, sourceHash, configHash)
+	os.MkdirAll(pkgPath, 0o755)
+	os.WriteFile(filepath.Join(pkgPath, "DESCRIPTION"),
+		[]byte("Package: "+pkg+"\n"), 0o644)
+
+	configs := StoreConfigs{
+		LinkingTo: linkingTo,
+		Configs:   make(map[string]map[string]string),
+	}
+	if emit {
+		if linkingToKeys == nil {
+			linkingToKeys = map[string]string{}
+		}
+		configs.Configs[configHash] = linkingToKeys
+	}
+	if err := WriteStoreConfigs(s.ConfigsPath(pkg, sourceHash), configs); err != nil {
+		t.Fatal(err)
+	}
+	WriteConfigMeta(s.ConfigMetaPath(pkg, sourceHash, configHash), ConfigMeta{})
+	return configHash
+}
+
+// seedWorkerLib creates a package dir under refLib so hardlinkDir can
+// copy it into staging.
+func seedWorkerLib(t *testing.T, refLib, pkg string) {
+	t.Helper()
+	p := filepath.Join(refLib, pkg)
+	os.MkdirAll(p, 0o755)
+	os.WriteFile(filepath.Join(p, "DESCRIPTION"),
+		[]byte("Package: "+pkg+"\n"), 0o644)
+}
+
+// TestPopulateRuntime_NoRefManifest_AllNew exercises the fourth phase
+// (new/changed packages) with an empty refManifest: every package is
+// "new", just like the build-time path. Covers both store-hit and
+// store-miss arms.
+func TestPopulateRuntime_NoRefManifest_AllNew(t *testing.T) {
+	root := t.TempDir()
+	lib, refLib := t.TempDir(), t.TempDir()
+	s := NewStore(root)
+	s.SetPlatform("4.5-x86_64-pc-linux-gnu")
+
+	hit := makeEntry("rlang", "1.1.0", "rlang-sha")
+	miss := makeEntry("purrr", "1.0.0", "purrr-sha")
+	lf := &Lockfile{LockfileVersion: 1, Packages: []LockfileEntry{hit, miss}}
+
+	hitKey, _ := StoreKey(hit)
+	seedStore(t, s, "rlang", hitKey, nil, nil, true)
+
+	stats, err := s.PopulateRuntime(lf, lib, refLib, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Hits != 1 {
+		t.Errorf("Hits = %d, want 1", stats.Hits)
+	}
+	if stats.Misses != 1 {
+		t.Errorf("Misses = %d, want 1", stats.Misses)
+	}
+	if _, err := os.Stat(filepath.Join(lib, "rlang", "DESCRIPTION")); err != nil {
+		t.Error("hit package not populated into lib")
+	}
+}
+
+// TestPopulateRuntime_UnchangedNoLinkingTo verifies the "no LinkingTo"
+// short-circuit: a package whose source key matches refManifest and
+// has no LinkingTo deps is hardlinked directly from refLib.
+func TestPopulateRuntime_UnchangedNoLinkingTo(t *testing.T) {
+	root := t.TempDir()
+	lib, refLib := t.TempDir(), t.TempDir()
+	s := NewStore(root)
+	s.SetPlatform("4.5-x86_64-pc-linux-gnu")
+
+	entry := makeEntry("rlang", "1.1.0", "rlang-sha")
+	lf := &Lockfile{LockfileVersion: 1, Packages: []LockfileEntry{entry}}
+
+	sourceHash, _ := StoreKey(entry)
+	configHash := seedStore(t, s, "rlang", sourceHash, nil, nil, true)
+	seedWorkerLib(t, refLib, "rlang")
+
+	refManifest := map[string]string{"rlang": StoreRef(sourceHash, configHash)}
+
+	stats, err := s.PopulateRuntime(lf, lib, refLib, refManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Hits != 0 || stats.Misses != 0 || stats.ABIHits != 0 || stats.ABIRebuilds != 0 {
+		t.Errorf("unchanged no-linkingto: stats = %+v, want all zero", stats)
+	}
+	if _, err := os.Stat(filepath.Join(lib, "rlang", "DESCRIPTION")); err != nil {
+		t.Error("package not hardlinked from refLib")
+	}
+}
+
+// TestPopulateRuntime_UnchangedLinkingToUnchanged covers the branch
+// where the package has LinkingTo deps but none of them changed —
+// should still hardlink from refLib (no recompile needed).
+func TestPopulateRuntime_UnchangedLinkingToUnchanged(t *testing.T) {
+	root := t.TempDir()
+	lib, refLib := t.TempDir(), t.TempDir()
+	s := NewStore(root)
+	s.SetPlatform("4.5-x86_64-pc-linux-gnu")
+
+	rcpp := makeEntry("Rcpp", "1.0.12", "rcpp-sha")
+	rcppK, _ := StoreKey(rcpp)
+	seedStore(t, s, "Rcpp", rcppK, nil, nil, true)
+
+	consumer := makeEntry("s2", "1.1.0", "s2-sha")
+	consumerK, _ := StoreKey(consumer)
+	// s2 declares LinkingTo Rcpp; the stored config used Rcpp's key.
+	seedStore(t, s, "s2", consumerK,
+		[]string{"Rcpp"}, map[string]string{"Rcpp": rcppK}, true)
+	seedWorkerLib(t, refLib, "Rcpp")
+	seedWorkerLib(t, refLib, "s2")
+
+	lf := &Lockfile{LockfileVersion: 1, Packages: []LockfileEntry{rcpp, consumer}}
+	refManifest := map[string]string{
+		"Rcpp": StoreRef(rcppK, ConfigHash(nil)),
+		"s2":   StoreRef(consumerK, ConfigHash(map[string]string{"Rcpp": rcppK})),
+	}
+
+	stats, err := s.PopulateRuntime(lf, lib, refLib, refManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.ABIHits != 0 || stats.ABIRebuilds != 0 {
+		t.Errorf("expected no ABI action, got %+v", stats)
+	}
+}
+
+// TestPopulateRuntime_LinkingToChanged_ABIHit covers: the consumer is
+// unchanged but its LinkingTo dep (Rcpp) has a new source key. The
+// store has a matching config for the new key combo, so the consumer
+// is hardlinked from the store (ABIHit).
+func TestPopulateRuntime_LinkingToChanged_ABIHit(t *testing.T) {
+	root := t.TempDir()
+	lib, refLib := t.TempDir(), t.TempDir()
+	s := NewStore(root)
+	s.SetPlatform("4.5-x86_64-pc-linux-gnu")
+
+	// New Rcpp in the lockfile.
+	rcppNew := makeEntry("Rcpp", "1.1.0", "rcpp-new-sha")
+	rcppNewK, _ := StoreKey(rcppNew)
+	seedStore(t, s, "Rcpp", rcppNewK, nil, nil, true)
+
+	// Consumer's source key is unchanged, but refManifest carries the
+	// OLD Rcpp key — so changed[Rcpp]==true.
+	rcppOld := makeEntry("Rcpp", "1.0.0", "rcpp-old-sha")
+	rcppOldK, _ := StoreKey(rcppOld)
+
+	consumer := makeEntry("s2", "1.1.0", "s2-sha")
+	consumerK, _ := StoreKey(consumer)
+	// Emit a store config for s2 compiled against the NEW Rcpp key.
+	seedStore(t, s, "s2", consumerK,
+		[]string{"Rcpp"}, map[string]string{"Rcpp": rcppNewK}, true)
+
+	lf := &Lockfile{LockfileVersion: 1, Packages: []LockfileEntry{rcppNew, consumer}}
+	refManifest := map[string]string{
+		"Rcpp": StoreRef(rcppOldK, ConfigHash(nil)),
+		"s2":   StoreRef(consumerK, ConfigHash(map[string]string{"Rcpp": rcppOldK})),
+	}
+
+	stats, err := s.PopulateRuntime(lf, lib, refLib, refManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.ABIHits != 1 {
+		t.Errorf("ABIHits = %d, want 1", stats.ABIHits)
+	}
+	if stats.ABIRebuilds != 0 {
+		t.Errorf("ABIRebuilds = %d, want 0", stats.ABIRebuilds)
+	}
+	if _, err := os.Stat(filepath.Join(lib, "s2", "DESCRIPTION")); err != nil {
+		t.Error("ABI-updated consumer not linked into lib")
+	}
+}
+
+// TestPopulateRuntime_LinkingToChanged_ABIRebuild covers: consumer's
+// LinkingTo dep changed AND the store has no config for the new
+// key combo. Consumer is excluded (ABIRebuild) so pak can reinstall.
+func TestPopulateRuntime_LinkingToChanged_ABIRebuild(t *testing.T) {
+	root := t.TempDir()
+	lib, refLib := t.TempDir(), t.TempDir()
+	s := NewStore(root)
+	s.SetPlatform("4.5-x86_64-pc-linux-gnu")
+
+	rcppNew := makeEntry("Rcpp", "1.1.0", "rcpp-new-sha")
+	rcppNewK, _ := StoreKey(rcppNew)
+	seedStore(t, s, "Rcpp", rcppNewK, nil, nil, true)
+
+	rcppOld := makeEntry("Rcpp", "1.0.0", "rcpp-old-sha")
+	rcppOldK, _ := StoreKey(rcppOld)
+
+	consumer := makeEntry("s2", "1.1.0", "s2-sha")
+	consumerK, _ := StoreKey(consumer)
+	// Store has a configs.json referencing the OLD Rcpp key only, so
+	// the new key combo misses.
+	seedStore(t, s, "s2", consumerK,
+		[]string{"Rcpp"}, map[string]string{"Rcpp": rcppOldK}, true)
+
+	lf := &Lockfile{LockfileVersion: 1, Packages: []LockfileEntry{rcppNew, consumer}}
+	refManifest := map[string]string{
+		"Rcpp": StoreRef(rcppOldK, ConfigHash(nil)),
+		"s2":   StoreRef(consumerK, ConfigHash(map[string]string{"Rcpp": rcppOldK})),
+	}
+
+	stats, err := s.PopulateRuntime(lf, lib, refLib, refManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.ABIRebuilds != 1 {
+		t.Errorf("ABIRebuilds = %d, want 1", stats.ABIRebuilds)
+	}
+	if stats.ABIHits != 0 {
+		t.Errorf("ABIHits = %d, want 0", stats.ABIHits)
+	}
+	if _, err := os.Stat(filepath.Join(lib, "s2")); err == nil {
+		t.Error("consumer should be excluded from staging")
+	}
+}
+
+// TestPopulateRuntime_ChangedPackage_CacheHit covers the fourth phase
+// "changed" arm: the consumer's own source key changed and a matching
+// config exists in the store.
+func TestPopulateRuntime_ChangedPackage_CacheHit(t *testing.T) {
+	root := t.TempDir()
+	lib, refLib := t.TempDir(), t.TempDir()
+	s := NewStore(root)
+	s.SetPlatform("4.5-x86_64-pc-linux-gnu")
+
+	// New version of rlang in the lockfile.
+	newEntry := makeEntry("rlang", "1.1.0", "new-sha")
+	newK, _ := StoreKey(newEntry)
+	seedStore(t, s, "rlang", newK, nil, nil, true)
+
+	// refManifest holds the OLD key → changed[rlang]==true.
+	oldEntry := makeEntry("rlang", "1.0.0", "old-sha")
+	oldK, _ := StoreKey(oldEntry)
+
+	lf := &Lockfile{LockfileVersion: 1, Packages: []LockfileEntry{newEntry}}
+	refManifest := map[string]string{
+		"rlang": StoreRef(oldK, ConfigHash(nil)),
+	}
+
+	stats, err := s.PopulateRuntime(lf, lib, refLib, refManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Hits != 1 {
+		t.Errorf("Hits = %d, want 1", stats.Hits)
+	}
+}
+
+// TestPopulateRuntime_AlreadyInStaging skips packages that are already
+// present in the staging lib (idempotency safeguard).
+func TestPopulateRuntime_AlreadyInStaging(t *testing.T) {
+	root := t.TempDir()
+	lib, refLib := t.TempDir(), t.TempDir()
+	s := NewStore(root)
+	s.SetPlatform("4.5-x86_64-pc-linux-gnu")
+
+	entry := makeEntry("rlang", "1.1.0", "rlang-sha")
+	lf := &Lockfile{LockfileVersion: 1, Packages: []LockfileEntry{entry}}
+
+	// Both unchanged-in-refManifest and pre-staged — should be skipped.
+	os.MkdirAll(filepath.Join(lib, "rlang"), 0o755)
+	sourceHash, _ := StoreKey(entry)
+	refManifest := map[string]string{
+		"rlang": StoreRef(sourceHash, ConfigHash(nil)),
+	}
+
+	stats, err := s.PopulateRuntime(lf, lib, refLib, refManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Hits != 0 || stats.Misses != 0 || stats.ABIHits != 0 || stats.ABIRebuilds != 0 {
+		t.Errorf("expected zero stats for pre-staged package, got %+v", stats)
+	}
+}
+
+// TestPopulateRuntime_SkipsMetaEntries ensures pak pseudo-packages
+// (deps::/app, local::/lib) are ignored by the runtime populate path.
+func TestPopulateRuntime_SkipsMetaEntries(t *testing.T) {
+	root := t.TempDir()
+	lib, refLib := t.TempDir(), t.TempDir()
+	s := NewStore(root)
+	s.SetPlatform("4.5-x86_64-pc-linux-gnu")
+
+	lf := &Lockfile{
+		LockfileVersion: 1,
+		Packages: []LockfileEntry{
+			{Package: "deps::/app", Type: "deps"},
+			{Package: "local::/lib", Type: "local"},
+		},
+	}
+
+	stats, err := s.PopulateRuntime(lf, lib, refLib, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Hits != 0 || stats.Misses != 0 || stats.ABIHits != 0 || stats.ABIRebuilds != 0 {
+		t.Errorf("expected zero stats for meta-only lockfile, got %+v", stats)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // IngestPackages
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- `cmd/by/login.go`: subprocess integration tests for the login RunE — server flag / stdin prompts, JSON output, and the three error exits. Function coverage ~7% → 97%.
- `cmd/by/selfupdate.go`: main-channel + inferred-channel paths and four `downloadAsset` error branches. Weighted coverage ~50% → ~60%.
- `internal/pkgstore/populate.go`: eight subtests for `PopulateRuntime` covering all four algorithm arms (no-refManifest, unchanged ± LinkingTo changes, changed package). `PopulateRuntime` 0% → 91%.
- Locally observed +0.91pp total coverage vs `c97568c`; ratchets `ci.yml` `-min-total` / `-min-patch` from 75 → 76.

Fixes #328