### PR TITLE
fix(misc): write bundle status before signaling task done

### DIFF
--- a/internal/bundle/restore.go
+++ b/internal/bundle/restore.go
@@ -74,6 +74,10 @@ func SpawnRestore(params RestoreParams) <-chan struct{} {
 					"bundle_id", params.BundleID,
 					"panic", r)
 				params.Sender.Write("FATAL: an unexpected error occurred during build.")
+				if err := params.DB.UpdateBundleStatus(params.BundleID, "failed"); err != nil {
+					slog.Error("restore: update status to failed after panic",
+						"bundle_id", params.BundleID, "error", err)
+				}
 				params.Sender.Complete(task.Failed)
 				if params.Metrics != nil {
 					params.Metrics.BundleRestoresFailed.Inc()
@@ -86,10 +90,6 @@ func SpawnRestore(params RestoreParams) <-chan struct{} {
 						Detail: map[string]any{"bundle_id": params.BundleID},
 					})
 				}
-				if err := params.DB.UpdateBundleStatus(params.BundleID, "failed"); err != nil {
-					slog.Error("restore: update status to failed after panic",
-						"bundle_id", params.BundleID, "error", err)
-				}
 			}
 		}()
 		buildStart := time.Now()
@@ -100,6 +100,10 @@ func SpawnRestore(params RestoreParams) <-chan struct{} {
 				"elapsed", time.Since(buildStart).Round(time.Millisecond),
 				"error", err)
 			params.Sender.Write(fmt.Sprintf("ERROR: %s", err))
+			if err := params.DB.UpdateBundleStatus(params.BundleID, "failed"); err != nil {
+				slog.Error("restore: update status to failed",
+					"bundle_id", params.BundleID, "error", err)
+			}
 			params.Sender.Complete(task.Failed)
 			if params.Metrics != nil {
 				params.Metrics.BundleRestoresFailed.Inc()
@@ -111,10 +115,6 @@ func SpawnRestore(params RestoreParams) <-chan struct{} {
 					Target: params.AppID,
 					Detail: map[string]any{"bundle_id": params.BundleID},
 				})
-			}
-			if err := params.DB.UpdateBundleStatus(params.BundleID, "failed"); err != nil {
-				slog.Error("restore: update status to failed",
-					"bundle_id", params.BundleID, "error", err)
 			}
 			return
 		}

--- a/internal/bundle/restore_errors_test.go
+++ b/internal/bundle/restore_errors_test.go
@@ -162,6 +162,62 @@ func TestSpawnRestore_PanicRecovery(t *testing.T) {
 	}
 }
 
+// TestSpawnRestore_PanicRecovery_DBClosed exercises the error-logging
+// branch in the panic-recovery defer when the failed-status update
+// itself fails (DB connection gone).
+func TestSpawnRestore_PanicRecovery_DBClosed(t *testing.T) {
+	params, tasks := setupRestoreTest(t, true)
+	database := params.DB
+	be := params.Backend.(*mockmock.MockBackend)
+	be.BuildFn = func(context.Context, backend.BuildSpec) (backend.BuildResult, error) {
+		_ = database.Close()
+		panic("simulated backend crash")
+	}
+
+	SpawnRestore(params)
+
+	_, _, doneCh, ok := tasks.Subscribe("task-1")
+	if !ok {
+		t.Fatal("task not found")
+	}
+	select {
+	case <-doneCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out")
+	}
+	if status, _ := tasks.Status("task-1"); status != task.Failed {
+		t.Errorf("status = %d, want Failed", status)
+	}
+}
+
+// TestSpawnRestore_BuildError_DBClosed exercises the error-logging
+// branch in the non-panic error path when the failed-status update
+// itself fails.
+func TestSpawnRestore_BuildError_DBClosed(t *testing.T) {
+	params, tasks := setupRestoreTest(t, true)
+	database := params.DB
+	be := params.Backend.(*mockmock.MockBackend)
+	be.BuildFn = func(context.Context, backend.BuildSpec) (backend.BuildResult, error) {
+		_ = database.Close()
+		return backend.BuildResult{}, fmt.Errorf("backend unreachable")
+	}
+
+	SpawnRestore(params)
+
+	_, _, doneCh, ok := tasks.Subscribe("task-1")
+	if !ok {
+		t.Fatal("task not found")
+	}
+	select {
+	case <-doneCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out")
+	}
+	if status, _ := tasks.Status("task-1"); status != task.Failed {
+		t.Errorf("status = %d, want Failed", status)
+	}
+}
+
 // TestRunRestore_InvalidPakVersion covers the error branch when
 // pakcache.EnsureInstalled rejects the version string.
 func TestRunRestore_InvalidPakVersion(t *testing.T) {


### PR DESCRIPTION
## Summary
- The restore goroutine signaled `Sender.Complete(Failed)` before persisting `bundle.status = "failed"` in both the panic-recovery defer and the non-panic error path.
- Tests waiting on the task done channel could read the bundle row while it was still `"building"` — the cause of the intermittent `TestSpawnRestore_PanicRecovery` failure on PR #355.
- Reorder so the DB update lands before the done signal; the post-signal block (metrics, audit) is unaffected.

Fixes #356