### PR TITLE
test(process): cover blockyard startup wiring via testable helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
       # instrumentation those stale entries get merged with fresh
       # entries from packages that did change, producing two block
       # sets for the same source file and a misleadingly low total.
-      - run: go test -count=1 -coverprofile=coverage-unit.out -coverpkg=./internal/...,./cmd/by/...,./cmd/blockyard/... ./internal/... ./cmd/...
+      - run: go test -count=1 -coverprofile=coverage-unit.out -coverpkg=./internal/...,./cmd/by/... ./internal/... ./cmd/...
       - uses: actions/upload-artifact@v7
         with:
           name: coverage-unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
       # instrumentation those stale entries get merged with fresh
       # entries from packages that did change, producing two block
       # sets for the same source file and a misleadingly low total.
-      - run: go test -count=1 -coverprofile=coverage-unit.out -coverpkg=./internal/...,./cmd/by/... ./internal/... ./cmd/...
+      - run: go test -count=1 -coverprofile=coverage-unit.out -coverpkg=./internal/...,./cmd/by/...,./cmd/blockyard/... ./internal/... ./cmd/...
       - uses: actions/upload-artifact@v7
         with:
           name: coverage-unit

--- a/cmd/blockyard/drainer_process_test.go
+++ b/cmd/blockyard/drainer_process_test.go
@@ -1,0 +1,43 @@
+//go:build !minimal || process_backend
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cynkra/blockyard/internal/backend/process"
+	"github.com/cynkra/blockyard/internal/config"
+)
+
+// Process-backend branch of finishIdleWaitForBackend: default is 5
+// minutes when cfg.Update is nil or DrainIdleWait is zero, otherwise
+// the configured value. Guards the rolling-update correctness rule
+// that workers get a chance to finish local sessions before
+// Pdeathsig tears them down.
+func TestFinishIdleWaitForBackend_Process(t *testing.T) {
+	be := &process.ProcessBackend{}
+
+	t.Run("no cfg.Update section — defaults to 5m", func(t *testing.T) {
+		cfg := &config.Config{}
+		if got := finishIdleWaitForBackend(be, cfg); got != 5*time.Minute {
+			t.Errorf("finishIdleWaitForBackend(process, no-update) = %v, want 5m", got)
+		}
+	})
+
+	t.Run("zero DrainIdleWait — defaults to 5m", func(t *testing.T) {
+		cfg := &config.Config{Update: &config.UpdateConfig{}}
+		if got := finishIdleWaitForBackend(be, cfg); got != 5*time.Minute {
+			t.Errorf("finishIdleWaitForBackend(process, zero) = %v, want 5m", got)
+		}
+	})
+
+	t.Run("explicit DrainIdleWait — honoured verbatim", func(t *testing.T) {
+		cfg := &config.Config{Update: &config.UpdateConfig{
+			DrainIdleWait: config.Duration{Duration: 90 * time.Second},
+		}}
+		if got := finishIdleWaitForBackend(be, cfg); got != 90*time.Second {
+			t.Errorf("finishIdleWaitForBackend(process, 90s) = %v, want 90s", got)
+		}
+	})
+}

--- a/cmd/blockyard/main.go
+++ b/cmd/blockyard/main.go
@@ -36,9 +36,7 @@ import (
 	"github.com/cynkra/blockyard/internal/preflight"
 	"github.com/cynkra/blockyard/internal/proxy"
 	"github.com/cynkra/blockyard/internal/redisstate"
-	"github.com/cynkra/blockyard/internal/registry"
 	"github.com/cynkra/blockyard/internal/server"
-	"github.com/cynkra/blockyard/internal/session"
 	"github.com/cynkra/blockyard/internal/telemetry"
 	"github.com/cynkra/blockyard/internal/update"
 )
