### PR TITLE
test(misc): cover backend error paths for phase 2 coverage bump

### DIFF
--- a/internal/backend/docker/preflight_modes_test.go
+++ b/internal/backend/docker/preflight_modes_test.go
@@ -1,0 +1,94 @@
+//go:build docker_test
+
+package docker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cynkra/blockyard/internal/preflight"
+)
+
+// TestCheckROBindVisibility_BindMode hits the MountModeBind switch
+// branch inside checkROBindVisibility that translates the host-side
+// temp directory via MountConfig.ToHostPath.
+//
+// This complements the existing Native-mode test at
+// preflight_test.go:TestCheckROBindVisibility.
+func TestCheckROBindVisibility_BindMode(t *testing.T) {
+	cli := testDockerClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	storePath := t.TempDir()
+	ensureAlpine(t, ctx, cli)
+
+	d := newPreflightTestBackend(t, cli, "alpine:latest", MountModeBind)
+	// Configure the mount translation so HostPath(serverPath) passes
+	// unchanged — storePath is already the host path in this test
+	// environment, and ToHostPath(MountDest + subpath) = HostSource +
+	// subpath. With both set equal to storePath, the translation is a
+	// no-op and the check exercises the bind-mount code path without
+	// relying on a real mount-point discovery.
+	d.mountCfg.HostSource = storePath
+	d.mountCfg.MountDest = storePath
+	deps := PreflightDeps{StorePath: storePath}
+
+	res := checkROBindVisibility(ctx, d, deps)
+	if res.Severity != preflight.SeverityOK {
+		t.Errorf("severity = %v, want OK: %s", res.Severity, res.Message)
+	}
+}
+
+// TestCheckByBuilder_BindMode exercises the MountModeBind branch in
+// checkByBuilder where the builder-binary path is translated through
+// MountConfig.ToHostPath before the container bind mount is created.
+func TestCheckByBuilder_BindMode(t *testing.T) {
+	cli := testDockerClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	ensureAlpine(t, ctx, cli)
+
+	scriptDir := t.TempDir()
+	script := filepath.Join(scriptDir, "by-builder")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho usage\n"), 0o755); err != nil { //nolint:gosec
+		t.Fatal(err)
+	}
+
+	d := newPreflightTestBackend(t, cli, "alpine:latest", MountModeBind)
+	d.mountCfg.HostSource = scriptDir
+	d.mountCfg.MountDest = scriptDir
+	deps := PreflightDeps{BuilderBin: script}
+
+	res := checkByBuilder(ctx, d, deps)
+	if res.Severity != preflight.SeverityOK {
+		t.Errorf("severity = %v, want OK: %s", res.Severity, res.Message)
+	}
+}
+
+// TestRunEphemeralContainer_CreateFailure covers the error-return path
+// in runEphemeralContainer when ContainerCreate rejects the config —
+// here we use an invalid image reference so Docker returns an error
+// before the container is started.
+func TestRunEphemeralContainer_CreateFailure(t *testing.T) {
+	cli := testDockerClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// An empty Image string is not a valid reference — ContainerCreate
+	// errors immediately.
+	_, exit, err := runEphemeralContainer(ctx, cli,
+		nil, nil,
+		"blockyard-test-invalid",
+	)
+	if err == nil {
+		t.Fatal("expected error for nil container Config")
+	}
+	if exit != -1 {
+		t.Errorf("exitCode = %d, want -1 on create failure", exit)
+	}
+}

--- a/internal/backend/docker/preflight_nodep_test.go
+++ b/internal/backend/docker/preflight_nodep_test.go
@@ -1,10 +1,12 @@
 package docker
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/cynkra/blockyard/internal/config"
 	"github.com/cynkra/blockyard/internal/preflight"
 )
 
@@ -54,5 +56,68 @@ func TestCheckMetadataBlocking_WithServerID(t *testing.T) {
 	// and iptables is available.
 	if res.Severity == preflight.SeverityError {
 		t.Errorf("unexpected Error severity: %s", res.Message)
+	}
+}
+
+// TestCheckRedisOnServiceNetwork_MissingConfig hits the early OK-return
+// branch when RedisURL is empty — the check is skipped with a "not
+// configured" message. This does not require a Docker client.
+func TestCheckRedisOnServiceNetwork_MissingConfig(t *testing.T) {
+	d := &DockerBackend{config: &config.DockerConfig{}}
+	res := checkRedisOnServiceNetwork(context.Background(), d, PreflightDeps{RedisURL: ""})
+	if res.Severity != preflight.SeverityOK {
+		t.Errorf("severity = %v, want OK when unconfigured", res.Severity)
+	}
+}
+
+// TestCheckRedisOnServiceNetwork_ParseError hits the "parse error"
+// branch when the URL is malformed — the function returns OK with a
+// skip message rather than an error.
+func TestCheckRedisOnServiceNetwork_ParseError(t *testing.T) {
+	d := &DockerBackend{config: &config.DockerConfig{ServiceNetwork: "svc-net"}}
+	res := checkRedisOnServiceNetwork(context.Background(), d,
+		PreflightDeps{RedisURL: "::::not-a-url"})
+	if res.Severity != preflight.SeverityOK {
+		t.Errorf("severity = %v, want OK on parse error", res.Severity)
+	}
+	if res.Category != "docker" {
+		t.Errorf("category = %q", res.Category)
+	}
+}
+
+// TestCheckRedisOnServiceNetwork_EmptyHost hits the "no host" branch
+// where a URL parses but has no hostname (e.g. scheme-only).
+func TestCheckRedisOnServiceNetwork_EmptyHost(t *testing.T) {
+	d := &DockerBackend{config: &config.DockerConfig{ServiceNetwork: "svc-net"}}
+	res := checkRedisOnServiceNetwork(context.Background(), d,
+		PreflightDeps{RedisURL: "redis://"})
+	if res.Severity != preflight.SeverityOK {
+		t.Errorf("severity = %v, want OK when URL has no host", res.Severity)
+	}
+}
+
+// TestCleanupOrphanResources_NoOpReturnsNil exercises the trivial
+// public CleanupOrphanResources method, covering the 0% block.
+func TestCleanupOrphanResources_NoOpReturnsNil(t *testing.T) {
+	d := &DockerBackend{
+		runCmd: func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+			return nil, nil
+		},
+	}
+	if err := d.CleanupOrphanResources(context.Background()); err != nil {
+		t.Errorf("CleanupOrphanResources = %v, want nil", err)
+	}
+}
+
+// TestCheckRVersion_AlwaysNil covers the trivial CheckRVersion method
+// on DockerBackend — the docker backend selects R via image tag and
+// always returns nil.
+func TestCheckRVersion_AlwaysNil(t *testing.T) {
+	d := &DockerBackend{}
+	if err := d.CheckRVersion("4.5.0"); err != nil {
+		t.Errorf("CheckRVersion = %v, want nil", err)
+	}
+	if err := d.CheckRVersion(""); err != nil {
+		t.Errorf("CheckRVersion(\"\") = %v, want nil", err)
 	}
 }

