### PR TITLE
fix(process): build pure-R source pkgs on toolchain-free worker

### DIFF
--- a/internal/backend/docker/pak_integration_test.go
+++ b/internal/backend/docker/pak_integration_test.go
@@ -83,26 +83,33 @@ func TestBuildE2E_PureRSourceBuildNoToolchain(t *testing.T) {
 	// Mirror the production build scripts: PakCompilerShimR runs first, then the
 	// standard pak setup, then a source install of the local pure-R package.
 	rScript := bundle.PakCompilerShimR + `
-Sys.setenv(R_USER_CACHE_DIR = "/cache", PKG_CACHE_DIR = "/cache")
+Sys.setenv(R_USER_CACHE_DIR = "/cache", PKG_CACHE_DIR = "/cache", PKG_SYSREQS = "false")
 .libPaths(c("/pak", .libPaths()))
 library(pak)
 pak_lib <- system.file("library", package = "pak")
 if (nzchar(pak_lib) && dir.exists(pak_lib)) .libPaths(c(pak_lib, .libPaths()))
-pak::pkg_install("local::/pkg", lib = "/lib", upgrade = FALSE)
-if (!file.exists("/lib/pureonly/DESCRIPTION")) stop("pureonly not installed")
+pak::pkg_install("local::/app", lib = "/build-lib", upgrade = FALSE)
+if (!file.exists("/build-lib/pureonly/DESCRIPTION")) stop("pureonly not installed")
 cat("OK: pureonly installed without toolchain\n")
 `
 
+	// Mount targets matter here. The package goes at /app because Build() forces
+	// WorkingDir=/app on a read-only rootfs — with nothing mounted there the
+	// container can't start ("exec Rscript: no such file or directory"); /app is
+	// also where production bundles live, so local::/app mirrors the real build.
+	// The install library goes at /build-lib, NOT /lib: /lib holds the image's
+	// dynamic linker and libc, and shadowing it with an empty mount makes the
+	// dynamically-linked Rscript unloadable (same exec error).
 	spec := backend.BuildSpec{
 		AppID:    "purer-build-test",
 		BundleID: uuid.New().String()[:8],
 		Image:    image,
 		Cmd:      []string{"Rscript", "--vanilla", "-e", rScript},
 		Mounts: []backend.MountEntry{
-			{Source: pkgDir, Target: "/pkg", ReadOnly: true},
+			{Source: pkgDir, Target: "/app", ReadOnly: true},
 			{Source: pakPath, Target: "/pak", ReadOnly: true},
 			{Source: cacheDir, Target: "/cache", ReadOnly: false},
-			{Source: libDir, Target: "/lib", ReadOnly: false},
+			{Source: libDir, Target: "/build-lib", ReadOnly: false},
 		},
 		Labels: map[string]string{},
 	}

--- a/internal/backend/docker/pak_integration_test.go
+++ b/internal/backend/docker/pak_integration_test.go
@@ -34,6 +34,92 @@ func pakTestConfig(t *testing.T) *config.Config {
 	}
 }
 