@@ -449,38 +447,12 @@ func main() {
 	mode := config.ResolveSessionStoreMode(cfg)
 	registryTTL := 3 * cfg.Proxy.HealthInterval.Duration
 	idleTTL := cfg.Proxy.SessionIdleTTL.Duration
-	var pgSessions *session.PostgresStore
-	var pgWorkers *server.PostgresWorkerMap
-	switch mode {
-	case config.SessionStoreMemory:
-		srv.Registry = registry.NewMemoryRegistry()
-		srv.Workers = server.NewMemoryWorkerMap()
-		srv.Sessions = session.NewMemoryStore()
-	case config.SessionStoreRedis:
-		srv.Registry = registry.NewRedisRegistry(rc, registryTTL)
-		srv.Workers = server.NewRedisWorkerMap(rc, serverID)
-		srv.Sessions = session.NewRedisStore(rc, idleTTL)
-	case config.SessionStorePostgres:
-		srv.Registry = registry.NewPostgresRegistry(database.DB, registryTTL)
-		pgWorkers = server.NewPostgresWorkerMap(database.DB, serverID)
-		srv.Workers = pgWorkers
-		pgSessions = session.NewPostgresStore(database.DB, idleTTL)
-		srv.Sessions = pgSessions
-	case config.SessionStoreLayered:
-		srv.Registry = registry.NewLayeredRegistry(
-			registry.NewPostgresRegistry(database.DB, registryTTL),
-			registry.NewRedisRegistry(rc, registryTTL),
-		)
-		pgWorkers = server.NewPostgresWorkerMap(database.DB, serverID)
-		srv.Workers = server.NewLayeredWorkerMap(
-			pgWorkers,
-			server.NewRedisWorkerMap(rc, serverID),
-		)
-		pgSessions = session.NewPostgresStore(database.DB, idleTTL)
-		srv.Sessions = session.NewLayeredStore(
-			pgSessions, session.NewRedisStore(rc, idleTTL),
-		)
-	}
+	stores := buildSharedStateStores(mode, rc, database.DB, serverID, registryTTL, idleTTL)
+	srv.Registry = stores.Registry
+	srv.Workers = stores.Workers
+	srv.Sessions = stores.Sessions
+	pgSessions := stores.PGSessions
+	pgWorkers := stores.PGWorkers
 	if rc != nil {
 		srv.RedisClient = rc
 		slog.Info("using redis for shared state",

--- a/cmd/blockyard/main_test.go
+++ b/cmd/blockyard/main_test.go
@@ -95,9 +95,11 @@ func TestRandomNonceHex(t *testing.T) {
 
 	// Two draws should differ with overwhelming probability. Colliding
 	// would mean crypto/rand returned the same bytes twice — a signal
-	// something is very wrong, not a flake to tolerate.
-	if randomNonceHex(8) == randomNonceHex(8) {
-		t.Error("two 8-byte nonces collided")
+	// something is very wrong, not a flake to tolerate. Bound each call
+	// to its own local so staticcheck does not flag this as SA4000.
+	a, b := randomNonceHex(8), randomNonceHex(8)
+	if a == b {
+		t.Errorf("two 8-byte nonces collided: %q", a)
 	}
 }
 

--- a/cmd/blockyard/main_test.go
+++ b/cmd/blockyard/main_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"encoding/hex"
 	"net"
 	"strings"
 	"testing"
+
+	"github.com/cynkra/blockyard/internal/config"
 )
 
 // runProbe is security-critical: checkWorkerEgress trusts its exit
@@ -75,5 +78,92 @@ func TestRunBwrapSmokeUnknownFlag(t *testing.T) {
 	err := runBwrapSmoke([]string{"--bogus"})
 	if err == nil {
 		t.Error("expected parse error for unknown flag")
+	}
+}
+
+func TestRandomNonceHex(t *testing.T) {
+	// Length output = 2*n hex chars; decodes back to n bytes.
+	for _, n := range []int{1, 4, 8, 16} {
+		s := randomNonceHex(n)
+		if len(s) != 2*n {
+			t.Errorf("randomNonceHex(%d) len = %d, want %d", n, len(s), 2*n)
+		}
+		if _, err := hex.DecodeString(s); err != nil {
+			t.Errorf("randomNonceHex(%d) = %q not hex: %v", n, s, err)
+		}
+	}
+
+	// Two draws should differ with overwhelming probability. Colliding
+	// would mean crypto/rand returned the same bytes twice — a signal
+	// something is very wrong, not a flake to tolerate.
+	if randomNonceHex(8) == randomNonceHex(8) {
+		t.Error("two 8-byte nonces collided")
+	}
+}
+
+func TestMaskRedisPassword(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "plain — no credentials, passthrough",
+			in:   "redis://localhost:6379/0",
+			want: "redis://localhost:6379/0",
+		},
+		{
+			name: "user only — no password to mask",
+			in:   "redis://user@localhost:6379/0",
+			want: "redis://user@localhost:6379/0",
+		},
+		{
+			// net/url percent-encodes reserved chars in the password
+			// position — *** → %2A%2A%2A. Downstream consumers render
+			// this via slog so the encoded form is what operators see.
+			name: "user+password — password redacted, user preserved",
+			in:   "redis://user:secret@localhost:6379/0",
+			want: "redis://user:%2A%2A%2A@localhost:6379/0",
+		},
+		{
+			name: "empty-user password — edge case still masked",
+			in:   "redis://:secret@localhost:6379/0",
+			want: "redis://:%2A%2A%2A@localhost:6379/0",
+		},
+		{
+			name: "unparseable — returned verbatim rather than erroring",
+			in:   "not a url :: at all",
+			want: "not a url :: at all",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := maskRedisPassword(tc.in)
+			if got != tc.want {
+				t.Errorf("maskRedisPassword(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// finishIdleWaitForBackend branches on the concrete backend type. The
+// nil-backend case covers the fall-through arm; the process-backend
+// cases are covered in drainer_process_test.go where a real
+// *process.ProcessBackend is in scope.
+func TestFinishIdleWaitForBackend_NilReturnsZero(t *testing.T) {
+	cfg := &config.Config{}
+	if got := finishIdleWaitForBackend(nil, cfg); got != 0 {
+		t.Errorf("finishIdleWaitForBackend(nil, _) = %v, want 0", got)
+	}
+}
+
+// newServerFactory asks each registered candidate whether it matches
+// the backend; nil matches no one, so the function should return nil.
+// Proves the dispatch loop terminates cleanly instead of panicking on
+// an empty type assertion.
+func TestNewServerFactory_NilBackendReturnsNil(t *testing.T) {
+	cfg := &config.Config{}
+	if got := newServerFactory(nil, cfg, nil); got != nil {
+		t.Errorf("newServerFactory(_, _, nil) = %v, want nil", got)
 	}
 }

--- a/cmd/blockyard/stores.go
+++ b/cmd/blockyard/stores.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"time"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/cynkra/blockyard/internal/config"
+	"github.com/cynkra/blockyard/internal/redisstate"
+	"github.com/cynkra/blockyard/internal/registry"
+	"github.com/cynkra/blockyard/internal/server"
+	"github.com/cynkra/blockyard/internal/session"
+)
+
+// sharedStateStores groups the registry, worker map, and session store
+// constructed for a given shared-state mode. The two *Postgres* fields
+// are exposed separately so callers can start the per-store background
+// workers (RunExpiry, RunReaper) without type-asserting the interface
+// values.
+type sharedStateStores struct {
+	Registry   registry.WorkerRegistry
+	Workers    server.WorkerMap
+	Sessions   session.Store
+	PGSessions *session.PostgresStore
+	PGWorkers  *server.PostgresWorkerMap
+}
+
+// buildSharedStateStores constructs the registry / worker map /
+// session store triple for the given mode. Split out of main() so
+// each mode's wiring is exercised directly by tests instead of by a
+// full server boot. Callers do the post-construction bookkeeping
+// (assigning onto *server.Server, spawning Postgres expiry/reaper
+// goroutines) themselves.
+//
+// Unknown modes fall through to in-memory — config.Validate bounds
+// the set to memory/redis/postgres/layered (plus "" which resolves to
+// one of them), so the default arm only fires on a programming bug.
+func buildSharedStateStores(
+	mode config.SessionStoreMode,
+	rc *redisstate.Client,
+	pgDB *sqlx.DB,
+	serverID string,
+	registryTTL, idleTTL time.Duration,
+) sharedStateStores {
+	switch mode {
+	case config.SessionStoreRedis:
+		return sharedStateStores{
+			Registry: registry.NewRedisRegistry(rc, registryTTL),
+			Workers:  server.NewRedisWorkerMap(rc, serverID),
+			Sessions: session.NewRedisStore(rc, idleTTL),
+		}
+	case config.SessionStorePostgres:
+		pgW := server.NewPostgresWorkerMap(pgDB, serverID)
+		pgS := session.NewPostgresStore(pgDB, idleTTL)
+		return sharedStateStores{
+			Registry:   registry.NewPostgresRegistry(pgDB, registryTTL),
+			Workers:    pgW,
+			Sessions:   pgS,
+			PGSessions: pgS,
+			PGWorkers:  pgW,
+		}
+	case config.SessionStoreLayered:
+		pgW := server.NewPostgresWorkerMap(pgDB, serverID)
+		pgS := session.NewPostgresStore(pgDB, idleTTL)
+		return sharedStateStores{
+			Registry: registry.NewLayeredRegistry(
+				registry.NewPostgresRegistry(pgDB, registryTTL),
+				registry.NewRedisRegistry(rc, registryTTL),
+			),
+			Workers: server.NewLayeredWorkerMap(
+				pgW, server.NewRedisWorkerMap(rc, serverID),
+			),
+			Sessions: session.NewLayeredStore(
+				pgS, session.NewRedisStore(rc, idleTTL),
+			),
+			PGSessions: pgS,
+			PGWorkers:  pgW,
+		}
+	default:
+		return sharedStateStores{
+			Registry: registry.NewMemoryRegistry(),
+			Workers:  server.NewMemoryWorkerMap(),
+			Sessions: session.NewMemoryStore(),
+		}
+	}
+}

--- a/cmd/blockyard/stores_test.go
+++ b/cmd/blockyard/stores_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+
+	"github.com/cynkra/blockyard/internal/config"
+	"github.com/cynkra/blockyard/internal/redisstate"
+	"github.com/cynkra/blockyard/internal/registry"
+	"github.com/cynkra/blockyard/internal/server"
+	"github.com/cynkra/blockyard/internal/session"
+)
+
+// buildSharedStateStores is the single place where the SessionStore
+// mode chooses concrete registry / worker map / session store
+// implementations. Each mode's branch is validated here so adding a
+// new backend triple has a failure pattern that doesn't require a
+// full server boot.
+
+func TestBuildSharedStateStores_Memory(t *testing.T) {
+	stores := buildSharedStateStores(
+		config.SessionStoreMemory,
+		nil, nil, "srv-A",
+		30*time.Second, 2*time.Minute,
+	)
+
+	if _, ok := stores.Registry.(*registry.MemoryRegistry); !ok {
+		t.Errorf("Registry = %T, want *MemoryRegistry", stores.Registry)
+	}
+	if _, ok := stores.Workers.(*server.MemoryWorkerMap); !ok {
+		t.Errorf("Workers = %T, want *MemoryWorkerMap", stores.Workers)
+	}
+	if _, ok := stores.Sessions.(*session.MemoryStore); !ok {
+		t.Errorf("Sessions = %T, want *MemoryStore", stores.Sessions)
+	}
+	if stores.PGSessions != nil {
+		t.Error("PGSessions should be nil in memory mode")
+	}
+	if stores.PGWorkers != nil {
+		t.Error("PGWorkers should be nil in memory mode")
+	}
+}
+
+// Unknown modes must not panic; buildSharedStateStores treats them as
+// memory (config.Validate gates the input).
+func TestBuildSharedStateStores_UnknownDefaultsToMemory(t *testing.T) {
+	stores := buildSharedStateStores(
+		config.SessionStoreMode("unexpected"),
+		nil, nil, "srv-A",
+		30*time.Second, 2*time.Minute,
+	)
+
+	if _, ok := stores.Registry.(*registry.MemoryRegistry); !ok {
+		t.Errorf("Registry = %T, want *MemoryRegistry", stores.Registry)
+	}
+	if _, ok := stores.Workers.(*server.MemoryWorkerMap); !ok {
+		t.Errorf("Workers = %T, want *MemoryWorkerMap", stores.Workers)
+	}
+	if _, ok := stores.Sessions.(*session.MemoryStore); !ok {
+		t.Errorf("Sessions = %T, want *MemoryStore", stores.Sessions)
+	}
+}
+
+func TestBuildSharedStateStores_Redis(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rc := redisstate.TestClient(t, mr.Addr())
+
+	stores := buildSharedStateStores(
+		config.SessionStoreRedis,
+		rc, nil, "srv-A",
+		30*time.Second, 2*time.Minute,
+	)
+
+	if _, ok := stores.Registry.(*registry.RedisRegistry); !ok {
+		t.Errorf("Registry = %T, want *RedisRegistry", stores.Registry)
+	}
+	if _, ok := stores.Workers.(*server.RedisWorkerMap); !ok {
+		t.Errorf("Workers = %T, want *RedisWorkerMap", stores.Workers)
+	}
+	if _, ok := stores.Sessions.(*session.RedisStore); !ok {
+		t.Errorf("Sessions = %T, want *RedisStore", stores.Sessions)
+	}
+	if stores.PGSessions != nil {
+		t.Error("PGSessions should be nil in redis mode")
+	}
+	if stores.PGWorkers != nil {
+		t.Error("PGWorkers should be nil in redis mode")
+	}
+}
+
+// Postgres mode wiring is exercised by type assertions; the
+// Postgres{Registry,WorkerMap,Store} constructors only capture the
+// *sqlx.DB pointer, so passing nil here is safe. The database is
+// never dereferenced by the wiring itself — only by later method
+// calls.
+func TestBuildSharedStateStores_Postgres(t *testing.T) {
+	stores := buildSharedStateStores(
+		config.SessionStorePostgres,
+		nil, nil, "srv-A",
+		30*time.Second, 2*time.Minute,
+	)
+
+	if _, ok := stores.Registry.(*registry.PostgresRegistry); !ok {
+		t.Errorf("Registry = %T, want *PostgresRegistry", stores.Registry)
+	}
+	if _, ok := stores.Workers.(*server.PostgresWorkerMap); !ok {
+		t.Errorf("Workers = %T, want *PostgresWorkerMap", stores.Workers)
+	}
+	if _, ok := stores.Sessions.(*session.PostgresStore); !ok {
+		t.Errorf("Sessions = %T, want *PostgresStore", stores.Sessions)
+	}
+	if stores.PGSessions == nil {
+		t.Error("PGSessions should be non-nil so main() can start RunExpiry")
+	}
+	if stores.PGWorkers == nil {
+		t.Error("PGWorkers should be non-nil so main() can start RunReaper")
+	}
+	// The interface and the *Postgres* fields must point at the same
+	// instance — main() uses the latter to start RunExpiry/RunReaper
+	// on the value exposed as the former.
+	if stores.Sessions != session.Store(stores.PGSessions) {
+		t.Error("Sessions and PGSessions must be the same instance")
+	}
+	if stores.Workers != server.WorkerMap(stores.PGWorkers) {
+		t.Error("Workers and PGWorkers must be the same instance")
+	}
+}
+
+func TestBuildSharedStateStores_Layered(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rc := redisstate.TestClient(t, mr.Addr())
+
+	stores := buildSharedStateStores(
+		config.SessionStoreLayered,
+		rc, nil, "srv-A",
+		30*time.Second, 2*time.Minute,
+	)
+
+	if _, ok := stores.Registry.(*registry.LayeredRegistry); !ok {
+		t.Errorf("Registry = %T, want *LayeredRegistry", stores.Registry)
+	}
+	if _, ok := stores.Workers.(*server.LayeredWorkerMap); !ok {
+		t.Errorf("Workers = %T, want *LayeredWorkerMap", stores.Workers)
+	}
+	if _, ok := stores.Sessions.(*session.LayeredStore); !ok {
+		t.Errorf("Sessions = %T, want *LayeredStore", stores.Sessions)
+	}
+	// Layered mode still exposes PGSessions/PGWorkers so main() can
+	// drive the Postgres-only background loops (RunExpiry, RunReaper)
+	// against the primary tier — the Redis tier is a cache and needs
+	// neither.
+	if stores.PGSessions == nil {
+		t.Error("PGSessions should be non-nil in layered mode")
+	}
+	if stores.PGWorkers == nil {
+		t.Error("PGWorkers should be non-nil in layered mode")
+	}
+}


### PR DESCRIPTION
## Summary
- Extract the SessionStore/Registry/WorkerMap switch from main() into buildSharedStateStores so each mode's wiring is drivable without a full server boot.
- Add unit tests for all four shared-state modes (memory, redis, postgres, layered), plus coverage for randomNonceHex, maskRedisPassword, finishIdleWaitForBackend, and newServerFactory.
- Include cmd/blockyard in the unit job's -coverpkg so the new tests land in merged coverage; ratchet stays at 75 until phases 1-3 (#328, #329, #330) close the gap to 80.

Fixes #331