### PR TITLE
fix(misc): warn on removed vault.token_file key in loaded TOML

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -326,11 +326,12 @@ func Load(path string) (*Config, error) {
 	}
 
 	var cfg Config
-	if err := toml.Unmarshal(data, &cfg); err != nil {
+	meta, err := toml.Decode(string(data), &cfg)
+	if err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
 
-	warnRemovedKeys(data)
+	warnRemovedKeys(meta)
 	migrateDeprecatedFields(&cfg)
 	applyDefaults(&cfg)
 	applyEnvOverrides(&cfg)
@@ -372,21 +373,14 @@ func migrateDeprecatedFields(cfg *Config) {
 	}
 }
 
-// warnRemovedKeys re-parses the raw TOML into a generic map and warns
-// when any config key that used to be valid but has since been removed
-// still appears in the operator's file. Needed because BurntSushi/toml
-// silently ignores unknown keys when unmarshaling into a struct, so a
-// schema-change otherwise lands without a peep.
-func warnRemovedKeys(data []byte) {
-	var raw map[string]any
-	if err := toml.Unmarshal(data, &raw); err != nil {
-		// Load already surfaced the parse error; nothing to do here.
-		return
-	}
-	if vault, ok := raw["vault"].(map[string]any); ok {
-		if _, ok := vault["token_file"]; ok {
-			slog.Warn("config: vault.token_file is deprecated and ignored; remove it from your config")
-		}
+// warnRemovedKeys emits a deprecation warning for any config key that
+// used to be valid but has since been removed. BurntSushi/toml silently
+// ignores unknown keys when decoding into a struct, so a schema change
+// otherwise lands without a peep — we consult the decoder metadata to
+// surface them instead.
+func warnRemovedKeys(meta toml.MetaData) {
+	if meta.IsDefined("vault", "token_file") {
+		slog.Warn("config: vault.token_file is deprecated and ignored; remove it from your config")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -330,6 +330,7 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
 
+	warnRemovedKeys(data)
 	migrateDeprecatedFields(&cfg)
 	applyDefaults(&cfg)
 	applyEnvOverrides(&cfg)
@@ -368,6 +369,24 @@ func migrateDeprecatedFields(cfg *Config) {
 		}
 		slog.Warn("config: [openbao] is deprecated; rename the section to [vault]")
 		cfg.Openbao = nil
+	}
+}
+
+// warnRemovedKeys re-parses the raw TOML into a generic map and warns
+// when any config key that used to be valid but has since been removed
+// still appears in the operator's file. Needed because BurntSushi/toml
+// silently ignores unknown keys when unmarshaling into a struct, so a
+// schema-change otherwise lands without a peep.
+func warnRemovedKeys(data []byte) {
+	var raw map[string]any
+	if err := toml.Unmarshal(data, &raw); err != nil {
+		// Load already surfaced the parse error; nothing to do here.
+		return
+	}
+	if vault, ok := raw["vault"].(map[string]any); ok {
+		if _, ok := vault["token_file"]; ok {
+			slog.Warn("config: vault.token_file is deprecated and ignored; remove it from your config")
+		}
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -40,6 +41,18 @@ func loadFromString(t *testing.T, content string) *Config {
 		t.Fatal(err)
 	}
 	return cfg
+}
+
+// captureSlog routes slog.Default output into a buffer for the lifetime
+// of the test, so assertions can inspect warning messages. Restores the
+// previous default logger on cleanup.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
 }
 
 func TestParseMinimalConfig(t *testing.T) {
@@ -1010,6 +1023,30 @@ func TestDeprecatedOpenbaoEnvVarMigrates(t *testing.T) {
 	cfg := loadFromString(t, vaultTOML(t))
 	if cfg.Vault.TokenTTL.Duration != 45*time.Minute {
 		t.Errorf("token_ttl = %v, want 45m (from deprecated env var)", cfg.Vault.TokenTTL.Duration)
+	}
+}
+
+// TestRemovedVaultTokenFileWarns verifies that an upgraded config still
+// carrying the removed vault.token_file key triggers an explicit
+// deprecation warning rather than being silently dropped by the TOML
+// decoder.
+func TestRemovedVaultTokenFileWarns(t *testing.T) {
+	logs := captureSlog(t)
+	toml := vaultTOML(t) + "token_file = \"/data/.vault-token\"\n"
+	loadFromString(t, toml)
+	if !strings.Contains(logs.String(), "vault.token_file is deprecated") {
+		t.Errorf("expected deprecation warning for vault.token_file, got logs:\n%s", logs.String())
+	}
+}
+
+// TestRemovedVaultTokenFileNotPresent ensures the deprecation warning
+// does not fire when the key is absent — otherwise every startup noise
+// would be indistinguishable from an actual upgrade problem.
+func TestRemovedVaultTokenFileNotPresent(t *testing.T) {
+	logs := captureSlog(t)
+	loadFromString(t, vaultTOML(t))
+	if strings.Contains(logs.String(), "vault.token_file is deprecated") {
+		t.Errorf("unexpected token_file warning for clean config:\n%s", logs.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- Re-parse raw TOML after `toml.Unmarshal` and `slog.Warn` when `vault.token_file` is still present — otherwise BurntSushi/toml drops the (now-removed) key silently and operators lose the signal.
- Added two tests around the new `warnRemovedKeys` helper, plus a `captureSlog` test helper that routes `slog.Default` into a buffer for the test lifetime.

Fixes #344