### PR TITLE
fix(auth): request offline_access and surface session loss

### DIFF
--- a/docs/content/docs/reference/config.md
+++ b/docs/content/docs/reference/config.md
@@ -363,6 +363,15 @@ default_role         = "viewer"
 > authentication. Users must log in before accessing apps (except for apps
 > with `public` visibility).
 
+> [!NOTE]
+> Blockyard requests `openid profile email offline_access` from the IdP so
+> that long-lived sessions can refresh access tokens without forcing the
+> user to log in again. The IdP must advertise `offline_access` in
+> `scopes_supported` and grant it to the client; otherwise the authorize
+> request fails with `invalid_scope`. For Authentik this means adding the
+> bundled `offline_access` scope to the provider's property mappings.
+> Dex grants refresh tokens by default and needs no extra configuration.
+
 ### Split-URL OIDC
 
 In Docker or Kubernetes deployments, the OIDC provider (e.g. Dex, Keycloak)

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -395,6 +395,13 @@ func TestMiddlewareMissingServerSession(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Errorf("expected 200 for missing session (pass-through), got %d", w.Code)
 	}
+
+	// The middleware should clear the stale cookie so the browser stops
+	// presenting it on subsequent requests.
+	cleared := findCookie(w.Result(), "blockyard_session")
+	if cleared == nil || cleared.Value != "" {
+		t.Errorf("expected session cookie to be cleared, got %+v", cleared)
+	}
 }
 
 func TestMiddlewareContextCarriesUser(t *testing.T) {

--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -77,6 +77,16 @@ func secureFlag(cfg *config.Config) string {
 	return ""
 }
 
+// clearSessionCookie writes a Set-Cookie header that clears the
+// blockyard_session cookie on the client. Used by LogoutHandler and
+// by AppAuthMiddleware whenever it discards a stale or invalid session.
+func clearSessionCookie(w http.ResponseWriter, cfg *config.Config) {
+	w.Header().Add("Set-Cookie", fmt.Sprintf(
+		"blockyard_session=; Path=/; HttpOnly%s; Max-Age=0",
+		secureFlag(cfg),
+	))
+}
+
 // randomHex generates a cryptographically random hex string of n bytes.
 func randomHex(n int) (string, error) {
 	b := make([]byte, n)
@@ -384,11 +394,7 @@ func LogoutHandler(deps *Deps) http.HandlerFunc {
 			})
 		}
 
