### PR TITLE
feat(misc): opt-in response-wrapped secret_id delivery

### DIFF
--- a/cmd/blockyard/main.go
+++ b/cmd/blockyard/main.go
@@ -234,6 +234,7 @@ func main() {
 		if cfg.Vault.RoleID != "" {
 			// AppRole auth flow.
 			auth := integration.NewAppRoleAuth(cfg.Vault.Address, cfg.Vault.RoleID, cfg.Vault.SecretIDFile).
+				WithSecretIDWrapped(cfg.Vault.SecretIDWrapped).
 				WithHTTPClient(vaultHTTPClient)
 			if err := auth.Login(context.Background()); err != nil {
 				slog.Error("vault authentication failed", "error", err)

--- a/docs/content/docs/guides/credentials.md
+++ b/docs/content/docs/guides/credentials.md
@@ -135,13 +135,71 @@ With those in place, a secret_id leak requires either privileged
 on-host access (root) or a sandbox escape, both of which compromise
 every secret on the host equally.
 
-> [!NOTE]
-> A stronger opt-in delivery mode using vault response-wrapping — where
-> the on-disk file holds a short-lived wrap token instead of the raw
-> `secret_id`, giving tamper-detection and bounded exposure windows —
-> is tracked in [#337](https://github.com/cynkra/blockyard/issues/337).
-> File-based delivery today is suitable for the standard uid-separated
-> worker threat model.
+### Response-wrapped `secret_id` (file)
+
+For deployments that want **bounded on-disk exposure** and **leak
+detection** on top of the standard uid-perms story, opt in to
+response-wrap mode. The file contains a vault [response-wrap
+token](https://developer.hashicorp.com/vault/docs/concepts/response-wrapping)
+instead of the raw `secret_id`; Blockyard unwraps it at login time:
+
+```toml
+[vault]
+address           = "http://vault:8200"
+role_id           = "blockyard-server"
+token_ttl         = "1h"
+secret_id_file    = "/run/secrets/vault_secret_id"
+secret_id_wrapped = true
+```
+
+Or via env var: `BLOCKYARD_VAULT_SECRET_ID_WRAPPED=true`.
+
+Properties this gives you on top of raw-file delivery:
+
+- **Time-bounded exposure.** The on-disk artifact is valid for the
+  wrap TTL only (vault default 5 min, operator-configurable). After
+  the TTL elapses, even an attacker with the file bytes gets nothing.
+- **Tamper detection.** Wrap tokens are single-use. If a hostile
+  process reads and unwraps the file before Blockyard does,
+  Blockyard's unwrap fails loudly and the login errors — the operator
+  sees something broke instead of a silent read.
+- **Same rotation story.** The rotation tool produces a fresh wrap
+  token per rotation and overwrites the file; Blockyard unwraps on
+  every change. Plaintext is cached keyed by file contents, so
+  proactive re-logins don't burn additional unwraps against the same
+  rotation.
+
+Blockyard requires `secret_id_file` to be set when this flag is on;
+the file path is the input to the unwrap.
+
+#### Generating wrap tokens
+
+A Vault Agent config that keeps `/run/secrets/vault_secret_id` holding
+a fresh 5-minute wrap token looks like:
+
+```hcl
+auto_auth {
+  method "approle" {
+    config = {
+      role_id_file_path   = "/run/secrets/role_id"
+      secret_id_file_path = "/run/secrets/agent_secret_id"
+    }
+  }
+}
+
+template {
+  destination = "/run/secrets/vault_secret_id"
+  perms       = "0400"
+
+  contents = <<EOT
+{{ with secret "auth/approle/role/blockyard-server/secret-id" "-wrap-ttl=5m" }}{{ .WrapInfo.Token }}{{ end }}
+EOT
+}
+```
+
+The same idea works with a cron job that calls
+`vault write -f -wrap-ttl=5m auth/approle/role/blockyard-server/secret-id`
+and writes `.wrap_info.token` to the file atomically.
 
 ### Migrating from `admin_token`
 

--- a/docs/content/docs/reference/config.md
+++ b/docs/content/docs/reference/config.md
@@ -395,12 +395,13 @@ Enable Vault-compatible credential management. Requires `[oidc]` to also be conf
 
 ```toml
 [vault]
-address          = "http://openbao:8200"
-role_id          = "blockyard-server"           # AppRole role identifier (recommended)
-# admin_token    = "vault-admin-token"          # deprecated: use role_id instead
-token_ttl        = "1h"
-jwt_auth_path    = "jwt"
-# secret_id_file = "/run/secrets/vault_secret_id"   # opt-in: re-read secret_id on each login for rotation
+address            = "http://openbao:8200"
+role_id            = "blockyard-server"          # AppRole role identifier (recommended)
+# admin_token      = "vault-admin-token"         # deprecated: use role_id instead
+token_ttl          = "1h"
+jwt_auth_path      = "jwt"
+# secret_id_file    = "/run/secrets/vault_secret_id"   # opt-in: re-read secret_id on each login for rotation
+# secret_id_wrapped = true                             # opt-in: secret_id_file holds a response-wrap token to unwrap at login
 ```
 
 | Field | Type | Default | Required | Description |
@@ -410,7 +411,8 @@ jwt_auth_path    = "jwt"
 | `admin_token` | `string` | — | One of `role_id` or `admin_token` | **Deprecated.** Static admin token. Supports [vault references](#vault-references). Use `role_id` with AppRole auth instead. |
 | `token_ttl` | `duration` | `1h` | No | TTL hint; the actual TTL is whatever vault returns on login. Shorten it to make rotation propagate faster. |
 | `jwt_auth_path` | `string` | `jwt` | No | Auth method mount path in the vault |
-| `secret_id_file` | `string` | — | No | Path to a file containing the AppRole `secret_id`. When set, the file is re-read on every login so `secret_id` rotations on disk take effect without restarting Blockyard. Takes precedence over `BLOCKYARD_VAULT_SECRET_ID`. |
+| `secret_id_file` | `string` | — | No | Path to a file containing the AppRole `secret_id` (or, with `secret_id_wrapped`, a response-wrap token). When set, the file is re-read on every login so rotations on disk take effect without restarting Blockyard. Takes precedence over `BLOCKYARD_VAULT_SECRET_ID`. |
+| `secret_id_wrapped` | `boolean` | `false` | No | Treat `secret_id_file` contents as a vault response-wrap token; Blockyard calls `sys/wrapping/unwrap` to fetch the real `secret_id`. Gives time-bounded on-disk exposure and tamper detection. Requires `secret_id_file`. |
 | `ca_cert` | `string` | — | No | Path to a PEM-encoded CA bundle used to verify the vault server's TLS certificate. When set, replaces the system CA bundle for vault HTTP calls (matches `VAULT_CACERT` semantics). Overridable via `BLOCKYARD_VAULT_CA_CERT`. |
 | `skip_policy_scope_check` | `boolean` | `false` | No | Skip the policy scope check during vault bootstrap. Useful when the vault policy format differs from what Blockyard expects. |
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -286,6 +286,7 @@ type VaultConfig struct {
 	TokenTTL             Duration        `toml:"token_ttl"`                // default: 1h
 	JWTAuthPath          string          `toml:"jwt_auth_path"`            // default: "jwt"
 	SecretIDFile         string          `toml:"secret_id_file"`           // opt-in: read secret_id from this path at every AppRole login, enabling rotation without restart
+	SecretIDWrapped      bool            `toml:"secret_id_wrapped"`        // opt-in: treat secret_id_file contents as a response-wrap token to unwrap at login time
 	CACert               string          `toml:"ca_cert"`                  // path to PEM file; when set, replaces system CA trust for vault HTTP calls
 	SkipPolicyScopeCheck bool            `toml:"skip_policy_scope_check"`
 	Services             []ServiceConfig `toml:"services"`
@@ -870,6 +871,9 @@ func validate(cfg *Config) error {
 		}
 		if !cfg.Vault.AdminToken.IsEmpty() {
 			slog.Warn("vault.admin_token is deprecated; use vault.role_id with AppRole auth")
+		}
+		if cfg.Vault.SecretIDWrapped && cfg.Vault.SecretIDFile == "" {
+			return fmt.Errorf("config: vault.secret_id_wrapped requires vault.secret_id_file")
 		}
 		if cfg.OIDC == nil {
 			return fmt.Errorf("config: [oidc] is required when [vault] is configured")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -908,6 +908,48 @@ func TestVaultSecretIDFileSet(t *testing.T) {
 	}
 }
 
+func TestVaultSecretIDWrappedRequiresFile(t *testing.T) {
+	// secret_id_wrapped without secret_id_file is a configuration
+	// error — the file path is the unwrap input.
+	toml := strings.Replace(
+		vaultTOML(t),
+		`admin_token = "hvs.admin123"`,
+		`role_id            = "blockyard-server"`+"\n"+`secret_id_wrapped  = true`,
+		1,
+	)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "blockyard.toml")
+	os.WriteFile(path, []byte(toml), 0o644)
+	_, err := Load(path)
+	if err == nil || !strings.Contains(err.Error(), "secret_id_wrapped") {
+		t.Errorf("expected vault.secret_id_wrapped error, got %v", err)
+	}
+}
+
+func TestVaultSecretIDWrappedEnabled(t *testing.T) {
+	toml := strings.Replace(
+		vaultTOML(t),
+		`admin_token = "hvs.admin123"`,
+		`role_id            = "blockyard-server"`+"\n"+
+			`secret_id_file     = "/run/secrets/vault_secret_id"`+"\n"+
+			`secret_id_wrapped  = true`,
+		1,
+	)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "blockyard.toml")
+	os.WriteFile(path, []byte(toml), 0o644)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.Vault.SecretIDWrapped {
+		t.Error("expected secret_id_wrapped = true")
+	}
+	if cfg.Vault.SecretIDFile != "/run/secrets/vault_secret_id" {
+		t.Errorf("secret_id_file = %q", cfg.Vault.SecretIDFile)
+	}
+}
+
 func TestParseConfigWithoutVault(t *testing.T) {
 	cfg := loadFromString(t, minimalTOML)
 	if cfg.Vault != nil {

--- a/internal/integration/approle.go
+++ b/internal/integration/approle.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -74,10 +75,11 @@ func appRoleLogin(ctx context.Context, httpClient *http.Client, addr, roleID, se
 // trigger an on-demand re-login through the same singleflight-coalesced
 // path.
 type AppRoleAuth struct {
-	addr         string
-	roleID       string
-	secretIDFile string // empty → read BLOCKYARD_VAULT_SECRET_ID from the process environment
-	httpClient   *http.Client
+	addr            string
+	roleID          string
+	secretIDFile    string // empty → read BLOCKYARD_VAULT_SECRET_ID from the process environment
+	secretIDWrapped bool   // when true, file contents are a response-wrap token to unwrap at login time
+	httpClient      *http.Client
 
 	token    atomic.Value // string
 	expireAt atomic.Value // time.Time — zero until first successful login
@@ -88,6 +90,14 @@ type AppRoleAuth struct {
 	// timerMu guards the scheduling state updated from both Login and Run.
 	timerMu sync.Mutex
 	nextAt  time.Time
+
+	// Wrap-unwrap cache. Wrap tokens are single-use, so re-unwrapping
+	// the same bytes fails — we cache the plaintext keyed by the SHA-256
+	// of the file contents and only re-unwrap when the file changes.
+	// Accessed only from resolveSecretID, which runs under the "login"
+	// singleflight, so no lock is needed.
+	unwrapHash      [sha256.Size]byte
+	unwrapPlaintext string
 }
 
 // NewAppRoleAuth constructs an AppRoleAuth. secretIDFile may be empty,
@@ -111,6 +121,16 @@ func NewAppRoleAuth(addr, roleID, secretIDFile string) *AppRoleAuth {
 // receiver to allow chaining from NewAppRoleAuth.
 func (a *AppRoleAuth) WithHTTPClient(h *http.Client) *AppRoleAuth {
 	a.httpClient = h
+	return a
+}
+
+// WithSecretIDWrapped enables response-wrap mode: the secret_id file
+// is treated as a vault wrap token, and the real secret_id is fetched
+// via sys/wrapping/unwrap on every login for which the file has
+// changed. Requires SecretIDFile to be set. Returns the receiver to
+// allow chaining from NewAppRoleAuth.
+func (a *AppRoleAuth) WithSecretIDWrapped(b bool) *AppRoleAuth {
+	a.secretIDWrapped = b
 	return a
 }
 
@@ -144,7 +164,7 @@ func (a *AppRoleAuth) Login(ctx context.Context) error {
 }
 
 func (a *AppRoleAuth) doLogin(ctx context.Context) error {
-	secretID, err := a.resolveSecretID()
+	secretID, err := a.resolveSecretID(ctx)
 	if err != nil {
 		a.healthy.Store(false)
 		return err
@@ -170,9 +190,12 @@ func (a *AppRoleAuth) doLogin(ctx context.Context) error {
 
 // resolveSecretID returns the secret_id to use for the next login. When
 // SecretIDFile is set, the file is re-read every call so a rotation on
-// disk is picked up immediately. Otherwise BLOCKYARD_VAULT_SECRET_ID is
-// read from the process environment.
-func (a *AppRoleAuth) resolveSecretID() (string, error) {
+// disk is picked up immediately. In wrap mode the file contents are a
+// single-use response-wrap token; the plaintext secret_id is cached
+// against the file's hash so proactive re-logins don't burn extra
+// unwraps against the same rotation. Without SecretIDFile, the
+// BLOCKYARD_VAULT_SECRET_ID env var is used.
+func (a *AppRoleAuth) resolveSecretID(ctx context.Context) (string, error) {
 	if a.secretIDFile != "" {
 		data, err := os.ReadFile(a.secretIDFile) //nolint:gosec // G304: operator-configured path
 		if err != nil {
@@ -182,13 +205,71 @@ func (a *AppRoleAuth) resolveSecretID() (string, error) {
 		if s == "" {
 			return "", fmt.Errorf("secret_id file %q is empty", a.secretIDFile)
 		}
-		return s, nil
+		if !a.secretIDWrapped {
+			return s, nil
+		}
+		hash := sha256.Sum256([]byte(s))
+		if hash == a.unwrapHash && a.unwrapPlaintext != "" {
+			return a.unwrapPlaintext, nil
+		}
+		plaintext, err := unwrapSecretID(ctx, a.httpClient, a.addr, s)
+		if err != nil {
+			return "", fmt.Errorf("unwrap secret_id file %q: %w", a.secretIDFile, err)
+		}
+		a.unwrapHash = hash
+		a.unwrapPlaintext = plaintext
+		return plaintext, nil
 	}
 	s := os.Getenv("BLOCKYARD_VAULT_SECRET_ID")
 	if s == "" {
 		return "", errors.New("set BLOCKYARD_VAULT_SECRET_ID or vault.secret_id_file")
 	}
 	return s, nil
+}
+
+// wrappingUnwrapResponse is the relevant subset of the vault
+// sys/wrapping/unwrap response when the wrapped payload was a
+// {"secret_id": ..., "secret_id_accessor": ...} envelope (the shape
+// `vault write -f -wrap-ttl=… auth/approle/role/<name>/secret-id`
+// produces).
+type wrappingUnwrapResponse struct {
+	Data struct {
+		SecretID string `json:"secret_id"`
+	} `json:"data"`
+	Errors []string `json:"errors"`
+}
+
+// unwrapSecretID POSTs a wrap token to sys/wrapping/unwrap and returns
+// the enclosed secret_id. Wrap tokens are single-use: a repeat unwrap
+// of the same token fails, which is the intended tamper signal when a
+// hostile process consumed the token before blockyard did.
+func unwrapSecretID(ctx context.Context, httpClient *http.Client, addr, wrapToken string) (string, error) {
+	url := strings.TrimRight(addr, "/") + "/v1/sys/wrapping/unwrap"
+	req, err := http.NewRequestWithContext(ctx, "POST", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("unwrap: %w", err)
+	}
+	req.Header.Set("X-Vault-Token", wrapToken)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("unwrap: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		io.Copy(io.Discard, resp.Body)
+		return "", fmt.Errorf("unwrap: status %d", resp.StatusCode)
+	}
+
+	var result wrappingUnwrapResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("unwrap: decode: %w", err)
+	}
+	if result.Data.SecretID == "" {
+		return "", fmt.Errorf("unwrap: empty secret_id in response")
+	}
+	return result.Data.SecretID, nil
 }
 
 // Run blocks until ctx is cancelled, re-logging in shortly before each

--- a/internal/integration/approle_test.go
+++ b/internal/integration/approle_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -424,6 +425,85 @@ func TestAppRoleAuthWrappedReunwrapsAfterRotation(t *testing.T) {
 	}
 	if len(*seen) != 2 || (*seen)[0] != "plain-A" || (*seen)[1] != "plain-B" {
 		t.Errorf("server received %v, want [plain-A plain-B]", *seen)
+	}
+}
+
+func TestAppRoleAuthWrappedUnwrapDecodeErrorIsFatal(t *testing.T) {
+	// sys/wrapping/unwrap returns 200 with a non-JSON body: the
+	// unwrap must error out rather than treat the garbage as a
+	// successful response.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/sys/wrapping/unwrap" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("not-json"))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret_id")
+	if err := os.WriteFile(path, []byte("wrap"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := NewAppRoleAuth(srv.URL, "r", path).WithSecretIDWrapped(true)
+	if err := a.Login(context.Background()); err == nil {
+		t.Fatal("expected Login to fail when unwrap body is malformed JSON")
+	}
+	if a.Healthy() {
+		t.Error("Healthy() = true after decode failure")
+	}
+}
+
+func TestAppRoleAuthWrappedUnwrapEmptyResponseIsFatal(t *testing.T) {
+	// sys/wrapping/unwrap returns 200 with no secret_id. Without this
+	// guard we'd attempt an AppRole login with an empty secret_id,
+	// which is a distinct, more confusing failure mode.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/sys/wrapping/unwrap" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{}})
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret_id")
+	if err := os.WriteFile(path, []byte("wrap"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := NewAppRoleAuth(srv.URL, "r", path).WithSecretIDWrapped(true)
+	err := a.Login(context.Background())
+	if err == nil {
+		t.Fatal("expected Login to fail when unwrap returns empty secret_id")
+	}
+	if !strings.Contains(err.Error(), "empty secret_id") {
+		t.Errorf("error %v does not mention empty secret_id", err)
+	}
+}
+
+func TestAppRoleAuthWrappedUnwrapNetworkErrorIsFatal(t *testing.T) {
+	// Point at a server that has already been closed: httpClient.Do
+	// fails at the transport layer, exercising the dial-error return
+	// path distinct from the non-200-status path.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	addr := srv.URL
+	srv.Close()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret_id")
+	if err := os.WriteFile(path, []byte("wrap"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := NewAppRoleAuth(addr, "r", path).WithSecretIDWrapped(true)
+	if err := a.Login(context.Background()); err == nil {
+		t.Fatal("expected Login to fail when unwrap cannot reach the server")
 	}
 }
 

--- a/internal/integration/approle_test.go
+++ b/internal/integration/approle_test.go
@@ -274,6 +274,186 @@ func TestClient403TriggersReloginAndRetries(t *testing.T) {
 	}
 }
 
+// wrappedApproleServer returns a test vault that answers both
+// POST /v1/sys/wrapping/unwrap and POST /v1/auth/approle/login.
+// Each unwrap call consumes one token from wrapTokens in order,
+// mapping it to the matching plaintext from plaintexts. The approle
+// handler records every secret_id it received so tests can assert
+// which plaintext reached the login endpoint.
+func wrappedApproleServer(t *testing.T, wrapTokens, plaintexts []string) (url string, seenSecrets *[]string, unwrapCount, loginCount *atomic.Int32) {
+	t.Helper()
+	if len(wrapTokens) != len(plaintexts) {
+		t.Fatalf("wrapTokens and plaintexts length mismatch: %d vs %d", len(wrapTokens), len(plaintexts))
+	}
+	var (
+		mu          sync.Mutex
+		seen        []string
+		unwraps     atomic.Int32
+		logins      atomic.Int32
+		tokenToPlain = make(map[string]string, len(wrapTokens))
+		consumed    = make(map[string]bool, len(wrapTokens))
+	)
+	for i, tok := range wrapTokens {
+		tokenToPlain[tok] = plaintexts[i]
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/sys/wrapping/unwrap":
+			unwraps.Add(1)
+			tok := r.Header.Get("X-Vault-Token")
+			mu.Lock()
+			plain, ok := tokenToPlain[tok]
+			already := consumed[tok]
+			if ok && !already {
+				consumed[tok] = true
+			}
+			mu.Unlock()
+			if !ok || already {
+				// Unknown wrap token or already-consumed — matches
+				// vault's real tamper behaviour.
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"secret_id": plain},
+			})
+		case "/v1/auth/approle/login":
+			logins.Add(1)
+			var body struct {
+				RoleID   string `json:"role_id"`
+				SecretID string `json:"secret_id"`
+			}
+			json.NewDecoder(r.Body).Decode(&body)
+			mu.Lock()
+			seen = append(seen, body.SecretID)
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"auth": map[string]any{
+					"client_token":   fmt.Sprintf("hvs.login-%d", logins.Load()),
+					"lease_duration": 3600,
+				},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL, &seen, &unwraps, &logins
+}
+
+func TestAppRoleAuthUnwrapsWrappedSecretID(t *testing.T) {
+	url, seen, unwraps, logins := wrappedApproleServer(t,
+		[]string{"wrap-token-A"}, []string{"real-secret-A"})
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret_id")
+	if err := os.WriteFile(path, []byte("wrap-token-A\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := NewAppRoleAuth(url, "my-role", path).WithSecretIDWrapped(true)
+	if err := a.Login(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !a.Healthy() {
+		t.Error("Healthy() = false after successful wrapped login")
+	}
+	if got := unwraps.Load(); got != 1 {
+		t.Errorf("unwrap calls = %d, want 1", got)
+	}
+	if got := logins.Load(); got != 1 {
+		t.Errorf("login calls = %d, want 1", got)
+	}
+	if len(*seen) != 1 || (*seen)[0] != "real-secret-A" {
+		t.Errorf("server received secret_ids %v, want [real-secret-A] (unwrapped plaintext)", *seen)
+	}
+}
+
+func TestAppRoleAuthWrappedCachesPlaintextAcrossLogins(t *testing.T) {
+	// Server will reject a second unwrap of the same wrap token. The
+	// cache must skip the second unwrap so a proactive re-login works
+	// on an unchanged file.
+	url, seen, unwraps, _ := wrappedApproleServer(t,
+		[]string{"wrap-A"}, []string{"plain-A"})
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret_id")
+	if err := os.WriteFile(path, []byte("wrap-A"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := NewAppRoleAuth(url, "r", path).WithSecretIDWrapped(true)
+	if err := a.Login(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Login(context.Background()); err != nil {
+		t.Fatalf("second login failed (cache miss would re-unwrap a consumed token): %v", err)
+	}
+	if got := unwraps.Load(); got != 1 {
+		t.Errorf("unwrap calls = %d, want 1 (cache should coalesce re-logins on unchanged file)", got)
+	}
+	if len(*seen) != 2 || (*seen)[0] != "plain-A" || (*seen)[1] != "plain-A" {
+		t.Errorf("server received %v, want [plain-A plain-A]", *seen)
+	}
+}
+
+func TestAppRoleAuthWrappedReunwrapsAfterRotation(t *testing.T) {
+	url, seen, unwraps, _ := wrappedApproleServer(t,
+		[]string{"wrap-A", "wrap-B"}, []string{"plain-A", "plain-B"})
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret_id")
+	if err := os.WriteFile(path, []byte("wrap-A"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := NewAppRoleAuth(url, "r", path).WithSecretIDWrapped(true)
+	if err := a.Login(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// Rotate the on-disk wrap token.
+	if err := os.WriteFile(path, []byte("wrap-B"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Login(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := unwraps.Load(); got != 2 {
+		t.Errorf("unwrap calls = %d, want 2 (one per distinct wrap token)", got)
+	}
+	if len(*seen) != 2 || (*seen)[0] != "plain-A" || (*seen)[1] != "plain-B" {
+		t.Errorf("server received %v, want [plain-A plain-B]", *seen)
+	}
+}
+
+func TestAppRoleAuthWrappedUnwrapFailureIsFatal(t *testing.T) {
+	// sys/wrapping/unwrap returns 400 (e.g. tampered/consumed token);
+	// the login must fail and Healthy() must be false.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/sys/wrapping/unwrap" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret_id")
+	if err := os.WriteFile(path, []byte("bad-wrap-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := NewAppRoleAuth(srv.URL, "r", path).WithSecretIDWrapped(true)
+	if err := a.Login(context.Background()); err == nil {
+		t.Fatal("expected Login to fail when unwrap returns 400")
+	}
+	if a.Healthy() {
+		t.Error("Healthy() = true after unwrap failure")
+	}
+}
+
 func TestClient403NoReloginWhenNoneConfigured(t *testing.T) {
 	// Static admin-token path (no relogin callback): 403 is terminal.
 	var attempts atomic.Int32


### PR DESCRIPTION
## Summary
- Add `vault.secret_id_wrapped` (env `BLOCKYARD_VAULT_SECRET_ID_WRAPPED`) to treat `secret_id_file` as a vault response-wrap token; Blockyard unwraps it at each login via `sys/wrapping/unwrap`.
- Bounds on-disk exposure to the wrap TTL and turns a hostile tail-read into a loud unwrap failure at the next login (single-use tokens).
- Plaintext is cached keyed by SHA-256 of the file contents, so proactive re-logins on an unchanged rotation don't re-hit the unwrap endpoint.
- Validation: `secret_id_wrapped` requires `secret_id_file`. Raw-file and env-only delivery paths are unchanged.
- Docs: new "Response-wrapped `secret_id` (file)" section with a Vault Agent template; config reference updated.

Fixes #337