### PR TITLE
fix(misc): re-arm AppRoleAuth proactive timer on external Login

### DIFF
--- a/internal/integration/approle.go
+++ b/internal/integration/approle.go
@@ -302,12 +302,11 @@ func (a *AppRoleAuth) Run(ctx context.Context) {
 	backoff := 1 * time.Second
 	const maxBackoff = 60 * time.Second
 
-	timer := time.NewTimer(a.waitUntilNext())
-	defer timer.Stop()
-
 	for {
+		timer := time.NewTimer(a.waitUntilNext())
 		select {
 		case <-ctx.Done():
+			timer.Stop()
 			return
 		case <-timer.C:
 			if err := a.Login(ctx); err != nil {
@@ -322,21 +321,15 @@ func (a *AppRoleAuth) Run(ctx context.Context) {
 			} else {
 				backoff = 1 * time.Second
 			}
-			// Drain the self-kick our own successful Login just emitted
-			// so the next loop iteration doesn't re-arm for no reason.
+			// Drain the self-kick our own Login just emitted (only on
+			// success; on error doLogin returns before kicking). The
+			// next iteration recomputes wait from nextAt either way.
 			select {
 			case <-a.kick:
 			default:
 			}
-			timer.Reset(a.waitUntilNext())
 		case <-a.kick:
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
-			timer.Reset(a.waitUntilNext())
+			timer.Stop()
 		}
 	}
 }

--- a/internal/integration/approle.go
+++ b/internal/integration/approle.go
@@ -91,6 +91,13 @@ type AppRoleAuth struct {
 	timerMu sync.Mutex
 	nextAt  time.Time
 
+	// kick is a buffered (cap 1) signal from doLogin to Run that nextAt
+	// was updated outside the proactive-timer path (startup Login, a
+	// 403-driven re-login). Run re-arms its timer against the fresh
+	// nextAt so the already-armed timer doesn't fire a redundant
+	// second login at its originally-scheduled time.
+	kick chan struct{}
+
 	// Wrap-unwrap cache. Wrap tokens are single-use, so re-unwrapping
 	// the same bytes fails — we cache the plaintext keyed by the SHA-256
 	// of the file contents and only re-unwrap when the file changes.
@@ -111,6 +118,7 @@ func NewAppRoleAuth(addr, roleID, secretIDFile string) *AppRoleAuth {
 		roleID:       roleID,
 		secretIDFile: secretIDFile,
 		httpClient:   DefaultHTTPClient(),
+		kick:         make(chan struct{}, 1),
 	}
 	a.token.Store("")
 	a.expireAt.Store(time.Time{})
@@ -183,6 +191,14 @@ func (a *AppRoleAuth) doLogin(ctx context.Context) error {
 	a.timerMu.Lock()
 	a.nextAt = time.Now().Add(ttl - reloginBuffer)
 	a.timerMu.Unlock()
+
+	// Non-blocking: signal Run to re-arm its timer against the new
+	// nextAt. A full buffer means a previous kick is still pending;
+	// Run will read the latest nextAt when it drains either way.
+	select {
+	case a.kick <- struct{}{}:
+	default:
+	}
 
 	slog.Info("vault AppRole login succeeded", "ttl", ttl)
 	return nil
@@ -278,38 +294,62 @@ func unwrapSecretID(ctx context.Context, httpClient *http.Client, addr, wrapToke
 // can recover. Retries use exponential backoff (1s → 60s cap) because
 // the 403-retry path on admin calls provides the actual recovery signal,
 // so the proactive loop only needs to keep trying without flooding vault.
+//
+// A Login that completes outside this loop (startup bootstrap, 403
+// retry) signals via a.kick so Run re-arms against the fresh nextAt,
+// avoiding a redundant second login at the previously-scheduled time.
 func (a *AppRoleAuth) Run(ctx context.Context) {
 	backoff := 1 * time.Second
 	const maxBackoff = 60 * time.Second
 
+	timer := time.NewTimer(a.waitUntilNext())
+	defer timer.Stop()
+
 	for {
-		a.timerMu.Lock()
-		wait := time.Until(a.nextAt)
-		a.timerMu.Unlock()
-
-		if wait < time.Second {
-			wait = time.Second
-		}
-
-		timer := time.NewTimer(wait)
 		select {
 		case <-ctx.Done():
-			timer.Stop()
 			return
 		case <-timer.C:
-		}
-
-		if err := a.Login(ctx); err != nil {
-			slog.Warn("vault AppRole re-login failed", "error", err, "retry_in", backoff)
-			// On failure, retry with exponential backoff. If an admin
-			// call 403s in the meantime, that call re-logs in through
-			// the same singleflight and kicks nextAt forward.
-			a.timerMu.Lock()
-			a.nextAt = time.Now().Add(backoff)
-			a.timerMu.Unlock()
-			backoff = min(backoff*2, maxBackoff)
-		} else {
-			backoff = 1 * time.Second
+			if err := a.Login(ctx); err != nil {
+				slog.Warn("vault AppRole re-login failed", "error", err, "retry_in", backoff)
+				// On failure, retry with exponential backoff. If an
+				// admin call 403s in the meantime, that call re-logs in
+				// through the same singleflight and kicks nextAt forward.
+				a.timerMu.Lock()
+				a.nextAt = time.Now().Add(backoff)
+				a.timerMu.Unlock()
+				backoff = min(backoff*2, maxBackoff)
+			} else {
+				backoff = 1 * time.Second
+			}
+			// Drain the self-kick our own successful Login just emitted
+			// so the next loop iteration doesn't re-arm for no reason.
+			select {
+			case <-a.kick:
+			default:
+			}
+			timer.Reset(a.waitUntilNext())
+		case <-a.kick:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(a.waitUntilNext())
 		}
 	}
+}
+
+// waitUntilNext returns how long until the currently-scheduled re-login
+// should fire, clamped to a 1s minimum so a missed deadline still gives
+// the vault round-trip room to land.
+func (a *AppRoleAuth) waitUntilNext() time.Duration {
+	a.timerMu.Lock()
+	defer a.timerMu.Unlock()
+	w := time.Until(a.nextAt)
+	if w < time.Second {
+		w = time.Second
+	}
+	return w
 }

--- a/internal/integration/approle_test.go
+++ b/internal/integration/approle_test.go
@@ -266,6 +266,58 @@ func TestAppRoleAuthRunRetriesWithExponentialBackoff(t *testing.T) {
 	}
 }
 
+func TestAppRoleAuthRunReArmsOnExternalLogin(t *testing.T) {
+	// A Login that completes outside Run's timer path (startup, a
+	// 403-driven retry) must push the proactive timer forward. If the
+	// already-armed timer fires anyway it drives a redundant second
+	// login at its original deadline. Verify that an external Login at
+	// T≈500ms prevents a proactive fire at the original T≈1s.
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"auth": map[string]any{"client_token": "hvs.t", "lease_duration": 2},
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("BLOCKYARD_VAULT_SECRET_ID", "s")
+	a := NewAppRoleAuth(srv.URL, "r", "")
+	if err := a.Login(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		a.Run(ctx)
+		close(done)
+	}()
+
+	// External re-login before the proactive timer would fire.
+	time.Sleep(500 * time.Millisecond)
+	if err := a.Login(ctx); err != nil {
+		t.Fatal(err)
+	}
+	after := count.Load()
+	if after != 2 {
+		t.Fatalf("count after external Login = %d, want 2 (initial + external)", after)
+	}
+
+	// The original timer was armed for ~T=1s. With the re-arm it now
+	// fires at ~T=1.5s. Sleep past the original deadline but before
+	// the re-armed one.
+	time.Sleep(700 * time.Millisecond)
+	cancel()
+	<-done
+
+	if got := count.Load(); got != after {
+		t.Errorf("proactive timer fired at its original deadline: count=%d, want %d", got, after)
+	}
+}
+
 func TestClient403TriggersReloginAndRetries(t *testing.T) {
 	// On the first admin call, vault returns 403; the client must
 	// re-login and retry. The retry succeeds with the fresh token.

--- a/internal/integration/approle_test.go
+++ b/internal/integration/approle_test.go
@@ -318,6 +318,36 @@ func TestAppRoleAuthRunReArmsOnExternalLogin(t *testing.T) {
 	}
 }
 
+func TestAppRoleAuthRunHandlesLoginFailure(t *testing.T) {
+	// When the proactive Login fails (e.g. vault rejects us), Run
+	// marks the component unhealthy and pushes nextAt out by 10s so
+	// the loop retries on a coarse schedule rather than tight-looping.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	t.Setenv("BLOCKYARD_VAULT_SECRET_ID", "s")
+	a := NewAppRoleAuth(srv.URL, "r", "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		a.Run(ctx)
+		close(done)
+	}()
+
+	// Initial nextAt is zero so waitUntilNext clamps to 1s. Give Run
+	// time to fire the timer, attempt Login (403), take the error path.
+	time.Sleep(1400 * time.Millisecond)
+	if a.Healthy() {
+		t.Error("Healthy() = true after failed proactive Login")
+	}
+	cancel()
+	<-done
+}
+
 func TestClient403TriggersReloginAndRetries(t *testing.T) {
 	// On the first admin call, vault returns 403; the client must
 	// re-login and retry. The retry succeeds with the fresh token.


### PR DESCRIPTION
## Summary

- A 403-driven re-login updates `nextAt` via the singleflight path, but the proactive timer in `Run()` was still armed against the original deadline and fired a redundant second login.
- Added a buffered (cap 1) `kick` channel from `doLogin` to `Run`; `Run` selects over `ctx.Done()`, the timer, and the kick, and on a kick stops the timer so the next iteration re-arms against the fresh `nextAt`.
- Regression test `TestAppRoleAuthRunReArmsOnExternalLogin` fails on pre-fix code (count=3 at T=1.2s) and passes with the fix (count=2).
- Follow-up cleanup: fresh timer per iteration (avoids the Stop+drain dance) and `TestAppRoleAuthRunHandlesLoginFailure` to cover the proactive-Login error branch.

Fixes #342