-		secure := secureFlag(deps.Config)
-		clearCookie := fmt.Sprintf(
-			"blockyard_session=; Path=/; HttpOnly%s; Max-Age=0", secure,
-		)
-		w.Header().Set("Set-Cookie", clearCookie)
+		clearSessionCookie(w, deps.Config)
 
 		if deps.OIDCClient != nil {
 			if endSession := deps.OIDCClient.EndSessionEndpoint(); endSession != "" {

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -58,6 +58,7 @@ func AppAuthMiddleware(deps *Deps) func(http.Handler) http.Handler {
 			cookie, err := DecodeCookie(cookieValue, deps.SigningKey)
 			if err != nil {
 				slog.Debug("auth: invalid session cookie", "error", err)
+				clearSessionCookie(w, deps.Config)
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -69,6 +70,7 @@ func AppAuthMiddleware(deps *Deps) func(http.Handler) http.Handler {
 			}
 			if nowUnix()-cookie.IssuedAt > maxAge {
 				slog.Debug("auth: session cookie expired", "sub", cookie.Sub)
+				clearSessionCookie(w, deps.Config)
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -76,6 +78,7 @@ func AppAuthMiddleware(deps *Deps) func(http.Handler) http.Handler {
 			session := deps.UserSessions.Get(cookie.Sub)
 			if session == nil {
 				slog.Debug("auth: no server-side session", "sub", cookie.Sub)
+				clearSessionCookie(w, deps.Config)
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -86,6 +89,7 @@ func AppAuthMiddleware(deps *Deps) func(http.Handler) http.Handler {
 				slog.Error("token refresh failed, removing session",
 					"sub", cookie.Sub, "error", err)
 				deps.UserSessions.Delete(cookie.Sub)
+				clearSessionCookie(w, deps.Config)
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -80,7 +80,7 @@ func Discover(ctx context.Context, issuerURL, discoveryURL, clientID, clientSecr
 		ClientSecret: clientSecret,
 		Endpoint:     endpoint,
 		RedirectURL:  redirectURL,
-		Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},
+		Scopes:       []string{oidc.ScopeOpenID, "profile", "email", oidc.ScopeOfflineAccess},
 	}
 
 	verifier := provider.Verifier(&oidc.Config{

--- a/internal/auth/testdata/blockyard-test-realm.json
+++ b/internal/auth/testdata/blockyard-test-realm.json
@@ -53,7 +53,8 @@
           "temporary": false
         }
       ],
-      "groups": ["testers"]
+      "groups": ["testers"],
+      "realmRoles": ["offline_access", "uma_authorization"]
     }
   ]
 }

--- a/internal/auth/testdata/blockyard-test-realm.json
+++ b/internal/auth/testdata/blockyard-test-realm.json
@@ -15,6 +15,8 @@
       "publicClient": false,
       "standardFlowEnabled": true,
       "directAccessGrantsEnabled": false,
+      "defaultClientScopes": ["acr", "basic", "email", "profile", "roles", "web-origins"],
+      "optionalClientScopes": ["address", "microprofile-jwt", "offline_access", "phone"],
       "protocolMappers": [
         {
           "name": "groups",

--- a/internal/bundle/restore.go
+++ b/internal/bundle/restore.go
@@ -78,10 +78,10 @@ func SpawnRestore(params RestoreParams) <-chan struct{} {
 					slog.Error("restore: update status to failed after panic",
 						"bundle_id", params.BundleID, "error", err)
 				}
-				params.Sender.Complete(task.Failed)
 				if params.Metrics != nil {
 					params.Metrics.BundleRestoresFailed.Inc()
 				}
+				params.Sender.Complete(task.Failed)
 				if params.AuditLog != nil {
 					params.AuditLog.Emit(audit.Entry{
 						Action: audit.ActionBundleRestoreFail,
@@ -104,10 +104,10 @@ func SpawnRestore(params RestoreParams) <-chan struct{} {
 				slog.Error("restore: update status to failed",
 					"bundle_id", params.BundleID, "error", err)
 			}
-			params.Sender.Complete(task.Failed)
 			if params.Metrics != nil {
 				params.Metrics.BundleRestoresFailed.Inc()
 			}
+			params.Sender.Complete(task.Failed)
 			if params.AuditLog != nil {
 				params.AuditLog.Emit(audit.Entry{
 					Action: audit.ActionBundleRestoreFail,

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -537,6 +537,23 @@ func requireAuth(w http.ResponseWriter, r *http.Request) *auth.AuthenticatedUser
 	return nil
 }
 
+// requireAdmin emits 401 when the caller is unauthenticated or 403 when
+// authenticated but lacking admin privilege. Returns false when the
+// handler should stop. Splitting the two status codes lets the
+// htmx:beforeSwap session-expired modal trigger only on real session
+// loss, not on legitimate "wrong role" rejections.
+func requireAdmin(w http.ResponseWriter, caller *auth.CallerIdentity) bool {
+	if caller == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return false
+	}
+	if !caller.Role.CanManageRoles() {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return false
+	}
+	return true
+}
+
 func vaultEnabled(srv *server.Server) bool {
 	return srv.Config.Vault != nil && len(srv.Config.Vault.Services) > 0
 }
@@ -839,8 +856,7 @@ func (ui *UI) adminPage(srv *server.Server, orch *orchestrator.Orchestrator) htt
 func (ui *UI) adminUsersFragment(srv *server.Server) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		caller := auth.CallerFromContext(r.Context())
-		if caller == nil || !caller.Role.CanManageRoles() {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+		if !requireAdmin(w, caller) {
 			return
 		}
 
@@ -879,8 +895,7 @@ func parseAdminTab(v string) string {
 func (ui *UI) adminTabUsersFragment(srv *server.Server) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		caller := auth.CallerFromContext(r.Context())
-		if caller == nil || !caller.Role.CanManageRoles() {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+		if !requireAdmin(w, caller) {
 			return
 		}
 		data, err := buildAdminUsers(srv, caller, r.URL.Query())
@@ -899,8 +914,7 @@ func (ui *UI) adminTabUsersFragment(srv *server.Server) http.HandlerFunc {
 func (ui *UI) adminTabSystemFragment(srv *server.Server) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		caller := auth.CallerFromContext(r.Context())
-		if caller == nil || !caller.Role.CanManageRoles() {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+		if !requireAdmin(w, caller) {
 			return
 		}
 		var report *preflight.Report
@@ -920,8 +934,7 @@ func (ui *UI) adminTabSystemFragment(srv *server.Server) http.HandlerFunc {
 func (ui *UI) adminTabErrorsFragment(srv *server.Server) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		caller := auth.CallerFromContext(r.Context())
-		if caller == nil || !caller.Role.CanManageRoles() {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+		if !requireAdmin(w, caller) {
 			return
 		}
 		w.Header().Set("Content-Type", "text/html")
@@ -935,8 +948,7 @@ func (ui *UI) adminTabErrorsFragment(srv *server.Server) http.HandlerFunc {
 func (ui *UI) adminTabVersionFragment(srv *server.Server, orch *orchestrator.Orchestrator) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		caller := auth.CallerFromContext(r.Context())
-		if caller == nil || !caller.Role.CanManageRoles() {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+		if !requireAdmin(w, caller) {
 			return
 		}
 		w.Header().Set("Content-Type", "text/html")
@@ -952,8 +964,7 @@ func (ui *UI) adminTabVersionFragment(srv *server.Server, orch *orchestrator.Orc
 func (ui *UI) adminUpdateCheck(srv *server.Server, orch *orchestrator.Orchestrator) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		caller := auth.CallerFromContext(r.Context())
-		if caller == nil || !caller.Role.CanManageRoles() {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+		if !requireAdmin(w, caller) {
 			return
 		}
 		channel := resolveChannel(r, srv)
@@ -976,8 +987,7 @@ func (ui *UI) adminUpdateCheck(srv *server.Server, orch *orchestrator.Orchestrat
 func (ui *UI) adminUpdateStart(srv *server.Server, orch *orchestrator.Orchestrator, bgCtx context.Context) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		caller := auth.CallerFromContext(r.Context())
-		if caller == nil || !caller.Role.CanManageRoles() {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+		if !requireAdmin(w, caller) {
 			return
 		}
 		channel := resolveChannel(r, srv)
@@ -1054,8 +1064,7 @@ func resolveChannel(r *http.Request, srv *server.Server) string {
 func (ui *UI) adminUpdateProgress(srv *server.Server, orch *orchestrator.Orchestrator) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		caller := auth.CallerFromContext(r.Context())
-		if caller == nil || !caller.Role.CanManageRoles() {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+		if !requireAdmin(w, caller) {
 			return
 		}
 		data := buildAdminVersion(srv, orch, "", "")
@@ -1110,8 +1119,7 @@ func buildAdminVersion(srv *server.Server, orch *orchestrator.Orchestrator, chec
 func (ui *UI) adminErrorsFragment(srv *server.Server) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		caller := auth.CallerFromContext(r.Context())
-		if caller == nil || !caller.Role.CanManageRoles() {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+		if !requireAdmin(w, caller) {
 			return
 		}
 		data := buildAdminErrors(srv)
@@ -1267,8 +1275,7 @@ func buildAdminUsers(srv *server.Server, caller *auth.CallerIdentity, q url.Valu
 func (ui *UI) systemRunFragment(srv *server.Server) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		caller := auth.CallerFromContext(r.Context())
-		if caller == nil || caller.Role < auth.RoleAdmin {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+		if !requireAdmin(w, caller) {
 			return
 		}
 

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -2941,6 +2941,23 @@ func TestAdminUsersFragmentForbiddenForNonAdmin(t *testing.T) {
 	}
 }
 
+// An unauthenticated request to an admin fragment must produce 401, not
+// 403, so the htmx:beforeSwap session-expired modal triggers. 403 is
+// reserved for "authenticated but wrong role".
+func TestAdminFragmentUnauthorizedReturns401(t *testing.T) {
+	_, ts := newTestServer(t, oidcConfig())
+
+	resp, err := http.Get(ts.URL + "/ui/admin/users")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401 for unauthenticated admin fragment, got %d", resp.StatusCode)
+	}
+}
+
 func TestAdminUsersFragmentSetsPushURL(t *testing.T) {
 	_, ts := authServer(t, oidcConfig(), "admin-1", auth.RoleAdmin)
 


### PR DESCRIPTION
## Summary

- Add `offline_access` to OIDC scopes so spec-conforming IdPs (Authentik, Keycloak, Auth0) issue refresh tokens. Without it, sessions silently die at the access-token TTL.
- Middleware now clears the stale `blockyard_session` cookie in all four "drop session" branches (invalid cookie, max-age expired, no server-side session, refresh failed).
- Admin/HTMX handlers return 401 (vs 403) when the caller is unauthenticated, so the existing `htmx:beforeSwap` modal triggers on session loss instead of a generic "Request failed" toast. 403 remains reserved for "authenticated but wrong role".
- Documents the Authentik property-mapping requirement in `config.md`.
- Closes #359.