### PR TITLE
fix(process): pin main channel to :main, digest-compare post-pull

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -131,14 +131,47 @@ jobs:
     timeout-minutes: 5
     permissions:
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: everything
+            image_suffix: ""
+          - variant: docker
+            image_suffix: -docker
+          - variant: process
+            image_suffix: -process
     steps:
       - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create and push multi-arch manifest
+      - name: Create and push multi-arch manifest (${{ matrix.variant }})
         run: |
-          docker buildx imagetools create -t "${{ env.IMAGE }}:main" \
-            "${{ env.IMAGE }}:build-linux-amd64" \
-            "${{ env.IMAGE }}:build-linux-arm64"
+          docker buildx imagetools create -t "${{ env.IMAGE }}${{ matrix.image_suffix }}:main" \
+            "${{ env.IMAGE }}${{ matrix.image_suffix }}:build-linux-amd64" \
+            "${{ env.IMAGE }}${{ matrix.image_suffix }}:build-linux-arm64"
+
+  # Registry contract test: assert that the install target the
+  # orchestrator's main-channel resolver constructs actually exists
+  # on ghcr.io. This is the test issue #360 was missing — mock-based
+  # unit tests passed while production was asking Docker to pull a
+  # tag the workflow never published. Build-tag-gated so it only
+  # runs after a publish (pre-publish runs in ci.yml are SKIP'd
+  # automatically).
+  registry-contract:
+    needs: manifest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      packages: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Verify main-channel install target is pullable
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: go test -tags registry_contract -run TestMainChannelInstallTargetIsPullable -v ./internal/update/...

