### PR TITLE
ci(misc): raise coverage-check thresholds to 80%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,8 +577,8 @@ jobs:
           git fetch --no-tags origin "$BASE"
           go run ./cmd/coverage-check \
             -profile=merged.out \
-            -min-total=76 \
-            -min-patch=76 \
+            -min-total=80 \
+            -min-patch=80 \
             -patch-base="origin/$BASE" \
             -ignore='internal/testutil/**' \
             -ignore='internal/preflight/docker_checks.go'


### PR DESCRIPTION
## Summary
- Bumps `-min-total` and `-min-patch` on `cmd/coverage-check` from 76 → 80 in the `coverage` CI job.
- Repo coverage is currently 80.29% (measured on #336's final run), so the gate is just-above the enforced floor and catches any regression going forward.
- Patch coverage gate applies only when the PR touches instrumented Go; diffs without Go code report `n/a` and pass.

Fixes #338