### PR TITLE
test+fix: deflake two scheduler-timing-dependent tests

### DIFF
--- a/internal/backend/process/process.go
+++ b/internal/backend/process/process.go
@@ -648,13 +648,22 @@ func (b *ProcessBackend) Build(ctx context.Context, spec backend.BuildSpec) (bac
 		return backend.BuildResult{Success: false, ExitCode: 1, Logs: err.Error()}, nil
 	}
 
-	// Run Start+Wait in a dedicated goroutine that LockOSThreads and
-	// never unlocks. Same Pdeathsig race as Spawn: pak installs run
-	// for minutes, so a stray runtime thread retirement would SIGKILL
-	// bwrap mid-build. The ingest goroutines read the pipes from any
-	// thread — Pdeathsig only watches the forking thread.
+	// Pin the fork to a single OS thread. Pdeathsig fires when the
+	// thread that forked the child exits, not when its goroutine is
+	// rescheduled, so a stray thread retirement would SIGKILL bwrap
+	// mid-build — pak installs run for minutes. The goroutine parks
+	// on `threadDone` until after cmd.Wait returns so the thread
+	// stays alive for the child's entire lifetime.
+	//
+	// cmd.Wait runs on the main goroutine, after the ingest
+	// goroutines have drained the pipes. cmd.Wait closes the parent
+	// side of the stdout/stderr pipes as part of its cleanup; if we
+	// called it in parallel with ingest (or before ingest attached),
+	// a near-instant child — e.g. the /bin/echo stand-in used in
+	// unit tests — could exit and have its output discarded before
+	// any reader saw it.
 	started := make(chan error, 1)
-	waitDone := make(chan error, 1)
+	threadDone := make(chan struct{})
 	go func() {
 		runtime.LockOSThread()
 		// Intentionally do NOT UnlockOSThread.
@@ -663,7 +672,7 @@ func (b *ProcessBackend) Build(ctx context.Context, spec backend.BuildSpec) (bac
 			return
 		}
 		started <- nil
-		waitDone <- cmd.Wait()
+		<-threadDone
 	}()
 
 	if err := <-started; err != nil {
@@ -698,7 +707,8 @@ func (b *ProcessBackend) Build(ctx context.Context, spec backend.BuildSpec) (bac
 	go ingest(stderr)
 	wg.Wait()
 
-	waitErr := <-waitDone
+	waitErr := cmd.Wait()
+	close(threadDone)
 	logs := logsBuf.String()
 
 	if waitErr != nil {

--- a/internal/integration/approle_test.go
+++ b/internal/integration/approle_test.go
@@ -136,18 +136,11 @@ func TestAppRoleAuthLoginErrors(t *testing.T) {
 }
 
 func TestAppRoleAuthLoginSingleflight(t *testing.T) {
-	var concurrent atomic.Int32
-	var maxConcurrent atomic.Int32
+	var calls atomic.Int32
+	release := make(chan struct{})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := concurrent.Add(1)
-		defer concurrent.Add(-1)
-		for {
-			m := maxConcurrent.Load()
-			if n <= m || maxConcurrent.CompareAndSwap(m, n) {
-				break
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
+		calls.Add(1)
+		<-release
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
 			"auth": map[string]any{"client_token": "hvs.shared", "lease_duration": 3600},
@@ -169,10 +162,16 @@ func TestAppRoleAuthLoginSingleflight(t *testing.T) {
 			}
 		}()
 	}
+
+	// The handler stays in flight until close(release), so the wait
+	// only needs to cover goroutine scheduling — not an HTTP round
+	// trip — for the late callers to arrive at singleflight.Do.
+	time.Sleep(20 * time.Millisecond)
+	close(release)
 	wg.Wait()
 
-	if got := maxConcurrent.Load(); got > 1 {
-		t.Errorf("max in-flight logins = %d, want 1 (singleflight should coalesce)", got)
+	if got := calls.Load(); got != 1 {
+		t.Errorf("HTTP handler called %d times, want 1 (singleflight should coalesce)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- **test(misc)**: AppRoleAuth singleflight test no longer depends on a 50ms handler sleep. The handler now blocks on a channel the test controls, so coalescing is tested against a call-count assertion rather than peak in-flight concurrency. Resolves #345.
- **fix(process)**: In the process-backend build path, `cmd.Wait` used to race with the ingest goroutines — for near-instant children like the `/bin/echo` test stand-in, Wait could close the parent side of the stdout/stderr pipes before any reader attached, silently discarding output. Move `cmd.Wait` to the main goroutine, after `wg.Wait`, so pipes are drained before they're closed. Resolves #349 (which CI on this very PR uncovered).

Fixes #345
Fixes #349