### PR TITLE
fix(misc): exponential backoff on AppRole re-login failure

### DIFF
--- a/internal/integration/approle.go
+++ b/internal/integration/approle.go
@@ -194,9 +194,13 @@ func (a *AppRoleAuth) resolveSecretID() (string, error) {
 // Run blocks until ctx is cancelled, re-logging in shortly before each
 // token expires. Failed re-logins mark the component unhealthy but do
 // not exit the loop — a later retry (or a 403-driven retry via Login)
-// can recover. Backoff is simple and short because the 403-retry path
-// on admin calls provides the actual recovery signal.
+// can recover. Retries use exponential backoff (1s → 60s cap) because
+// the 403-retry path on admin calls provides the actual recovery signal,
+// so the proactive loop only needs to keep trying without flooding vault.
 func (a *AppRoleAuth) Run(ctx context.Context) {
+	backoff := 1 * time.Second
+	const maxBackoff = 60 * time.Second
+
 	for {
 		a.timerMu.Lock()
 		wait := time.Until(a.nextAt)
@@ -215,14 +219,16 @@ func (a *AppRoleAuth) Run(ctx context.Context) {
 		}
 
 		if err := a.Login(ctx); err != nil {
-			slog.Warn("vault AppRole re-login failed", "error", err)
-			// On failure, retry sooner but not in a tight loop. The
-			// proactive timer isn't the load-bearing recovery path; if
-			// an admin call 403s in the meantime, that call re-logs in
-			// through the same singleflight and kicks nextAt forward.
+			slog.Warn("vault AppRole re-login failed", "error", err, "retry_in", backoff)
+			// On failure, retry with exponential backoff. If an admin
+			// call 403s in the meantime, that call re-logs in through
+			// the same singleflight and kicks nextAt forward.
 			a.timerMu.Lock()
-			a.nextAt = time.Now().Add(10 * time.Second)
+			a.nextAt = time.Now().Add(backoff)
 			a.timerMu.Unlock()
+			backoff = min(backoff*2, maxBackoff)
+		} else {
+			backoff = 1 * time.Second
 		}
 	}
 }

--- a/internal/integration/approle_test.go
+++ b/internal/integration/approle_test.go
@@ -229,6 +229,42 @@ func TestAppRoleAuthRunReloginsBeforeExpiry(t *testing.T) {
 	}
 }
 
+func TestAppRoleAuthRunRetriesWithExponentialBackoff(t *testing.T) {
+	// With the fixed 10s backoff, Run would fire at most once in 2.5s
+	// after a failure. Exponential backoff starts at 1s, so we should
+	// see multiple retries in that window.
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	t.Setenv("BLOCKYARD_VAULT_SECRET_ID", "s")
+	a := NewAppRoleAuth(srv.URL, "r", "")
+	// Seed an initial failure so Run starts in the retry path.
+	_ = a.Login(context.Background())
+	a.timerMu.Lock()
+	a.nextAt = time.Now()
+	a.timerMu.Unlock()
+	initial := count.Load()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		a.Run(ctx)
+		close(done)
+	}()
+
+	time.Sleep(2500 * time.Millisecond)
+	cancel()
+	<-done
+
+	if got := count.Load() - initial; got < 2 {
+		t.Errorf("expected ≥2 retries in 2.5s with exp backoff, got %d", got)
+	}
+}
+
 func TestClient403TriggersReloginAndRetries(t *testing.T) {
 	// On the first admin call, vault returns 403; the client must
 	// re-login and retry. The retry succeeds with the fresh token.


### PR DESCRIPTION
## Summary
- Replace the fixed 10s retry interval in `AppRoleAuth.Run` with exponential backoff (1s → 60s cap, reset on success).
- Over a 30-minute vault outage this drops retry volume from ~180 warn-logged attempts to ~30 without slowing real recovery — the 403-retry path on admin calls is still the load-bearing signal.
- Adds a unit test that seeds a failed login and asserts ≥2 retries fire in 2.5s (old fixed-10s behavior would show at most one).

Fixes #343