+// TestBuildE2E_PureRSourceBuildNoToolchain verifies that a pure-R package
+// requiring a source build — the GitHub-`Remotes:` case from #367 — installs
+// on the toolchain-free worker image. pak flags any non-binary ref [bld] and
+// runs pkgbuild::check_build_tools() before installing, which aborts with
+// "Could not find tools necessary to compile a package" on an image without a
+// C compiler, even though pure-R packages compile nothing. bundle.PakCompilerShimR
+// injects options(pkgbuild.has_compiler = TRUE) into pak's worker subprocess
+// via a project .Rprofile. Without the shim this build fails with the compiler
+// error; with it, it succeeds. Guards against pak changing how its subprocess
+// loads profiles, and against the shim being dropped.
+func TestBuildE2E_PureRSourceBuildNoToolchain(t *testing.T) {
+	image := testutil.TOMLDockerImage(t)
+
+	ctx := context.Background()
+	b, err := New(ctx, pakTestConfig(t), t.TempDir(), "test")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// A minimal pure-R source package: no src/, and — like a raw GitHub repo —
+	// no NeedsCompilation field, so pak takes the source-build path. local::
+	// exercises the same [bld] + check_build_tools path as a GitHub Remote
+	// without depending on network or GitHub availability.
+	pkgDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(pkgDir, "R"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	desc := "Package: pureonly\nTitle: Pure R\nVersion: 0.0.1\n" +
+		"Authors@R: person(\"T\", \"U\", email = \"t@e.com\", role = c(\"aut\", \"cre\"))\n" +
+		"Description: Pure-R package with no compiled code.\nLicense: MIT\nEncoding: UTF-8\n"
+	if err := os.WriteFile(filepath.Join(pkgDir, "DESCRIPTION"), []byte(desc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "R", "hello.R"),
+		[]byte("hello <- function() \"hi\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cacheDir := t.TempDir()
+	libDir := t.TempDir()
+	pakCachePath := t.TempDir()
+	pakPath, err := pakcache.EnsureInstalled(ctx, b, image, "stable", pakCachePath)
+	if err != nil {
+		t.Fatalf("EnsureInstalled: %v", err)
+	}
+
+	// Mirror the production build scripts: PakCompilerShimR runs first, then the
+	// standard pak setup, then a source install of the local pure-R package.
+	rScript := bundle.PakCompilerShimR + `
+Sys.setenv(R_USER_CACHE_DIR = "/cache", PKG_CACHE_DIR = "/cache")
+.libPaths(c("/pak", .libPaths()))
+library(pak)
+pak_lib <- system.file("library", package = "pak")
+if (nzchar(pak_lib) && dir.exists(pak_lib)) .libPaths(c(pak_lib, .libPaths()))
+pak::pkg_install("local::/pkg", lib = "/lib", upgrade = FALSE)
+if (!file.exists("/lib/pureonly/DESCRIPTION")) stop("pureonly not installed")
+cat("OK: pureonly installed without toolchain\n")
+`
+
+	spec := backend.BuildSpec{
+		AppID:    "purer-build-test",
+		BundleID: uuid.New().String()[:8],
+		Image:    image,
+		Cmd:      []string{"Rscript", "--vanilla", "-e", rScript},
+		Mounts: []backend.MountEntry{
+			{Source: pkgDir, Target: "/pkg", ReadOnly: true},
+			{Source: pakPath, Target: "/pak", ReadOnly: true},
+			{Source: cacheDir, Target: "/cache", ReadOnly: false},
+			{Source: libDir, Target: "/lib", ReadOnly: false},
+		},
+		Labels: map[string]string{},
+	}
+
+	result, err := b.Build(ctx, spec)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("pure-R source build failed (exit %d) — shim or pak subprocess profile regression?\n--- logs ---\n%s",
+			result.ExitCode, result.Logs)
+	}
+	if !strings.Contains(result.Logs, "OK: pureonly installed") {
+		t.Fatalf("expected success marker in logs; got:\n%s", result.Logs)
+	}
+}
+
 // TestBuildE2E_PakBuild exercises the Docker build pipeline with the new
 // Cmd/Mounts API. Since we cannot run a full pak install without pak in the
 // image, we use a simple R command to verify mounts and command override work.

--- a/internal/bundle/restore.go
+++ b/internal/bundle/restore.go
@@ -420,6 +420,34 @@ install_with_retry <- function(lockfile, lib, max_attempts = 3L) {
 }
 `
 
+// PakCompilerShimR lets pak's source-build step run on the toolchain-free
+// worker image (#191, #367). pak builds every non-binary ref — any GitHub /
+// git / local `Remotes:` dependency — from source, and pkgbuild aborts with
+// "Could not find tools necessary to compile a package" unless a C compiler
+// is present, even for pure-R packages that compile nothing. PPM only serves
+// binaries for CRAN/Bioc, so GitHub deps can never take the binary path.
+// `options(pkgbuild.has_compiler = TRUE)` skips pkgbuild's compiler probe:
+// pure-R builds then succeed with no toolchain, while a package that really
+// carries src/ still fails loudly at the actual compile ("make: not found"),
+// which is the correct signal to opt into a toolchain image via --image.
+//
+// The option must take effect in pak's *worker subprocess*, not this script's
+// process. pak spawns that subprocess through callr with
+// user_profile = "project", which sources a `.Rprofile` from the working
+// directory — so we write the option into a scratch dir and chdir there
+// before any pak call starts the subprocess. RENV_PROJECT is cleared because
+// pak disables the project profile when it is set. All paths the build script
+// uses afterwards are absolute, so changing the working directory is safe.
+const PakCompilerShimR = `
+local({
+  Sys.unsetenv("RENV_PROJECT")
+  d <- tempfile("pak-build-cwd-")
+  dir.create(d)
+  setwd(d)
+  writeLines("options(pkgbuild.has_compiler = TRUE)", ".Rprofile")
+})
+`
+
 // BuildCommand returns the R command that runs inside the build container.
 // The four-phase store-aware build script:
 //   - Phase 1: lockfile_create (pak resolves + solves)
@@ -429,7 +457,7 @@ install_with_retry <- function(lockfile, lib, max_attempts = 3L) {
 //
 // Exported for use by the refresh pipeline (server/refresh.go).
 func BuildCommand() []string {
-	rScript := LockfileInstallWithRetryR + `
+	rScript := LockfileInstallWithRetryR + PakCompilerShimR + `
 Sys.setenv(
   R_USER_CACHE_DIR = "/pak-cache",
   PKG_CACHE_DIR = "/pak-cache",
@@ -560,7 +588,7 @@ func BuildMounts(
 // legacyBuildCommand returns the R command for the phase 2-5 build flow
 // (no package store). Used when Store is nil (tests, pre-store deployments).
 func legacyBuildCommand() []string {
-	rScript := LockfileInstallWithRetryR + `
+	rScript := LockfileInstallWithRetryR + PakCompilerShimR + `
 Sys.setenv(
   R_USER_CACHE_DIR = "/pak-cache",
   PKG_CACHE_DIR = "/pak-cache",


### PR DESCRIPTION
## Summary

- pak builds every non-binary ref (GitHub/git/local `Remotes:` deps) from source and runs `pkgbuild::check_build_tools()` first, which aborts with "Could not find tools necessary to compile a package" on the hardened, toolchain-free worker image (#191) — even for pure-R packages that compile nothing. PPM only serves binaries for CRAN/Bioc, so GitHub deps can't take the binary path.
- Inject `options(pkgbuild.has_compiler = TRUE)` into pak's worker subprocess via a project `.Rprofile` (`PakCompilerShimR`), prepended to both the store-aware and legacy build scripts. pak starts that subprocess through callr with `user_profile = "project"`, so it sources `./.Rprofile`; we write it into a scratch dir and `chdir` there before any pak call.
- Pure-R source deps now install with no toolchain; packages that genuinely carry `src/` still fail loudly at the real compile step (`make: not found`), the correct signal to opt into a toolchain image via `--image`. Keeps #191's runtime hardening fully intact.
- Adds `TestBuildE2E_PureRSourceBuildNoToolchain` (pak_test) building a pure-R `local::` package on the toolchain-free image — guards against pak changing its subprocess profile handling or the shim being dropped.

Fixes #367