--- a/internal/backend/process/process_coverage_test.go
+++ b/internal/backend/process/process_coverage_test.go
@@ -1,0 +1,472 @@
+package process
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+
+	"github.com/cynkra/blockyard/internal/backend"
+	"github.com/cynkra/blockyard/internal/config"
+	"github.com/cynkra/blockyard/internal/redisstate"
+)
+
+// --- CheckRVersion ---
+
+func TestCheckRVersion_Empty(t *testing.T) {
+	b := newFakeBackend(t)
+	if err := b.CheckRVersion(""); err != nil {
+		t.Errorf("empty version should be OK: %v", err)
+	}
+}
+
+func TestCheckRVersion_Resolves(t *testing.T) {
+	dir := setupRigFixture(t, "4.5.0")
+	orig := rigBase
+	defer setRigBase(orig)
+	setRigBase(dir)
+
+	b := newFakeBackend(t)
+	if err := b.CheckRVersion("4.5.0"); err != nil {
+		t.Errorf("installed version should resolve cleanly: %v", err)
+	}
+}
+
+func TestCheckRVersion_MissingOtherVersionsInstalled(t *testing.T) {
+	dir := setupRigFixture(t, "4.5.0", "4.4.3")
+	orig := rigBase
+	defer setRigBase(orig)
+	setRigBase(dir)
+
+	b := newFakeBackend(t)
+	err := b.CheckRVersion("3.6.0")
+	if err == nil {
+		t.Fatal("expected error for uninstalled version")
+	}
+	if !strings.Contains(err.Error(), "not installed; available:") {
+		t.Errorf("error should list available versions, got: %v", err)
+	}
+}
+
+func TestCheckRVersion_NoneInstalled(t *testing.T) {
+	// Point rigBase at an empty directory so InstalledRVersions returns [].
+	dir := t.TempDir()
+	orig := rigBase
+	defer setRigBase(orig)
+	setRigBase(dir)
+
+	b := newFakeBackend(t)
+	err := b.CheckRVersion("4.5.0")
+	if err == nil {
+		t.Fatal("expected error when no R versions installed")
+	}
+	if !strings.Contains(err.Error(), "no R versions are installed") {
+		t.Errorf("error should explain no versions, got: %v", err)
+	}
+}
+
+// --- selectAllocators ---
+
+func TestSelectAllocators_ExplicitMemory(t *testing.T) {
+	cfg := &config.Config{
+		Process: &config.ProcessConfig{
+			PortRangeStart: 30000, PortRangeEnd: 30010,
+			WorkerUIDStart: 80000, WorkerUIDEnd: 80010,
+		},
+		Proxy: config.ProxyConfig{SessionStore: config.SessionStoreMemory},
+	}
+	p, u := selectAllocators(cfg, nil, nil)
+	if _, ok := p.(*memoryPortAllocator); !ok {
+		t.Errorf("port allocator = %T, want memoryPortAllocator", p)
+	}
+	if _, ok := u.(*memoryUIDAllocator); !ok {
+		t.Errorf("uid allocator = %T, want memoryUIDAllocator", u)
+	}
+}
+
+// TestSelectAllocators_Redis covers the Redis branch of the selector.
+// A miniredis stands in for a live Redis; selectAllocators only calls
+// the constructors, which don't exercise the connection, so the test
+// is deterministic without a real Redis server.
+func TestSelectAllocators_Redis(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rc := redisstate.TestClient(t, mr.Addr())
+
+	cfg := &config.Config{
+		Process: &config.ProcessConfig{
+			PortRangeStart: 30000, PortRangeEnd: 30010,
+			WorkerUIDStart: 80000, WorkerUIDEnd: 80010,
+		},
+		Proxy: config.ProxyConfig{SessionStore: config.SessionStoreRedis},
+	}
+	p, u := selectAllocators(cfg, rc, nil)
+	if _, ok := p.(*redisPortAllocator); !ok {
+		t.Errorf("port allocator = %T, want redisPortAllocator", p)
+	}
+	if _, ok := u.(*redisUIDAllocator); !ok {
+		t.Errorf("uid allocator = %T, want redisUIDAllocator", u)
+	}
+}
+
+// TestSelectAllocators_Postgres covers the Postgres branch. Skips if
+// BLOCKYARD_TEST_POSTGRES_URL is unset — the package-level testPGDB
+// already gates on that env var.
+func TestSelectAllocators_Postgres(t *testing.T) {
+	if pgTestBaseURL == "" {
+		t.Skip("postgres not available")
+	}
+	db := testPGDB(t)
+
+	cfg := &config.Config{
+		Process: &config.ProcessConfig{
+			PortRangeStart: 30000, PortRangeEnd: 30010,
+			WorkerUIDStart: 80000, WorkerUIDEnd: 80010,
+		},
+		Proxy: config.ProxyConfig{SessionStore: config.SessionStorePostgres},
+	}
+	p, u := selectAllocators(cfg, nil, db)
+	if _, ok := p.(*postgresPortAllocator); !ok {
+		t.Errorf("port allocator = %T, want postgresPortAllocator", p)
+	}
+	if _, ok := u.(*postgresUIDAllocator); !ok {
+		t.Errorf("uid allocator = %T, want postgresUIDAllocator", u)
+	}
+}
+
+// TestSelectAllocators_Layered covers the Layered branch — wraps PG +
+// Redis allocators behind a layered cache.
+func TestSelectAllocators_Layered(t *testing.T) {
+	if pgTestBaseURL == "" {
+		t.Skip("postgres not available")
+	}
+	db := testPGDB(t)
+	mr := miniredis.RunT(t)
+	rc := redisstate.TestClient(t, mr.Addr())
+
+	cfg := &config.Config{
+		Process: &config.ProcessConfig{
+			PortRangeStart: 30000, PortRangeEnd: 30010,
+			WorkerUIDStart: 80000, WorkerUIDEnd: 80010,
+		},
+		Proxy: config.ProxyConfig{SessionStore: config.SessionStoreLayered},
+	}
+	p, u := selectAllocators(cfg, rc, db)
+	if _, ok := p.(*layeredPortAllocator); !ok {
+		t.Errorf("port allocator = %T, want layeredPortAllocator", p)
+	}
+	if _, ok := u.(*layeredUIDAllocator); !ok {
+		t.Errorf("uid allocator = %T, want layeredUIDAllocator", u)
+	}
+}
+
+// --- Build error paths (without real bwrap execution) ---
+
+// TestBuild_UIDPoolExhausted hits the early uid-allocation failure
+// branch — easier than driving bwrap with a real process, and it's a
+// real error path that would otherwise be uncovered.
+func TestBuild_UIDPoolExhausted(t *testing.T) {
+	b := newFakeBackend(t)
+	// Exhaust the UID pool before calling Build.
+	for {
+		if _, err := b.uids.Alloc(); err != nil {
+			break
+		}
+	}
+
+	res, err := b.Build(context.Background(), backend.BuildSpec{
+		AppID: "app-1", BundleID: "b-1", Image: "img",
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+	if res.Success {
+		t.Fatal("Build with exhausted UID pool should report failure")
+	}
+	if res.ExitCode != 1 {
+		t.Errorf("ExitCode = %d, want 1", res.ExitCode)
+	}
+}
+
+// TestBuild_BadSeccompProfile covers the applySeccomp error branch —
+// the configured profile file does not exist, so Build must return a
+// failure with the error captured in Logs and the UID released.
+func TestBuild_BadSeccompProfile(t *testing.T) {
+	b := newFakeBackend(t)
+	b.cfg.SeccompProfile = "/nonexistent/profile.bpf"
+
+	before := b.uids.InUse()
+	res, err := b.Build(context.Background(), backend.BuildSpec{
+		AppID: "app-1", BundleID: "b-1", Image: "img",
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+	if res.Success {
+		t.Fatal("Build with bad seccomp profile should fail")
+	}
+	if after := b.uids.InUse(); after != before {
+		t.Errorf("UID leaked: before=%d after=%d", before, after)
+	}
+}
+
+// TestBuild_RVersionNotInstalled covers the early-return branch where
+// ResolveRBinary's fell flag is true for a Cmd-leading Rscript.
+func TestBuild_RVersionNotInstalled(t *testing.T) {
+	dir := setupRigFixture(t, "4.5.0")
+	orig := rigBase
+	defer setRigBase(orig)
+	setRigBase(dir)
+
+	b := newFakeBackend(t)
+	b.cfg.RPath = "/usr/bin/R"
+
+	res, err := b.Build(context.Background(), backend.BuildSpec{
+		AppID:    "app-1",
+		BundleID: "b-1",
+		Image:    "img",
+		Cmd:      []string{"Rscript", "app.R"},
+		RVersion: "3.6.0", // not in the fixture
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+	if res.Success {
+		t.Fatal("Build with uninstalled RVersion should fail")
+	}
+	if !strings.Contains(res.Logs, "no longer installed") {
+		t.Errorf("Logs = %q, want 'no longer installed'", res.Logs)
+	}
+}
+
+// TestBuild_BadBwrapPath covers the bwrapExecSpec error branch. The
+// shim resolution fails because the bwrap path is not a real executable
+// that can be stat'ed for the readlink dance inside bwrapExecSpec.
+func TestBuild_BadBwrapPath(t *testing.T) {
+	b := newFakeBackend(t)
+	b.cfg.BwrapPath = "/nonexistent/bwrap"
+
+	before := b.uids.InUse()
+	res, err := b.Build(context.Background(), backend.BuildSpec{
+		AppID: "app-1", BundleID: "b-1", Image: "img",
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+	if res.Success {
+		t.Fatal("Build with missing bwrap should fail")
+	}
+	if after := b.uids.InUse(); after != before {
+		t.Errorf("UID leaked: before=%d after=%d", before, after)
+	}
+}
+
+// TestCleanupOrphanResources_Error covers the error branches inside the
+// CleanupOrphanResources switch — using a stub allocator that
+// implements CleanupOwnedOrphans and returns an error.
+func TestCleanupOrphanResources_Error(t *testing.T) {
+	b := newFakeBackend(t)
+	stub := &errCleanupUIDAllocator{err: errStub}
+	b.uids = stub
+
+	err := b.CleanupOrphanResources(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "uid cleanup") {
+		t.Errorf("expected uid cleanup error, got: %v", err)
+	}
+}
+
+func TestCleanupOrphanResources_PortError(t *testing.T) {
+	b := newFakeBackend(t)
+	// Replace the port allocator with one that errors on cleanup.
+	b.ports = &errCleanupPortAllocator{err: errStub}
+
+	err := b.CleanupOrphanResources(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "port cleanup") {
+		t.Errorf("expected port cleanup error, got: %v", err)
+	}
+}
+
+// errStub is a sentinel error used by cleanup-error stubs.
+var errStub = &stubError{msg: "cleanup failed"}
+
+type stubError struct{ msg string }
+
+func (e *stubError) Error() string { return e.msg }
+
+// errCleanupUIDAllocator wraps memoryUIDAllocator but returns an error
+// from CleanupOwnedOrphans. Satisfies the orphanCleaner interface used
+// inside CleanupOrphanResources.
+type errCleanupUIDAllocator struct {
+	*memoryUIDAllocator
+	err error
+}
+
+func (e *errCleanupUIDAllocator) CleanupOwnedOrphans(_ context.Context) error {
+	return e.err
+}
+
+type errCleanupPortAllocator struct {
+	*memoryPortAllocator
+	err error
+}
+
+func (e *errCleanupPortAllocator) CleanupOwnedOrphans(_ context.Context) error {
+	return e.err
+}
+
+// --- readOneProcStats / collectDescendants ---
+
+// TestCollectDescendants_BadPID covers the early-return branch when
+// /proc/<pid>/task/<pid>/children is unreadable.
+func TestCollectDescendants_BadPID(t *testing.T) {
+	descendants := collectDescendants(-1)
+	if descendants != nil {
+		t.Errorf("collectDescendants(-1) = %v, want nil", descendants)
+	}
+}
+
+// TestReadOneProcStats_Nonexistent covers the error return when
+// /proc/<pid>/status cannot be read.
+func TestReadOneProcStats_Nonexistent(t *testing.T) {
+	rss, ut, st := readOneProcStats(-1)
+	if rss != 0 || ut != 0 || st != 0 {
+		t.Errorf("stats = (%d, %d, %d), want all zero", rss, ut, st)
+	}
+}
+
+// TestReadOneProcStats_StatusReadable_StatMissing covers the branch
+// where /status is readable but /stat is not (rare). Hardest path to
+// reach reliably — skip if PID 1 doesn't exist (containers with no
+// PID 1 init).
+func TestReadOneProcStats_LiveProcess(t *testing.T) {
+	pid := os.Getpid()
+	rss, ut, _ := readOneProcStats(pid)
+	if rss == 0 {
+		t.Errorf("expected non-zero RSS for self (%d)", pid)
+	}
+	_ = ut
+}
+
+// TestWorkerResourceUsage_ExitedBetween exercises the branch where
+// the process exits between lookup and /proc read (readProcTreeStats
+// returns all zeros). Simulate by registering a workerProc with a
+// process that's already gone.
+func TestWorkerResourceUsage_ExitedBetween(t *testing.T) {
+	b := newFakeBackend(t)
+	w := &workerProc{
+		cmd:     nil,
+		process: &os.Process{Pid: -1}, // nonexistent PID
+		done:    make(chan struct{}),
+	}
+	b.workers["gone"] = w
+	usage, err := b.WorkerResourceUsage(context.Background(), "gone")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if usage != nil {
+		t.Errorf("usage = %+v, want nil for exited process", usage)
+	}
+}
+
+// TestBuild_Success runs Build against /bin/true — the fake bwrap
+// exits 0 immediately and produces no output, driving the
+// post-goroutine success path (lines 687-691). This is the cheapest
+// way to cover the Start+Wait pipeline without a real bwrap binary.
+func TestBuild_Success(t *testing.T) {
+	b := newFakeBackend(t)
+	// /bin/true: exits 0, no output. Build should report Success=true.
+	res, err := b.Build(context.Background(), backend.BuildSpec{
+		AppID: "app-1", BundleID: "b-1", Image: "ignored",
+		// No Cmd[0]=="R"/"Rscript", so RResolve branch is skipped.
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !res.Success {
+		t.Errorf("res.Success = false, want true (logs=%q, exit=%d)",
+			res.Logs, res.ExitCode)
+	}
+	if res.ExitCode != 0 {
+		t.Errorf("res.ExitCode = %d, want 0", res.ExitCode)
+	}
+}
+
+// TestBuild_NonZeroExit makes bwrap (/bin/false) exit 1, driving the
+// waitErr != nil branch in Build and the *exec.ExitError path inside
+// it. Exit codes are propagated verbatim.
+func TestBuild_NonZeroExit(t *testing.T) {
+	b := newFakeBackend(t)
+	b.cfg.BwrapPath = "/bin/false"
+	res, err := b.Build(context.Background(), backend.BuildSpec{
+		AppID: "app-1", BundleID: "b-1", Image: "ignored",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if res.Success {
+		t.Error("Build with /bin/false should not be successful")
+	}
+	if res.ExitCode != 1 {
+		t.Errorf("ExitCode = %d, want 1", res.ExitCode)
+	}
+}
+
+// TestBuild_LogWriterReceivesOutput covers the LogWriter callback path
+// and the line-by-line ingest loop by configuring a bwrap stand-in
+// that emits a line of output before exiting. /bin/echo prints its
+// args to stdout — Build captures that into spec.LogWriter.
+func TestBuild_LogWriterReceivesOutput(t *testing.T) {
+	b := newFakeBackend(t)
+	b.cfg.BwrapPath = "/bin/echo"
+
+	var gotLines []string
+	res, err := b.Build(context.Background(), backend.BuildSpec{
+		AppID:     "app-1",
+		BundleID:  "b-1",
+		Image:     "ignored",
+		LogWriter: func(line string) { gotLines = append(gotLines, line) },
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !res.Success {
+		t.Errorf("Build should succeed when bwrap stand-in exits 0, got %+v", res)
+	}
+	if len(gotLines) == 0 {
+		t.Error("LogWriter received no lines — ingest path not exercised")
+	}
+	if res.Logs == "" {
+		t.Error("Logs buffer empty — ingest output not captured")
+	}
+}
+
+// TestBuild_RCmdResolvesFromCfg covers the path where Cmd[0] is "R"
+// (not Rscript) and ResolveRBinary succeeds — the Cmd[0] is replaced
+// with the resolved R path without the Rscript filepath-dir dance.
+func TestBuild_RCmdResolvesFromCfg(t *testing.T) {
+	dir := setupRigFixture(t, "4.5.0")
+	orig := rigBase
+	defer setRigBase(orig)
+	setRigBase(dir)
+
+	b := newFakeBackend(t)
+	b.cfg.RPath = "/usr/bin/R"
+
+	// Cmd[0]="R" + installed RVersion: the resolve branch runs, the
+	// Rscript filepath.Dir branch is skipped. Bwrap stand-in is
+	// /bin/true so the actual build succeeds trivially.
+	res, err := b.Build(context.Background(), backend.BuildSpec{
+		AppID:    "app-1",
+		BundleID: "b-1",
+		Image:    "ignored",
+		Cmd:      []string{"R", "-e", "1+1"},
+		RVersion: "4.5.0",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !res.Success {
+		t.Errorf("Build failed unexpectedly: %+v", res)
+	}
+}

--- a/internal/bundle/restore_errors_test.go
+++ b/internal/bundle/restore_errors_test.go
@@ -2,7 +2,6 @@ package bundle
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,7 +14,6 @@ import (
 
 	"github.com/cynkra/blockyard/internal/backend"
 	mockmock "github.com/cynkra/blockyard/internal/backend/mock"
-	"github.com/cynkra/blockyard/internal/manifest"
 	"github.com/cynkra/blockyard/internal/pkgstore"
 	"github.com/cynkra/blockyard/internal/task"
 	"github.com/cynkra/blockyard/internal/telemetry"
@@ -339,21 +337,6 @@ func TestSpawnRestore_NilMetricsStillSucceeds(t *testing.T) {
 	<-doneCh
 	if s, _ := tasks.Status("task-1"); s != task.Completed {
 		t.Errorf("task status = %d, want Completed", s)
-	}
-}
-
-// writeManifestFile is a helper for tests that need an unpacked bundle
-// with a specific manifest layout (e.g., bare-scripts by omitting it).
-func writeManifestFile(t *testing.T, path string) {
-	t.Helper()
-	m := manifest.Manifest{
-		Version:  1,
-		RVersion: "4.4.2",
-		Metadata: manifest.Metadata{AppMode: "shiny", Entrypoint: "app.R"},
-	}
-	data, _ := json.Marshal(m)
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		t.Fatal(err)
 	}
 }
 

--- a/internal/bundle/restore_errors_test.go
+++ b/internal/bundle/restore_errors_test.go
@@ -1,0 +1,519 @@
+package bundle
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/cynkra/blockyard/internal/backend"
+	mockmock "github.com/cynkra/blockyard/internal/backend/mock"
+	"github.com/cynkra/blockyard/internal/manifest"
+	"github.com/cynkra/blockyard/internal/pkgstore"
+	"github.com/cynkra/blockyard/internal/task"
+	"github.com/cynkra/blockyard/internal/telemetry"
+)
+
+// stageBuilderCache pre-populates a by-builder cache entry so that
+// buildercache.EnsureCached returns immediately without attempting a
+// compile-from-source fallback that would take seconds and require a
+// Go toolchain on the worker.
+func stageBuilderCache(t *testing.T, dir, version string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	name := fmt.Sprintf("by-builder-%s-linux-%s", version, runtime.GOARCH)
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/true\n"), 0o755); err != nil { //nolint:gosec
+		t.Fatal(err)
+	}
+}
+
+// TestSpawnRestore_WithWaitGroup verifies that SpawnRestore calls
+// WaitGroup.Add(1) before the goroutine and Done() on exit, so callers
+// can synchronise server shutdown against in-flight restores.
+func TestSpawnRestore_WithWaitGroup(t *testing.T) {
+	params, tasks := setupRestoreTest(t, true)
+	var wg sync.WaitGroup
+	params.WG = &wg
+
+	SpawnRestore(params)
+
+	_, _, doneCh, ok := tasks.Subscribe("task-1")
+	if !ok {
+		t.Fatal("task not found")
+	}
+	select {
+	case <-doneCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for SpawnRestore")
+	}
+
+	// After the task signals done, the WaitGroup's Done() must have fired.
+	waitDone := make(chan struct{})
+	go func() { wg.Wait(); close(waitDone) }()
+	select {
+	case <-waitDone:
+	case <-time.After(time.Second):
+		t.Fatal("WaitGroup.Wait() did not return after task completion")
+	}
+}
+
+// TestSpawnRestore_MetricsOnSuccess asserts that the success counter
+// and build-duration histogram are touched on a successful restore.
+func TestSpawnRestore_MetricsOnSuccess(t *testing.T) {
+	params, tasks := setupRestoreTest(t, true)
+	reg := prometheus.NewRegistry()
+	params.Metrics = telemetry.NewMetrics(reg)
+
+	SpawnRestore(params)
+
+	_, _, doneCh, ok := tasks.Subscribe("task-1")
+	if !ok {
+		t.Fatal("task not found")
+	}
+	<-doneCh
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, mf := range mfs {
+		if mf.GetName() == "blockyard_bundle_restores_succeeded_total" {
+			for _, m := range mf.GetMetric() {
+				if m.GetCounter().GetValue() == 1 {
+					found = true
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("succeeded counter was not incremented")
+	}
+}
+
+// TestSpawnRestore_MetricsOnFailure asserts the failure counter is
+// incremented when the build fails.
+func TestSpawnRestore_MetricsOnFailure(t *testing.T) {
+	params, tasks := setupRestoreTest(t, false)
+	reg := prometheus.NewRegistry()
+	params.Metrics = telemetry.NewMetrics(reg)
+
+	SpawnRestore(params)
+
+	_, _, doneCh, ok := tasks.Subscribe("task-1")
+	if !ok {
+		t.Fatal("task not found")
+	}
+	<-doneCh
+
+	mfs, _ := reg.Gather()
+	found := false
+	for _, mf := range mfs {
+		if mf.GetName() == "blockyard_bundle_restores_failed_total" {
+			for _, m := range mf.GetMetric() {
+				if m.GetCounter().GetValue() == 1 {
+					found = true
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("failed counter was not incremented")
+	}
+}
+
+// TestSpawnRestore_PanicRecovery verifies the deferred recover() path
+// in SpawnRestore: a backend Build that panics must not crash the
+// server; the task is marked Failed and the bundle row transitions to
+// "failed".
+func TestSpawnRestore_PanicRecovery(t *testing.T) {
+	params, tasks := setupRestoreTest(t, true)
+	be := params.Backend.(*mockmock.MockBackend)
+	be.BuildFn = func(context.Context, backend.BuildSpec) (backend.BuildResult, error) {
+		panic("simulated backend crash")
+	}
+
+	SpawnRestore(params)
+
+	_, _, doneCh, ok := tasks.Subscribe("task-1")
+	if !ok {
+		t.Fatal("task not found")
+	}
+	select {
+	case <-doneCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out")
+	}
+
+	status, _ := tasks.Status("task-1")
+	if status != task.Failed {
+		t.Errorf("status = %d, want Failed", status)
+	}
+	b, _ := params.DB.GetBundle("b-1")
+	if b.Status != "failed" {
+		t.Errorf("bundle status = %q, want failed", b.Status)
+	}
+}
+
+// TestRunRestore_InvalidPakVersion covers the error branch when
+// pakcache.EnsureInstalled rejects the version string.
+func TestRunRestore_InvalidPakVersion(t *testing.T) {
+	params, _ := setupRestoreTest(t, true)
+	params.PakVersion = "not-a-channel"
+
+	err := runRestore(params)
+	if err == nil {
+		t.Fatal("expected error for invalid pak_version")
+	}
+}
+
+// TestRunRestore_BareScriptsFailure removes the manifest so that
+// runRestore falls through to preProcess, and makes the Build call fail
+// during preprocess — covering the preprocess error path.
+func TestRunRestore_BareScriptsFailure(t *testing.T) {
+	params, _ := setupRestoreTest(t, true)
+	// Remove manifest so resolveManifest returns nil.
+	os.Remove(filepath.Join(params.Paths.Unpacked, "manifest.json"))
+
+	be := params.Backend.(*mockmock.MockBackend)
+	calls := 0
+	be.BuildFn = func(_ context.Context, spec backend.BuildSpec) (backend.BuildResult, error) {
+		calls++
+		// First call = pak install; succeed. Second call = preprocess; fail.
+		if calls == 1 {
+			return backend.BuildResult{Success: true}, nil
+		}
+		return backend.BuildResult{Success: false, ExitCode: 1, Logs: "boom"}, nil
+	}
+
+	err := runRestore(params)
+	if err == nil {
+		t.Fatal("expected error from failed preprocess")
+	}
+}
+
+// TestRunRestore_BuildBackendError exercises the path where
+// Backend.Build returns a non-nil error (distinct from a non-success
+// result).
+func TestRunRestore_BuildBackendError(t *testing.T) {
+	params, _ := setupRestoreTest(t, true)
+	be := params.Backend.(*mockmock.MockBackend)
+	be.BuildFn = func(_ context.Context, _ backend.BuildSpec) (backend.BuildResult, error) {
+		return backend.BuildResult{}, fmt.Errorf("backend unreachable")
+	}
+
+	err := runRestore(params)
+	if err == nil || err.Error() == "" {
+		t.Fatal("expected build error")
+	}
+}
+
+// TestRunRestore_BuildTimeout covers the branch that distinguishes a
+// context-deadline timeout from a plain build failure.
+func TestRunRestore_BuildTimeout(t *testing.T) {
+	params, _ := setupRestoreTest(t, false)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // immediately cancel so ctx.Err() is non-nil by the time Build returns
+	params.Ctx = ctx
+
+	be := params.Backend.(*mockmock.MockBackend)
+	be.BuildFn = func(_ context.Context, _ backend.BuildSpec) (backend.BuildResult, error) {
+		// Simulate "container killed" from a cancelled context.
+		return backend.BuildResult{Success: false, ExitCode: -1}, nil
+	}
+
+	err := runRestore(params)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+}
+
+// TestRunRestore_StoreAwareMissingArtifacts exercises the
+// store-aware branch with a successful build but no store-manifest.json
+// written — the copyFile step must surface an error.
+func TestRunRestore_StoreAwareMissingArtifacts(t *testing.T) {
+	params, _ := setupRestoreTest(t, true)
+
+	storeRoot := filepath.Join(t.TempDir(), "store")
+	params.Store = pkgstore.NewStore(storeRoot)
+	builderCache := filepath.Join(t.TempDir(), "builder-cache")
+	stageBuilderCache(t, builderCache, "")
+	params.BuilderCachePath = builderCache
+
+	// Build reports success but does NOT populate the build dir with
+	// store-manifest.json — the copyFile call should fail.
+	be := params.Backend.(*mockmock.MockBackend)
+	be.BuildFn = func(_ context.Context, _ backend.BuildSpec) (backend.BuildResult, error) {
+		return backend.BuildResult{Success: true}, nil
+	}
+
+	err := runRestore(params)
+	if err == nil {
+		t.Fatal("expected error when store-manifest.json is missing after build")
+	}
+}
+
+// TestRunRestore_StoreAwareSuccess covers the happy path when Store is
+// wired, including lockfile read and manifest persistence to the base
+// dir. Requires staging both the builder cache and the build dir with
+// the expected artifacts.
+func TestRunRestore_StoreAwareSuccess(t *testing.T) {
+	params, _ := setupRestoreTest(t, true)
+
+	storeRoot := filepath.Join(t.TempDir(), "store")
+	params.Store = pkgstore.NewStore(storeRoot)
+	builderCache := filepath.Join(t.TempDir(), "builder-cache")
+	stageBuilderCache(t, builderCache, "")
+	params.BuilderCachePath = builderCache
+
+	// The BuildFn is invoked twice: once for pak install (ignore), once
+	// for the actual build. For the second, write a store-manifest.json
+	// into the build dir so copyFile succeeds.
+	be := params.Backend.(*mockmock.MockBackend)
+	be.BuildFn = func(_ context.Context, spec backend.BuildSpec) (backend.BuildResult, error) {
+		// Identify the app build (not pak install) by AppID.
+		if spec.AppID == params.AppID {
+			var buildUUID string
+			for _, env := range spec.Env {
+				if len(env) > len("BUILD_UUID=") && env[:len("BUILD_UUID=")] == "BUILD_UUID=" {
+					buildUUID = env[len("BUILD_UUID="):]
+				}
+			}
+			if buildUUID != "" {
+				buildDir := filepath.Join(storeRoot, ".builds", buildUUID)
+				os.MkdirAll(buildDir, 0o755)
+				os.WriteFile(filepath.Join(buildDir, "store-manifest.json"),
+					[]byte(`{"packages":[]}`), 0o644)
+				os.WriteFile(filepath.Join(buildDir, "pak.lock"),
+					[]byte(`{"packages":[]}`), 0o644)
+			}
+		}
+		return backend.BuildResult{Success: true}, nil
+	}
+
+	if err := runRestore(params); err != nil {
+		t.Fatalf("runRestore: %v", err)
+	}
+
+	// store-manifest.json should now live in the bundle base dir.
+	if _, err := os.Stat(filepath.Join(params.Paths.Base, "store-manifest.json")); err != nil {
+		t.Errorf("store-manifest.json not copied to base: %v", err)
+	}
+}
+
+// TestRunRestore_ActivateBundleFailure makes the bundle not exist in the
+// DB before runRestore so ActivateBundle's SQL update fails.
+func TestRunRestore_ActivateBundleFailure(t *testing.T) {
+	params, _ := setupRestoreTest(t, true)
+	// Force UpdateBundleStatus to succeed for "building" then have the
+	// bundle row disappear before ActivateBundle. Simulate by deleting
+	// the app row after setup — ActivateBundle checks for the
+	// app/bundle pair and returns ErrNoRows.
+	if _, err := params.DB.DeleteBundle("b-1"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runRestore(params)
+	if err == nil {
+		t.Fatal("expected ActivateBundle to fail for missing bundle")
+	}
+}
+
+// TestSpawnRestore_FailsIfAllCompleteFlowUsedNilMetrics verifies that
+// not setting Metrics still works — the nil-guard branches.
+func TestSpawnRestore_NilMetricsStillSucceeds(t *testing.T) {
+	params, tasks := setupRestoreTest(t, true)
+	params.Metrics = nil
+
+	SpawnRestore(params)
+	_, _, doneCh, _ := tasks.Subscribe("task-1")
+	<-doneCh
+	if s, _ := tasks.Status("task-1"); s != task.Completed {
+		t.Errorf("task status = %d, want Completed", s)
+	}
+}
+
+// writeManifestFile is a helper for tests that need an unpacked bundle
+// with a specific manifest layout (e.g., bare-scripts by omitting it).
+func writeManifestFile(t *testing.T, path string) {
+	t.Helper()
+	m := manifest.Manifest{
+		Version:  1,
+		RVersion: "4.4.2",
+		Metadata: manifest.Metadata{AppMode: "shiny", Entrypoint: "app.R"},
+	}
+	data, _ := json.Marshal(m)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestRunRestore_BadManifest covers the path where manifest.json exists
+// but is malformed — resolveManifest returns an error that must surface
+// from runRestore with the "resolve manifest" prefix.
+func TestRunRestore_BadManifest(t *testing.T) {
+	params, _ := setupRestoreTest(t, true)
+	// Overwrite the manifest with invalid JSON.
+	path := filepath.Join(params.Paths.Unpacked, "manifest.json")
+	if err := os.WriteFile(path, []byte("{not valid"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runRestore(params)
+	if err == nil {
+		t.Fatal("expected resolveManifest error for malformed manifest.json")
+	}
+}
+
+// TestRunRestore_DefaultPakCachePath covers the branch where
+// RestoreParams.PakCachePath is empty and the default
+// {BasePath}/.pak-cache is computed.
+func TestRunRestore_DefaultPakCachePath(t *testing.T) {
+	params, _ := setupRestoreTest(t, true)
+	// Pre-populate the default location so pakcache.EnsureInstalled short-circuits.
+	defaultCache := filepath.Join(params.BasePath, ".pak-cache")
+	if err := os.MkdirAll(filepath.Join(defaultCache, "pak-stable"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	params.PakCachePath = ""
+
+	if err := runRestore(params); err != nil {
+		t.Fatalf("runRestore with default pak cache: %v", err)
+	}
+}
+
+// TestRunRestore_DefaultBuilderCachePath covers the store-aware branch
+// where BuilderCachePath is empty and the default path is computed
+// from BasePath.
+func TestRunRestore_DefaultBuilderCachePath(t *testing.T) {
+	params, _ := setupRestoreTest(t, true)
+	storeRoot := filepath.Join(t.TempDir(), "store")
+	params.Store = pkgstore.NewStore(storeRoot)
+
+	// Stage builder cache at the default location.
+	defaultBuilderDir := filepath.Join(params.BasePath, ".by-builder-cache")
+	stageBuilderCache(t, defaultBuilderDir, "")
+	params.BuilderCachePath = ""
+
+	be := params.Backend.(*mockmock.MockBackend)
+	be.BuildFn = func(_ context.Context, spec backend.BuildSpec) (backend.BuildResult, error) {
+		if spec.AppID == params.AppID {
+			for _, env := range spec.Env {
+				if len(env) > len("BUILD_UUID=") && env[:len("BUILD_UUID=")] == "BUILD_UUID=" {
+					uuidVal := env[len("BUILD_UUID="):]
+					buildDir := filepath.Join(storeRoot, ".builds", uuidVal)
+					os.MkdirAll(buildDir, 0o755)
+					os.WriteFile(filepath.Join(buildDir, "store-manifest.json"),
+						[]byte(`{"packages":[]}`), 0o644)
+					os.WriteFile(filepath.Join(buildDir, "pak.lock"),
+						[]byte(`{"packages":[]}`), 0o644)
+				}
+			}
+		}
+		return backend.BuildResult{Success: true}, nil
+	}
+
+	if err := runRestore(params); err != nil {
+		t.Fatalf("runRestore with default builder cache: %v", err)
+	}
+}
+
+// TestRunRestore_LegacyManifestFromRenvLock exercises the legacy branch
+// where resolveManifest parses renv.lock (no manifest.json), writes
+// manifest.json, .pak-refs and .pak-repos. This covers the write paths
+// at lines 224-240.
+func TestRunRestore_LegacyManifestFromRenvLock(t *testing.T) {
+	params, _ := setupRestoreTest(t, true)
+	// Drop the manifest so resolveManifest falls through to renv.lock.
+	os.Remove(filepath.Join(params.Paths.Unpacked, "manifest.json"))
+	// Write a minimal renv.lock that manifest.FromRenvLock accepts.
+	renvLock := `{
+	"R": {"Version": "4.4.2", "Repositories": [{"Name": "CRAN", "URL": "https://cran.r-project.org"}]},
+	"Packages": {
+		"shiny": {"Package": "shiny", "Version": "1.8.0", "Source": "Repository", "Repository": "CRAN"}
+	}
+}`
+	if err := os.WriteFile(filepath.Join(params.Paths.Unpacked, "renv.lock"),
+		[]byte(renvLock), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runRestore(params); err != nil {
+		t.Fatalf("runRestore: %v", err)
+	}
+	// Both metadata files should now be on disk.
+	for _, name := range []string{"manifest.json", ".pak-refs", ".pak-repos"} {
+		if _, err := os.Stat(filepath.Join(params.Paths.Unpacked, name)); err != nil {
+			t.Errorf("%s not written: %v", name, err)
+		}
+	}
+}
+
+// TestRunRestore_LegacyBareScriptsSucceeds exercises the post-preprocess
+// resolveManifest+Write path in the legacy branch. preProcess writes a
+// DESCRIPTION into /output via the mock backend; the second
+// resolveManifest call picks it up.
+func TestRunRestore_LegacyBareScriptsSucceeds(t *testing.T) {
+	params, _ := setupRestoreTest(t, true)
+	// Bare scripts: no manifest.json and no renv.lock / DESCRIPTION.
+	os.Remove(filepath.Join(params.Paths.Unpacked, "manifest.json"))
+
+	// setupRestoreTest pre-populates the pak cache, so Build is only called
+	// for preprocess and the real build. Detect the preprocess call by its
+	// distinctive /output mount and write the synthetic DESCRIPTION there.
+	be := params.Backend.(*mockmock.MockBackend)
+	be.BuildFn = func(_ context.Context, spec backend.BuildSpec) (backend.BuildResult, error) {
+		for _, m := range spec.Mounts {
+			if m.Target == "/output" {
+				_ = os.WriteFile(filepath.Join(m.Source, "DESCRIPTION"),
+					[]byte("Package: app\nVersion: 0.0.1\nImports: shiny\n"), 0o644)
+			}
+		}
+		return backend.BuildResult{Success: true}, nil
+	}
+
+	if err := runRestore(params); err != nil {
+		t.Fatalf("runRestore bare-scripts: %v", err)
+	}
+}
+
+// TestRunRestore_StoreAwareWithExistingManifest covers the
+// `!fileExists(manifestPath)` branch in the store-aware path being
+// false (manifest.json is already on disk, so Write is skipped).
+func TestRunRestore_StoreAwareWithExistingManifest(t *testing.T) {
+	params, _ := setupRestoreTest(t, true)
+	storeRoot := filepath.Join(t.TempDir(), "store")
+	params.Store = pkgstore.NewStore(storeRoot)
+	builderCache := filepath.Join(t.TempDir(), "builder-cache")
+	stageBuilderCache(t, builderCache, "")
+	params.BuilderCachePath = builderCache
+
+	be := params.Backend.(*mockmock.MockBackend)
+	be.BuildFn = func(_ context.Context, spec backend.BuildSpec) (backend.BuildResult, error) {
+		if spec.AppID == params.AppID {
+			for _, env := range spec.Env {
+				if len(env) > len("BUILD_UUID=") && env[:len("BUILD_UUID=")] == "BUILD_UUID=" {
+					uuidVal := env[len("BUILD_UUID="):]
+					buildDir := filepath.Join(storeRoot, ".builds", uuidVal)
+					os.MkdirAll(buildDir, 0o755)
+					os.WriteFile(filepath.Join(buildDir, "store-manifest.json"),
+						[]byte(`{"packages":[]}`), 0o644)
+				}
+			}
+		}
+		return backend.BuildResult{Success: true}, nil
+	}
+
+	if err := runRestore(params); err != nil {
+		t.Fatalf("runRestore: %v", err)
+	}
+}

--- a/internal/db/db_coverage_test.go
+++ b/internal/db/db_coverage_test.go
@@ -1,0 +1,377 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cynkra/blockyard/internal/config"
+)
+
+// --- WithCredsRotator + Open options ---
+
+// TestOpen_WithCredsRotator_NoOpOnSQLite covers the WithCredsRotator
+// option function and confirms that it is a no-op for SQLite (the
+// openSQLite path ignores options).
+func TestOpen_WithCredsRotator_NoOpOnSQLite(t *testing.T) {
+	rot := RotatorFunc(func(_ context.Context) (string, string, error) {
+		return "u", "p", nil
+	})
+	dir := t.TempDir()
+	d, err := Open(
+		config.DatabaseConfig{Driver: "sqlite", Path: dir + "/x.db"},
+		WithCredsRotator(rot),
+	)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer d.Close()
+	// SQLite path does not wire a creds provider.
+	if d.creds != nil {
+		t.Error("SQLite DB should not carry a creds provider")
+	}
+}
+
+// TestOpen_UnsupportedDriverSurfacesClearError asserts that the default
+// branch in Open returns the "unsupported database driver" sentinel
+// with the driver string interpolated.
+func TestOpen_UnsupportedDriverReturnsError(t *testing.T) {
+	_, err := Open(config.DatabaseConfig{Driver: "mysql"})
+	if err == nil || !strings.Contains(err.Error(), "unsupported") {
+		t.Fatalf("expected unsupported-driver error, got %v", err)
+	}
+}
+
+// TestOpenPostgres_ParseErrorBubbles covers the pgxpool.ParseConfig
+// error branch in openPostgres — a clearly malformed DSN.
+func TestOpenPostgres_ParseError(t *testing.T) {
+	_, err := Open(config.DatabaseConfig{
+		Driver: "postgres",
+		URL:    "postgres://[not a valid url",
+	})
+	if err == nil {
+		t.Fatal("expected parse error for malformed postgres URL")
+	}
+}
+
+// TestOpenPostgres_SeedRotatorFailure covers the branch where the
+// vault seed fetch fails before the first connection is made.
+func TestOpenPostgres_SeedRotatorFailure(t *testing.T) {
+	if pgBaseURL == "" {
+		t.Skip("postgres not available")
+	}
+	rot := RotatorFunc(func(_ context.Context) (string, string, error) {
+		return "", "", errors.New("vault unreachable")
+	})
+	_, err := Open(
+		config.DatabaseConfig{Driver: "postgres", URL: pgBaseURL},
+		WithCredsRotator(rot),
+	)
+	if err == nil {
+		t.Fatal("expected seed-rotator failure to surface from Open")
+	}
+	if !strings.Contains(err.Error(), "seed postgres creds") {
+		t.Errorf("error should mention 'seed postgres creds': %v", err)
+	}
+}
+
+// --- EnsurePostgresVersion ---
+
+func TestEnsurePostgresVersion_RejectsSQLite(t *testing.T) {
+	d := testDB(t)
+	err := d.EnsurePostgresVersion(context.Background(), PostgresMinVersion16)
+	if err == nil {
+		t.Fatal("expected EnsurePostgresVersion to reject SQLite")
+	}
+	if !strings.Contains(err.Error(), "postgres driver") {
+		t.Errorf("error should mention 'postgres driver': %v", err)
+	}
+}
+
+func TestEnsurePostgresVersion_ServerMeetsMin(t *testing.T) {
+	if pgBaseURL == "" {
+		t.Skip("postgres not available")
+	}
+	d := testPostgresDB(t)
+	// Use a very low minimum so any real PG passes.
+	if err := d.EnsurePostgresVersion(context.Background(), 100000); err != nil {
+		t.Errorf("expected modern PG to meet min=100000, got: %v", err)
+	}
+}
+
+func TestEnsurePostgresVersion_TooOld(t *testing.T) {
+	if pgBaseURL == "" {
+		t.Skip("postgres not available")
+	}
+	d := testPostgresDB(t)
+	// Use an impossibly high minimum so the server always reports too old.
+	err := d.EnsurePostgresVersion(context.Background(), 999999)
+	if err == nil {
+		t.Fatal("expected 'too old' error from a 999999 floor")
+	}
+	if !strings.Contains(err.Error(), "or later required") {
+		t.Errorf("error phrasing changed: %v", err)
+	}
+}
+
+// --- Query error paths ---
+
+// TestQueriesReturnErrorOnClosedDB verifies that the error branches in
+// the common CRUD methods wire through when the pool is closed. sqlx
+// errors propagate with the query text wrapped via fmt.Errorf.
+func TestQueriesReturnErrorOnClosedDB(t *testing.T) {
+	d := testDB(t)
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Each of these functions has an "if err != nil" in its body that
+	// only fires when the underlying DB hand is broken. Running them
+	// through a closed DB trips every one in a single pass.
+	if _, err := d.ListApps(); err == nil {
+		t.Error("ListApps on closed DB: expected error")
+	}
+	if _, err := d.ListAccessibleApps("user"); err == nil {
+		t.Error("ListAccessibleApps on closed DB: expected error")
+	}
+	if _, err := d.ListBundlesByApp("app-x"); err == nil {
+		t.Error("ListBundlesByApp on closed DB: expected error")
+	}
+	if _, err := d.ListAppDataMounts("app-x"); err == nil {
+		t.Error("ListAppDataMounts on closed DB: expected error")
+	}
+	if _, err := d.ListPreWarmedApps(); err == nil {
+		t.Error("ListPreWarmedApps on closed DB: expected error")
+	}
+	if _, err := d.ListDeletedApps(); err == nil {
+		t.Error("ListDeletedApps on closed DB: expected error")
+	}
+	if _, err := d.ListExpiredDeletedApps("1970-01-01"); err == nil {
+		t.Error("ListExpiredDeletedApps on closed DB: expected error")
+	}
+	if _, err := d.ListAppsWithRefreshSchedule(); err == nil {
+		t.Error("ListAppsWithRefreshSchedule on closed DB: expected error")
+	}
+	if _, err := d.ListAppAccess("app-x"); err == nil {
+		t.Error("ListAppAccess on closed DB: expected error")
+	}
+	if _, err := d.ListTags(); err == nil {
+		t.Error("ListTags on closed DB: expected error")
+	}
+	if _, err := d.FailStaleBuilds(); err == nil {
+		t.Error("FailStaleBuilds on closed DB: expected error")
+	}
+	if err := d.ClearActiveBundle("app-x"); err == nil {
+		t.Error("ClearActiveBundle on closed DB: expected error")
+	}
+	if _, err := d.RevokeAppAccess("app-x", "p", "user"); err == nil {
+		t.Error("RevokeAppAccess on closed DB: expected error")
+	}
+	if _, err := d.DeleteBundle("b-x"); err == nil {
+		t.Error("DeleteBundle on closed DB: expected error")
+	}
+	if err := d.UpdateBundleStatus("b-x", "ready"); err == nil {
+		t.Error("UpdateBundleStatus on closed DB: expected error")
+	}
+	if err := d.SetBundleDeployed("b-x", "u"); err == nil {
+		t.Error("SetBundleDeployed on closed DB: expected error")
+	}
+	if err := d.SetActiveBundle("a", "b"); err == nil {
+		t.Error("SetActiveBundle on closed DB: expected error")
+	}
+	if err := d.ActivateBundle("a", "b"); err == nil {
+		t.Error("ActivateBundle on closed DB: expected error")
+	}
+	if err := d.SetAppDataMounts("a", nil); err == nil {
+		t.Error("SetAppDataMounts on closed DB: expected error")
+	}
+}
+
+// TestGetErrorsOnClosedDB complements the list-query check for Get-like
+// queries whose sql.ErrNoRows early-return is covered, but the generic
+// "err != nil" branch is not — close the DB to hit it.
+func TestGetErrorsOnClosedDB(t *testing.T) {
+	d := testDB(t)
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// These calls must each return a non-nil error from the generic
+	// err-check (not an ErrNoRows-mapped nil).
+	if _, err := d.GetApp("id"); err == nil {
+		t.Error("GetApp on closed DB: expected error")
+	}
+	if _, err := d.GetAppByName("name"); err == nil {
+		t.Error("GetAppByName on closed DB: expected error")
+	}
+	if _, err := d.GetAppIncludeDeleted("id"); err == nil {
+		t.Error("GetAppIncludeDeleted on closed DB: expected error")
+	}
+	if _, err := d.GetBundle("id"); err == nil {
+		t.Error("GetBundle on closed DB: expected error")
+	}
+	if _, err := d.GetUser("sub"); err == nil {
+		t.Error("GetUser on closed DB: expected error")
+	}
+	if _, err := d.GetTag("name"); err == nil {
+		t.Error("GetTag on closed DB: expected error")
+	}
+}
+
+// TestCreateBundle_ForeignKeyError covers the CreateBundle error branch
+// where the app does not exist. This drives the sqlite FK violation
+// that CreateBundle wraps with a diagnostic.
+func TestCreateBundle_ForeignKeyError(t *testing.T) {
+	d := testDB(t)
+	_, err := d.CreateBundle("b-1", "nonexistent-app", "admin", false)
+	if err == nil {
+		t.Fatal("expected FK-violation error")
+	}
+}
+
+// TestOpenSQLite_EmptyPath tries opening sqlite with an empty path —
+// this is an invalid configuration that should return a clear error
+// from the driver, exercising the err path of Open.
+func TestOpenSQLite_EmptyPath(t *testing.T) {
+	// Open("") resolves DSN to "?_pragma=..." which sqlite accepts as
+	// the current directory; so exercise a definitely-invalid path: a
+	// directory that doesn't exist and can't be created.
+	_, err := Open(config.DatabaseConfig{
+		Driver: "sqlite",
+		Path:   "/proc/nonexistent/" + fmt.Sprintf("x-%d.db", 1),
+	})
+	if err == nil {
+		t.Fatal("expected error opening sqlite under /proc/nonexistent")
+	}
+}
+
+// TestSessionErrorsOnClosedDB covers the error branches in session
+// mutating queries when the DB connection is unusable.
+func TestSessionErrorsOnClosedDB(t *testing.T) {
+	d := testDB(t)
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.CreateSession("s", "app", "w", ""); err == nil {
+		t.Error("CreateSession on closed DB: expected error")
+	}
+	if err := d.EndSession("s", "ended"); err == nil {
+		t.Error("EndSession on closed DB: expected error")
+	}
+	if err := d.CrashWorkerSessions("w"); err == nil {
+		t.Error("CrashWorkerSessions on closed DB: expected error")
+	}
+	if err := d.EndWorkerSessions("w"); err == nil {
+		t.Error("EndWorkerSessions on closed DB: expected error")
+	}
+	if err := d.EndAppSessions("app"); err == nil {
+		t.Error("EndAppSessions on closed DB: expected error")
+	}
+	if _, err := d.ListSessions("app", SessionListOpts{}); err == nil {
+		t.Error("ListSessions on closed DB: expected error")
+	}
+	if _, err := d.GetSession("s"); err == nil {
+		t.Error("GetSession on closed DB: expected error")
+	}
+}
+
+// TestPATErrorsOnClosedDB covers PAT mutating queries against a closed
+// pool. All should surface the connection error via their "if err !=
+// nil" branches.
+func TestPATErrorsOnClosedDB(t *testing.T) {
+	d := testDB(t)
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	hash := []byte("irrelevant-for-this-test")
+	if _, err := d.CreatePAT("p", hash, "u", "n", nil); err == nil {
+		t.Error("CreatePAT on closed DB: expected error")
+	}
+	if _, err := d.LookupPATByHash(hash); err == nil {
+		t.Error("LookupPATByHash on closed DB: expected error")
+	}
+	if _, err := d.ListPATsByUser("u"); err == nil {
+		t.Error("ListPATsByUser on closed DB: expected error")
+	}
+	if _, err := d.RevokePAT("p", "u"); err == nil {
+		t.Error("RevokePAT on closed DB: expected error")
+	}
+	if _, err := d.RevokeAllPATs("u"); err == nil {
+		t.Error("RevokeAllPATs on closed DB: expected error")
+	}
+}
+
+// TestUserErrorsOnClosedDB covers the user-table mutators.
+func TestUserErrorsOnClosedDB(t *testing.T) {
+	d := testDB(t)
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := d.UpsertUser("sub", "x@y", "name"); err == nil {
+		t.Error("UpsertUser on closed DB: expected error")
+	}
+	if _, err := d.UpsertUserWithRole("sub", "x@y", "name", "admin"); err == nil {
+		t.Error("UpsertUserWithRole on closed DB: expected error")
+	}
+	if _, _, err := d.ListUsers(ListUsersOpts{}); err == nil {
+		t.Error("ListUsers on closed DB: expected error")
+	}
+}
+
+// TestTagErrorsOnClosedDB covers tag-related mutators.
+func TestTagErrorsOnClosedDB(t *testing.T) {
+	d := testDB(t)
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := d.CreateTag("name"); err == nil {
+		t.Error("CreateTag on closed DB: expected error")
+	}
+	if err := d.AddAppTag("a", "t"); err == nil {
+		t.Error("AddAppTag on closed DB: expected error")
+	}
+	if _, err := d.RemoveAppTag("a", "t"); err == nil {
+		t.Error("RemoveAppTag on closed DB: expected error")
+	}
+	if _, err := d.ListAppTags("a"); err == nil {
+		t.Error("ListAppTags on closed DB: expected error")
+	}
+	if _, err := d.DeleteTag("name"); err == nil {
+		t.Error("DeleteTag on closed DB: expected error")
+	}
+}
+
+// TestPing_SQLiteBasic exercises the Ping happy path for SQLite so the
+// pre-rotate-check branch of Ping() is executed without a rotator.
+func TestPing_SQLiteBasic(t *testing.T) {
+	d := testDB(t)
+	if err := d.Ping(context.Background()); err != nil {
+		t.Errorf("Ping: %v", err)
+	}
+}
+
+// TestOpen_SqliteExistingDirectory covers the branch in openSQLite
+// where the target directory is resolved to an already-existing dir
+// (MkdirAll is a no-op).
+func TestOpen_SqliteExistingDirectory(t *testing.T) {
+	dir := t.TempDir()
+	nested := dir + "/pre-existing"
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	d, err := Open(config.DatabaseConfig{
+		Driver: "sqlite",
+		Path:   nested + "/x.db",
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer d.Close()
+}


### PR DESCRIPTION
## Summary
- Adds error-branch tests for `internal/bundle/restore.go` (manifest parsing, store-aware flow, panic recovery, metrics, timeout).
- Adds `process` backend tests covering `Build` success/failure, `CheckRVersion`, and `selectAllocators` for redis/postgres/layered.
- Adds `db` tests for `WithCredsRotator`, `EnsurePostgresVersion`, and closed-pool error branches across CRUD methods.
- Adds `docker` preflight tests (no-dep URL branches + `docker_test`-tagged MountModeBind variants).
- Converts ~191 uncovered statements locally; `docker_test` tests add more under the docker CI flag.

Fixes #329