--- a/internal/orchestrator/clone_docker.go
+++ b/internal/orchestrator/clone_docker.go
@@ -202,6 +202,29 @@ func (f *dockerServerFactory) CurrentImageTag(ctx context.Context) string {
 // previous version's image from the registry.
 func (f *dockerServerFactory) SupportsRollback() bool { return true }
 
+// IsAlreadyCurrent reports whether the locally-cached ref resolves
+// to the same image ID as the running container. Caller must have
+// pulled ref via PreUpdate first so the local cache reflects the
+// current registry manifest. Used by the orchestrator's main-channel
+// path to skip backup/drain/clone when the rolling :main tag points
+// at the digest already in use.
+//
+// Returns (false, err) on inspect failures rather than silently
+// returning true — a missing ref or unreachable Docker daemon means
+// "we don't know," and the safer default is to let the orchestrator
+// run the full update path and fail on the next concrete step.
+func (f *dockerServerFactory) IsAlreadyCurrent(ctx context.Context, ref string) (bool, error) {
+	cur, err := f.docker.ContainerInspect(ctx, f.serverID, client.ContainerInspectOptions{})
+	if err != nil {
+		return false, fmt.Errorf("inspect self: %w", err)
+	}
+	img, err := f.docker.ImageInspect(ctx, ref)
+	if err != nil {
+		return false, fmt.Errorf("inspect image %s: %w", ref, err)
+	}
+	return cur.Container.Image == img.ID, nil
+}
+
 // cloneConfig inspects the current container and returns a
 // ContainerCreateOptions for a new container with the given image
 // and additional environment variables. This is the pre-phase-3-8

--- a/internal/orchestrator/clone_docker_test.go
+++ b/internal/orchestrator/clone_docker_test.go
@@ -7,9 +7,11 @@ import (
 	"io"
 	"iter"
 	"net/netip"
+	"strings"
 	"testing"
 
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/api/types/jsonstream"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
@@ -424,6 +426,112 @@ func TestCreateInstanceStartFails(t *testing.T) {
 	_, err := f.CreateInstance(context.Background(), "img:2.0", nil, sender)
 	if err == nil {
 		t.Error("expected error when start fails")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IsAlreadyCurrent
+// ---------------------------------------------------------------------------
+
+// Both inspect calls report the same image ID — the rolling tag
+// resolves to the digest already in use, so the orchestrator must
+// short-circuit (issue #360, Monday-rebuild detection).
+func TestIsAlreadyCurrentSameDigest(t *testing.T) {
+	const digest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	docker := &mockDocker{
+		inspectFn: func(context.Context, string, client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+			return client.ContainerInspectResult{
+				Container: container.InspectResponse{
+					Image:      digest,
+					Config:     &container.Config{Image: "ghcr.io/cynkra/blockyard:main"},
+					HostConfig: &container.HostConfig{},
+				},
+			}, nil
+		},
+		imageInspectFn: func(context.Context, string, ...client.ImageInspectOption) (client.ImageInspectResult, error) {
+			return client.ImageInspectResult{InspectResponse: image.InspectResponse{ID: digest}}, nil
+		},
+	}
+	f := newDockerFactoryForTest(docker, "self-id", func() string { return "8080" })
+
+	current, err := f.IsAlreadyCurrent(context.Background(), "ghcr.io/cynkra/blockyard:main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !current {
+		t.Error("expected IsAlreadyCurrent=true when digests match")
+	}
+}
+
+// Different digests — Monday rebuild produced a new image, the
+// running container is still on the old one. Update must proceed.
+func TestIsAlreadyCurrentDifferentDigest(t *testing.T) {
+	docker := &mockDocker{
+		inspectFn: func(context.Context, string, client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+			return client.ContainerInspectResult{
+				Container: container.InspectResponse{
+					Image:      "sha256:aaaaaaaaaaaa",
+					Config:     &container.Config{Image: "ghcr.io/cynkra/blockyard:main"},
+					HostConfig: &container.HostConfig{},
+				},
+			}, nil
+		},
+		imageInspectFn: func(context.Context, string, ...client.ImageInspectOption) (client.ImageInspectResult, error) {
+			return client.ImageInspectResult{InspectResponse: image.InspectResponse{ID: "sha256:bbbbbbbbbbbb"}}, nil
+		},
+	}
+	f := newDockerFactoryForTest(docker, "self-id", func() string { return "8080" })
+
+	current, err := f.IsAlreadyCurrent(context.Background(), "ghcr.io/cynkra/blockyard:main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if current {
+		t.Error("expected IsAlreadyCurrent=false when digests differ")
+	}
+}
+
+// ImageInspect failing means the just-pulled ref isn't locally
+// resolvable — propagate the error so the orchestrator can abort
+// loudly rather than silently skipping.
+func TestIsAlreadyCurrentMissingImage(t *testing.T) {
+	docker := &mockDocker{
+		inspectFn: func(context.Context, string, client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+			return client.ContainerInspectResult{
+				Container: container.InspectResponse{
+					Image:      "sha256:aaaa",
+					Config:     &container.Config{Image: "ghcr.io/cynkra/blockyard:main"},
+					HostConfig: &container.HostConfig{},
+				},
+			}, nil
+		},
+		// imageInspectFn unset → mockDocker default returns errNotFound.
+	}
+	f := newDockerFactoryForTest(docker, "self-id", func() string { return "8080" })
+
+	_, err := f.IsAlreadyCurrent(context.Background(), "ghcr.io/cynkra/blockyard:main")
+	if err == nil {
+		t.Fatal("expected error when image not found")
+	}
+	if !strings.Contains(err.Error(), "inspect image") {
+		t.Errorf("error %q should mention 'inspect image'", err.Error())
+	}
+}
+
+func TestIsAlreadyCurrentSelfInspectFails(t *testing.T) {
+	docker := &mockDocker{
+		inspectFn: func(context.Context, string, client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+			return client.ContainerInspectResult{}, io.ErrUnexpectedEOF
+		},
+	}
+	f := newDockerFactoryForTest(docker, "self-id", func() string { return "8080" })
+
+	_, err := f.IsAlreadyCurrent(context.Background(), "ghcr.io/cynkra/blockyard:main")
+	if err == nil {
+		t.Fatal("expected error when self-inspect fails")
+	}
+	if !strings.Contains(err.Error(), "inspect self") {
+		t.Errorf("error %q should mention 'inspect self'", err.Error())
 	}
 }
 

--- a/internal/orchestrator/clone_process.go
+++ b/internal/orchestrator/clone_process.go
@@ -129,6 +129,15 @@ func (f *processServerFactory) CurrentImageTag(_ context.Context) string {
 // binary and restarting.
 func (f *processServerFactory) SupportsRollback() bool { return false }
 
+// IsAlreadyCurrent always returns false. The process variant has no
+// registry semantics: ref is ignored everywhere upstream, the binary
+// on disk is whatever the operator put there, and the orchestrator's
+// "update" is effectively a fork+exec restart. Returning false keeps
+// the orchestrator on its full-update path so the restart still runs.
+func (f *processServerFactory) IsAlreadyCurrent(_ context.Context, _ string) (bool, error) {
+	return false, nil
+}
+
 // CreateInstance picks a free alt port, fork+execs a new blockyard
 // with BLOCKYARD_PASSIVE=1 and BLOCKYARD_SERVER_BIND set to the new
 // bind, and returns a handle with the new server's address cached.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -138,6 +138,7 @@ func (stubFactory) PreUpdate(_ context.Context, _ string, _ task.Sender) error {
 func (stubFactory) CurrentImageBase(_ context.Context) string                  { return "blockyard" }
 func (stubFactory) CurrentImageTag(_ context.Context) string                   { return "test" }
 func (f stubFactory) SupportsRollback() bool                                   { return f.supportsRollback }
+func (stubFactory) IsAlreadyCurrent(_ context.Context, _ string) (bool, error) { return false, nil }
 
 // State returns the current orchestrator phase.
 func (o *Orchestrator) State() string {
@@ -186,7 +187,21 @@ func (o *Orchestrator) Update(
 	ctx context.Context,
 	channel string,
 	sender task.Sender,
-) (bool, error) {
+) (updated bool, retErr error) {
+	// Surface failures via the structured logger as well as the
+	// task sender. The sender goes to the UI progress card and is
+	// gone the moment the user closes the tab; structured logs land
+	// in journalctl/docker logs and are what an operator greps for
+	// when "Update" silently does nothing (issue #360).
+	defer func() {
+		if retErr != nil {
+			o.log.Error("orchestrator update failed",
+				"channel", channel,
+				"current", o.version,
+				"error", retErr)
+		}
+	}()
+
 	// 1. Resolve install target for the configured channel.
 	target, err := o.update.FetchInstallTarget(channel, o.version)
 	if err != nil {
@@ -204,7 +219,24 @@ func (o *Orchestrator) Update(
 		return false, fmt.Errorf("pre-update: %w", err)
 	}
 
-	// 3. Back up database.
+	// 3. Digest compare against the running container — the main
+	//    channel pins to a rolling tag (":main"), so the only way
+	//    to know we're up to date is to check whether the
+	//    just-pulled image's digest matches the one already in use.
+	//    Stable channel relies on the version-string short-circuit
+	//    in FetchInstallTarget, but running the check here too is
+	//    cheap insurance and adds zero network round-trips beyond
+	//    the local Docker socket.
+	current, err := o.factory.IsAlreadyCurrent(ctx, newRef)
+	if err != nil {
+		return false, fmt.Errorf("compare current image: %w", err)
+	}
+	if current {
+		sender.Write("Already up to date (" + newRef + ").")
+		return false, nil
+	}
+
+	// 4. Back up database.
 	sender.Write("Backing up database ...")
 	meta, err := o.db.BackupWithMeta(ctx, o.factory.CurrentImageTag(ctx))
 	if err != nil {
@@ -212,7 +244,7 @@ func (o *Orchestrator) Update(
 	}
 	sender.Write("Backup: " + meta.BackupPath)
 
-	// 4. Create new instance (passive mode).
+	// 5. Create new instance (passive mode).
 	o.activationToken = generateActivationToken()
 	sender.Write("Starting new instance ...")
 	startCtx, cancel := context.WithTimeout(ctx, o.cfg.Proxy.WorkerStartTimeout.Duration)
@@ -224,18 +256,18 @@ func (o *Orchestrator) Update(
 		return false, fmt.Errorf("create instance: %w", err)
 	}
 
-	// 5. Poll /readyz on new instance until 200.
+	// 6. Poll /readyz on new instance until 200.
 	sender.Write("Waiting for new instance to become ready ...")
 	if err := o.waitReady(startCtx, inst.Addr()); err != nil {
 		inst.Kill(ctx)
 		return false, fmt.Errorf("new instance never became ready: %w", err)
 	}
 
-	// 6. Drain self.
+	// 7. Drain self.
 	sender.Write("Draining current server ...")
 	o.drainFn()
 
-	// 7. Activate new server (start background goroutines).
+	// 8. Activate new server (start background goroutines).
 	sender.Write("Activating new server ...")
 	if err := o.activate(ctx, inst.Addr()); err != nil {
 		inst.Kill(ctx)
@@ -243,7 +275,7 @@ func (o *Orchestrator) Update(
 		return false, fmt.Errorf("activate new server: %w", err)
 	}
 
-	// 8. Stash the instance for Watchdog.
+	// 9. Stash the instance for Watchdog.
 	o.activeInstance = inst
 	sender.Write("Update complete. Entering watchdog mode ...")
 	return true, nil

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -42,6 +42,8 @@ type fakeServerFactory struct {
 	supportsRollback bool
 	imageBase        string
 	imageTag         string
+	alreadyCurrent   bool
+	alreadyCurrentEr error
 }
 
 func (f *fakeServerFactory) PreUpdate(_ context.Context, _ string, _ task.Sender) error {
@@ -71,6 +73,10 @@ func (f *fakeServerFactory) CurrentImageTag(_ context.Context) string {
 
 func (f *fakeServerFactory) SupportsRollback() bool {
 	return f.supportsRollback
+}
+
+func (f *fakeServerFactory) IsAlreadyCurrent(_ context.Context, _ string) (bool, error) {
+	return f.alreadyCurrent, f.alreadyCurrentEr
 }
 
 // --- mock update checker ---
@@ -152,6 +158,51 @@ func TestUpdateAlreadyCurrent(t *testing.T) {
 	}
 	if tracker.drained.Load() != 0 {
 		t.Error("drain should not be called when up to date")
+	}
+}
+
+// Main-channel target is the rolling tag ":main", which is always
+// non-empty; the up-to-date check moves to the factory's digest
+// compare. When that says "yes, already current", Update must
+// short-circuit before the database backup or any drain (issue #360).
+func TestUpdateAlreadyCurrentByDigest(t *testing.T) {
+	checker := &mockChecker{target: "main"}
+	factory := &fakeServerFactory{alreadyCurrent: true}
+	o, tracker := newTestOrchestrator(t, factory, checker)
+	sender := newSender(t)
+
+	updated, err := o.Update(context.Background(), "main", sender)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if updated {
+		t.Error("expected updated=false when factory reports already-current")
+	}
+	if tracker.drained.Load() != 0 {
+		t.Error("drain must not be called when already current")
+	}
+}
+
+// IsAlreadyCurrent returning an error must abort the update — the
+// orchestrator can't know whether to proceed, and the safer default
+// is to fail loudly rather than silently drain on stale information.
+func TestUpdateIsAlreadyCurrentError(t *testing.T) {
+	checker := &mockChecker{target: "main"}
+	factory := &fakeServerFactory{
+		alreadyCurrentEr: io.ErrUnexpectedEOF,
+	}
+	o, tracker := newTestOrchestrator(t, factory, checker)
+	sender := newSender(t)
+
+	_, err := o.Update(context.Background(), "main", sender)
+	if err == nil {
+		t.Fatal("expected error when IsAlreadyCurrent fails")
+	}
+	if !strings.Contains(err.Error(), "compare current image") {
+		t.Errorf("error %q should mention 'compare current image'", err.Error())
+	}
+	if tracker.drained.Load() != 0 {
+		t.Error("drain must not be called when comparison fails")
 	}
 }
 

--- a/internal/orchestrator/serverfactory.go
+++ b/internal/orchestrator/serverfactory.go
@@ -46,6 +46,18 @@ type ServerFactory interface {
 	// previous version. Docker can (pull old image); process cannot
 	// (previous binary typically overwritten by upgrade).
 	SupportsRollback() bool
+
+	// IsAlreadyCurrent reports whether ref resolves to the same
+	// image as the running server. Called after PreUpdate so the
+	// just-pulled image is in the local registry cache. Used by the
+	// main channel to short-circuit when the rolling :main tag
+	// resolves to the digest already in use.
+	//
+	// Docker: compares the pulled ref's image ID against the
+	// running container's image ID via ContainerInspect/ImageInspect.
+	// Process: returns false — the variant has no registry semantics
+	// and Update is effectively a fork+exec restart.
+	IsAlreadyCurrent(ctx context.Context, ref string) (bool, error)
 }
 
 // newServerInstance is the handle returned by CreateInstance. It

--- a/internal/update/registry_contract_test.go
+++ b/internal/update/registry_contract_test.go
@@ -1,0 +1,136 @@
+//go:build registry_contract
+
+// Package update's registry contract test asserts that the install
+// target the running code resolves *actually exists* on the GitHub
+// Container Registry. Build-tag-gated so it runs only when CI
+// explicitly opts in, since it requires network access to ghcr.io
+// and only makes sense after a publish has completed.
+//
+// This is the test that would have caught issue #360: the
+// orchestrator was constructing a tag (`:<git-describe>`) that
+// publish.yml never pushed. Mock-based tests passed; this contract
+// test would have failed at HEAD time with "manifest not found".
+//
+// Wired into .github/workflows/publish.yml as a step on the manifest
+// job — runs after the multi-arch :main manifest is created and
+// before the workflow concludes. CI sets GITHUB_TOKEN so the test
+// can request a pull-scoped bearer for the public ghcr.io repo;
+// anonymous fallback works for forks with the same public visibility.
+
+package update_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cynkra/blockyard/internal/update"
+)
+
+// repoFromAPIBase derives "owner/repo" from the configured API base
+// (e.g. https://api.github.com/repos/cynkra/blockyard → cynkra/blockyard).
+// Used to build the ghcr.io path; ghcr.io/<owner>/<repo> mirrors the
+// GitHub repo name.
+func repoFromAPIBase() string {
+	const marker = "/repos/"
+	idx := strings.Index(update.APIBase, marker)
+	if idx < 0 {
+		return "cynkra/blockyard"
+	}
+	return update.APIBase[idx+len(marker):]
+}
+
+// ghcrToken requests a pull-scoped bearer token for the given
+// repository. Uses the GITHUB_TOKEN as basic-auth username when
+// available (raises rate limits and works for private repos);
+// otherwise falls back to anonymous, which is fine for public ones.
+func ghcrToken(ctx context.Context, repo string) (string, error) {
+	url := fmt.Sprintf("https://ghcr.io/token?service=ghcr.io&scope=repository:%s:pull", repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	if tok := os.Getenv("GITHUB_TOKEN"); tok != "" {
+		// ghcr.io accepts the GH token as the password under any
+		// non-empty username for the token-exchange endpoint.
+		req.SetBasicAuth("anything", tok)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("ghcr.io token endpoint returned %s", resp.Status)
+	}
+	var out struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", err
+	}
+	if out.Token == "" {
+		return "", fmt.Errorf("ghcr.io token endpoint returned empty token")
+	}
+	return out.Token, nil
+}
+
+// TestMainChannelInstallTargetIsPullable resolves the main-channel
+// install target via the production code path and asserts the
+// resulting image reference exists on ghcr.io. Failure here is the
+// signal we missed in issue #360: code resolves a ref the registry
+// doesn't have.
+func TestMainChannelInstallTargetIsPullable(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	target, err := update.FetchInstallTarget("main", "")
+	if err != nil {
+		t.Fatalf("FetchInstallTarget(\"main\", \"\"): %v", err)
+	}
+	if target == "" {
+		t.Fatal("FetchInstallTarget returned empty target for main channel; the orchestrator would skip the update entirely")
+	}
+
+	repo := repoFromAPIBase()
+	token, err := ghcrToken(ctx, repo)
+	if err != nil {
+		t.Fatalf("get ghcr.io token: %v", err)
+	}
+
+	// HEAD the manifest. Accept the OCI manifest+index media types
+	// so a multi-arch image (which is what the manifest job pushes)
+	// resolves cleanly.
+	url := fmt.Sprintf("https://ghcr.io/v2/%s/manifests/%s", repo, target)
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", strings.Join([]string{
+		"application/vnd.oci.image.index.v1+json",
+		"application/vnd.oci.image.manifest.v1+json",
+		"application/vnd.docker.distribution.manifest.list.v2+json",
+		"application/vnd.docker.distribution.manifest.v2+json",
+	}, ","))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("HEAD %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("registry contract violation: ghcr.io/%s:%s does not exist (HEAD returned %s). "+
+			"This means the code's resolved install target is not on the registry — "+
+			"either the publish workflow didn't push it, or FetchInstallTarget returns "+
+			"a tag the workflow never publishes (issue #360).",
+			repo, target, resp.Status)
+	}
+	t.Logf("registry contract OK: ghcr.io/%s:%s exists (digest %s)", repo, target, resp.Header.Get("Docker-Content-Digest"))
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -272,29 +272,30 @@ func InferChannel(version string) string {
 	return "main"
 }
 
-// FetchInstallTarget returns the version string the orchestrator
-// should install on the given channel ("stable" or "main"). Returns
-// "" when current already matches the channel's head, signalling
-// "no update needed". The channel concept is preserved here (vs.
-// the version-classifier used by CheckLatest) because operators
-// pick which release stream to follow independently of how the
-// running build is versioned.
+// FetchInstallTarget returns the image tag the orchestrator should
+// install on the given channel ("stable" or "main").
+//
+// For "stable", returns the latest release's semver (e.g. "1.5.0"),
+// or "" when current already matches — version-string equality is a
+// sufficient up-to-date check on this channel.
+//
+// For "main", returns the rolling tag "main" unconditionally. The
+// main channel pins to the registry-side rolling tag rather than a
+// per-build release Name, so the orchestrator pulls :main and then
+// asks the factory whether the resolved digest matches the running
+// container (factory.IsAlreadyCurrent). This catches Monday-rebuild
+// updates that refresh image content without bumping the release
+// Name, and avoids the broken per-commit tag the publish workflow
+// never pushed (issue #360).
 func FetchInstallTarget(channel, currentVersion string) (string, error) {
-	var target string
-	switch channel {
-	case "main":
-		rel, err := FetchReleaseByTag("main")
-		if err != nil {
-			return "", err
-		}
-		target = rel.Name
-	default:
-		rel, err := FetchLatestStableRelease()
-		if err != nil {
-			return "", err
-		}
-		target = strings.TrimPrefix(rel.TagName, "v")
+	if channel == "main" {
+		return "main", nil
 	}
+	rel, err := FetchLatestStableRelease()
+	if err != nil {
+		return "", err
+	}
+	target := strings.TrimPrefix(rel.TagName, "v")
 	if target == currentVersion {
 		return "", nil
 	}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -306,6 +306,62 @@ func TestSetRepo(t *testing.T) {
 	}
 }
 
+// FetchInstallTarget for the main channel returns the rolling tag
+// "main" without consulting GitHub — the orchestrator pulls :main
+// and digest-compares to determine "already up to date." This is
+// the contract that issue #360 establishes; regression here would
+// re-introduce the broken per-commit tag.
+func TestFetchInstallTarget_Main(t *testing.T) {
+	// Install a fake remote that fails any call. The main channel
+	// must not hit GitHub at all.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("main channel should not call GitHub: %s", r.URL.Path)
+		http.Error(w, "no", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	old := APIBase
+	APIBase = srv.URL
+	defer func() { APIBase = old }()
+
+	target, err := FetchInstallTarget("main", "abc1234")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if target != "main" {
+		t.Errorf("target = %q, want %q", target, "main")
+	}
+}
+
+func TestFetchInstallTarget_StableUpdateAvailable(t *testing.T) {
+	f := newFakeRemote()
+	defer f.Close()
+	f.latestTag = "v1.5.0"
+	f.install(t)
+
+	target, err := FetchInstallTarget("stable", "1.4.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if target != "1.5.0" {
+		t.Errorf("target = %q, want %q", target, "1.5.0")
+	}
+}
+
+func TestFetchInstallTarget_StableAlreadyCurrent(t *testing.T) {
+	f := newFakeRemote()
+	defer f.Close()
+	f.latestTag = "v1.5.0"
+	f.install(t)
+
+	target, err := FetchInstallTarget("stable", "1.5.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if target != "" {
+		t.Errorf("target = %q, want empty (already current)", target)
+	}
+}
+
 func TestFetchRelease(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Accept") != "application/vnd.github+json" {


### PR DESCRIPTION
## Summary

- Pin `FetchInstallTarget("main", _)` to the rolling `:main` tag and move the up-to-date check to a post-pull digest compare via new `ServerFactory.IsAlreadyCurrent` — fixes the broken per-commit tag and picks up Monday-rebuild refreshes that don't bump the GH release Name.
- Add a build-tag-gated registry contract test (`//go:build registry_contract`) that calls the real `FetchInstallTarget` and HEADs ghcr.io for the resulting ref; wired into `publish.yml` so future code/registry divergence breaks the publish job loudly.
- Extend the publish manifest job to publish `:main` for the `-docker` and `-process` variants (previously only the `everything` variant got one).
- Log orchestrator update failures via `slog` so they appear in `journalctl`/`docker logs` instead of disappearing into the UI progress card.

Fixes #360