### PR TITLE
feat(misc): support custom CA cert for vault TLS trust

### DIFF
--- a/cmd/blockyard/main.go
+++ b/cmd/blockyard/main.go
@@ -228,16 +228,22 @@ func main() {
 	if cfg.Vault != nil {
 		tokenFilePath := cfg.Vault.TokenFile
 
+		vaultHTTPClient, err := integration.NewHTTPClient(cfg.Vault.CACert)
+		if err != nil {
+			slog.Error("vault http client", "error", err)
+			os.Exit(1)
+		}
+
 		if cfg.Vault.RoleID != "" {
 			// AppRole auth flow.
-			token, ttl, err := integration.InitAppRole(context.Background(), cfg.Vault.Address, cfg.Vault.RoleID, tokenFilePath)
+			token, ttl, err := integration.InitAppRole(context.Background(), vaultHTTPClient, cfg.Vault.Address, cfg.Vault.RoleID, tokenFilePath)
 			if err != nil {
 				slog.Error("vault authentication failed", "error", err)
 				os.Exit(1)
 			}
 
 			// Start token renewal goroutine.
-			renewer := integration.NewTokenRenewer(cfg.Vault.Address, token, tokenFilePath)
+			renewer := integration.NewTokenRenewer(cfg.Vault.Address, token, tokenFilePath).WithHTTPClient(vaultHTTPClient)
 			vaultAdminToken = renewer.Token
 			vaultTokenHealthy = renewer.Healthy
 
@@ -251,7 +257,7 @@ func main() {
 			vaultAdminToken = cfg.Vault.AdminToken.MustExpose
 		}
 
-		vaultClient = integration.NewClient(cfg.Vault.Address, vaultAdminToken)
+		vaultClient = integration.NewClient(cfg.Vault.Address, vaultAdminToken).WithHTTPClient(vaultHTTPClient)
 		vaultTokenCache = integration.NewVaultTokenCache()
 
 		// Resolve vault references in config (e.g. "vault:path#key").

--- a/docs/content/docs/reference/config.md
+++ b/docs/content/docs/reference/config.md
@@ -411,6 +411,7 @@ jwt_auth_path = "jwt"
 | `token_ttl` | `duration` | `1h` | No | TTL for issued credential tokens |
 | `jwt_auth_path` | `string` | `jwt` | No | Auth method mount path in the vault |
 | `token_file` | `string` | `/data/.vault-token` | No | Path where the persisted AppRole token is stored. The parent directory must be writable. |
+| `ca_cert` | `string` | — | No | Path to a PEM-encoded CA bundle used to verify the vault server's TLS certificate. When set, replaces the system CA bundle for vault HTTP calls (matches `VAULT_CACERT` semantics). Overridable via `BLOCKYARD_VAULT_CA_CERT`. |
 | `skip_policy_scope_check` | `boolean` | `false` | No | Skip the policy scope check during vault bootstrap. Useful when the vault policy format differs from what Blockyard expects. |
 
 > [!TIP]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -286,6 +286,7 @@ type VaultConfig struct {
 	TokenTTL             Duration        `toml:"token_ttl"`                // default: 1h
 	JWTAuthPath          string          `toml:"jwt_auth_path"`            // default: "jwt"
 	TokenFile            string          `toml:"token_file"`               // persisted vault token path; default: "/data/.vault-token"
+	CACert               string          `toml:"ca_cert"`                  // path to PEM file; when set, replaces system CA trust for vault HTTP calls
 	SkipPolicyScopeCheck bool            `toml:"skip_policy_scope_check"`
 	Services             []ServiceConfig `toml:"services"`
 }

--- a/internal/integration/approle.go
+++ b/internal/integration/approle.go
@@ -58,9 +58,12 @@ func AppRoleLogin(ctx context.Context, httpClient *http.Client, addr, roleID, se
 
 // InitAppRole authenticates to vault using AppRole. It first tries
 // a persisted token (renew-self), then falls back to AppRole login with
-// secret_id from the environment.
-func InitAppRole(ctx context.Context, addr, roleID, tokenFile string) (token string, ttl time.Duration, err error) {
-	httpClient := &http.Client{}
+// secret_id from the environment. Pass nil for httpClient to use the
+// default (system CA trust, 10s timeout).
+func InitAppRole(ctx context.Context, httpClient *http.Client, addr, roleID, tokenFile string) (token string, ttl time.Duration, err error) {
+	if httpClient == nil {
+		httpClient = DefaultHTTPClient()
+	}
 
 	// 1. Try persisted token.
 	persisted, err := ReadTokenFile(tokenFile)

--- a/internal/integration/httpclient.go
+++ b/internal/integration/httpclient.go
@@ -1,0 +1,44 @@
+package integration
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+// DefaultHTTPClient returns the http.Client used by vault integration
+// calls when no custom client is configured: 10s timeout, system CA
+// trust. Exposed so callers (renewer, approle login) can opt in to the
+// same defaults.
+func DefaultHTTPClient() *http.Client {
+	return &http.Client{Timeout: 10 * time.Second}
+}
+
+// NewHTTPClient returns an *http.Client suitable for vault HTTP calls.
+// When caCertPath is empty, the returned client uses Go's default TLS
+// trust (the system CA bundle). When caCertPath points at a PEM file,
+// the returned client trusts only certificates chaining to that bundle
+// — matching vault's own VAULT_CACERT semantics. Operators who need to
+// keep public-CA trust alongside a private CA must concatenate the
+// bundles themselves.
+func NewHTTPClient(caCertPath string) (*http.Client, error) {
+	client := DefaultHTTPClient()
+	if caCertPath == "" {
+		return client, nil
+	}
+	pem, err := os.ReadFile(caCertPath) //nolint:gosec // G304: operator-provided path
+	if err != nil {
+		return nil, fmt.Errorf("vault ca_cert: read %s: %w", caCertPath, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("vault ca_cert: no valid PEM certificates in %s", caCertPath)
+	}
+	client.Transport = &http.Transport{
+		TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12},
+	}
+	return client, nil
+}

--- a/internal/integration/httpclient_test.go
+++ b/internal/integration/httpclient_test.go
@@ -68,6 +68,22 @@ func TestNewHTTPClient_NotPEM(t *testing.T) {
 	}
 }
 
+func TestClient_WithHTTPClient(t *testing.T) {
+	custom := &http.Client{Timeout: 1 * time.Second}
+	c := NewClient("http://vault", func() string { return "" }).WithHTTPClient(custom)
+	if c.httpClient != custom {
+		t.Errorf("WithHTTPClient did not replace httpClient")
+	}
+}
+
+func TestTokenRenewer_WithHTTPClient(t *testing.T) {
+	custom := &http.Client{Timeout: 1 * time.Second}
+	r := NewTokenRenewer("http://vault", "tok", "").WithHTTPClient(custom)
+	if r.httpClient != custom {
+		t.Errorf("WithHTTPClient did not replace httpClient")
+	}
+}
+
 func writeCert(t *testing.T, cert *x509.Certificate) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "ca.pem")

--- a/internal/integration/httpclient_test.go
+++ b/internal/integration/httpclient_test.go
@@ -1,0 +1,83 @@
+package integration
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewHTTPClient_NoPath(t *testing.T) {
+	c, err := NewHTTPClient("")
+	if err != nil {
+		t.Fatalf("NewHTTPClient(\"\"): %v", err)
+	}
+	if c.Timeout != 10*time.Second {
+		t.Errorf("timeout = %v, want 10s", c.Timeout)
+	}
+	if c.Transport != nil {
+		t.Errorf("Transport = %v, want nil (default)", c.Transport)
+	}
+}
+
+func TestNewHTTPClient_ValidCA(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	caPath := writeCert(t, srv.Certificate())
+
+	c, err := NewHTTPClient(caPath)
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+
+	resp, err := c.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("GET with custom CA: %v", err)
+	}
+	resp.Body.Close()
+
+	// Default client (system CAs only) must reject the self-signed cert.
+	if _, err := DefaultHTTPClient().Get(srv.URL); err == nil {
+		t.Error("default client unexpectedly trusted self-signed cert")
+	}
+}
+
+func TestNewHTTPClient_MissingFile(t *testing.T) {
+	_, err := NewHTTPClient("/does/not/exist.pem")
+	if err == nil || !strings.Contains(err.Error(), "read") {
+		t.Fatalf("err = %v, want 'read' error", err)
+	}
+}
+
+func TestNewHTTPClient_NotPEM(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "junk.pem")
+	if err := os.WriteFile(path, []byte("not a pem file"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := NewHTTPClient(path)
+	if err == nil || !strings.Contains(err.Error(), "no valid PEM") {
+		t.Fatalf("err = %v, want 'no valid PEM' error", err)
+	}
+}
+
+func writeCert(t *testing.T, cert *x509.Certificate) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/integration/renew.go
+++ b/internal/integration/renew.go
@@ -20,15 +20,24 @@ type TokenRenewer struct {
 }
 
 // NewTokenRenewer creates a TokenRenewer with the given initial token.
-// The token is immediately marked as healthy.
+// The token is immediately marked as healthy. The underlying http.Client
+// uses system CA trust and a 10s timeout; call WithHTTPClient to
+// override (e.g. for a private CA).
 func NewTokenRenewer(addr, initialToken, tokenFile string) *TokenRenewer {
 	r := &TokenRenewer{
 		addr:       addr,
-		httpClient: &http.Client{Timeout: 10 * time.Second},
+		httpClient: DefaultHTTPClient(),
 		tokenFile:  tokenFile,
 	}
 	r.token.Store(initialToken)
 	r.healthy.Store(true)
+	return r
+}
+
+// WithHTTPClient replaces the underlying http.Client. Returns the
+// receiver to allow chaining from NewTokenRenewer.
+func (r *TokenRenewer) WithHTTPClient(h *http.Client) *TokenRenewer {
+	r.httpClient = h
 	return r
 }
 

--- a/internal/integration/vault.go
+++ b/internal/integration/vault.go
@@ -28,13 +28,21 @@ type Client struct {
 
 // NewClient creates a new vault client. The adminToken is retrieved
 // via a callback to avoid holding the plaintext value in a long-lived
-// struct field.
+// struct field. The underlying http.Client uses system CA trust and a
+// 10s timeout; call WithHTTPClient to override (e.g. for a private CA).
 func NewClient(addr string, adminTokenFunc func() string) *Client {
 	return &Client{
 		addr:           strings.TrimRight(addr, "/"),
 		adminTokenFunc: adminTokenFunc,
-		httpClient:     &http.Client{Timeout: 10 * time.Second},
+		httpClient:     DefaultHTTPClient(),
 	}
+}
+
+// WithHTTPClient replaces the underlying http.Client. Returns the
+// receiver to allow chaining from NewClient.
+func (c *Client) WithHTTPClient(h *http.Client) *Client {
+	c.httpClient = h
+	return c
 }
 
 // Addr returns the vault server address.


### PR DESCRIPTION
## Summary
- New `[vault].ca_cert` / `BLOCKYARD_VAULT_CA_CERT` knob for pinning a private CA on vault
- Shared `integration.NewHTTPClient` applied to all three vault http.Clients (client, AppRole login, renewer) — `SSL_CERT_FILE` bundle workaround no longer needed
- `WithHTTPClient` on `Client` and `TokenRenewer` keeps test call sites untouched
- Docs: new row in `[vault]` reference table

Fixes #257