### PR TITLE
test(misc): skip image pull when cached locally

### DIFF
--- a/internal/auth/idp_test.go
+++ b/internal/auth/idp_test.go
@@ -50,14 +50,18 @@ func TestMain(m *testing.M) {
 	}
 	defer cli.Close()
 
-	// Pull image (may already be cached from CI pre-pull step).
-	pullResp, err := cli.ImagePull(ctx, keycloakImage, client.ImagePullOptions{})
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "image pull: %v\n", err)
-		os.Exit(1)
+	// Pull the image only when not already cached locally. ImagePull
+	// issues a HEAD against the registry even on cache hits, which fails
+	// the package when the registry token endpoint is slow.
+	if _, err := cli.ImageInspect(ctx, keycloakImage); err != nil {
+		pullResp, err := cli.ImagePull(ctx, keycloakImage, client.ImagePullOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "image pull: %v\n", err)
+			os.Exit(1)
+		}
+		io.Copy(io.Discard, pullResp)
+		pullResp.Close()
 	}
-	io.Copy(io.Discard, pullResp)
-	pullResp.Close()
 
 	// Resolve the absolute path to the realm import file.
 	realmFile, err := filepath.Abs("testdata/blockyard-test-realm.json")

--- a/internal/integration/vault_integration_test.go
+++ b/internal/integration/vault_integration_test.go
@@ -40,14 +40,18 @@ func TestMain(m *testing.M) {
 	}
 	defer cli.Close()
 
-	// Pull image.
-	pullResp, err := cli.ImagePull(ctx, openbaoImage, client.ImagePullOptions{})
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "image pull: %v\n", err)
-		os.Exit(1)
+	// Pull the image only when not already cached locally. ImagePull
+	// issues a HEAD against the registry even on cache hits, which fails
+	// the package when the ghcr.io token endpoint is slow.
+	if _, err := cli.ImageInspect(ctx, openbaoImage); err != nil {
+		pullResp, err := cli.ImagePull(ctx, openbaoImage, client.ImagePullOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "image pull: %v\n", err)
+			os.Exit(1)
+		}
+		io.Copy(io.Discard, pullResp)
+		pullResp.Close()
 	}
-	io.Copy(io.Discard, pullResp)
-	pullResp.Close()
 
 	// Start MockIdP for JWT auth configuration.
 	mockIdP = testutil.NewMockIdP()


### PR DESCRIPTION
## Summary
- `cli.ImagePull` issues a registry HEAD even on cache hits; a slow ghcr.io token endpoint can time it out and fail the package despite the image being present locally.
- Short-circuit with `cli.ImageInspect` in the openbao and idp `TestMain`s — mirrors the existing pattern in `internal/orchestrator/clone_docker.go`.

Fixes #352