### PR TITLE
ci(process): push per-commit image tag; verify in contract test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -142,6 +142,7 @@ jobs:
           - variant: process
             image_suffix: -process
     steps:
+      - uses: actions/checkout@v6
       - uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -149,9 +150,23 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create and push multi-arch manifest (${{ matrix.variant }})
         run: |
-          docker buildx imagetools create -t "${{ env.IMAGE }}${{ matrix.image_suffix }}:main" \
-            "${{ env.IMAGE }}${{ matrix.image_suffix }}:build-linux-amd64" \
-            "${{ env.IMAGE }}${{ matrix.image_suffix }}:build-linux-arm64"
+          # Tag the manifest with both the rolling ":main" pointer and
+          # the immutable per-commit ":<git-describe>" tag. ":main" is
+          # what the current orchestrator pins to (digest-compared
+          # post-pull); ":<VERSION>" is the install target older builds
+          # resolve (the GH release Name, which equals git describe).
+          # Without it, a build published before the #360 :main fix is
+          # stranded: it asks Docker for a per-commit tag that was never
+          # pushed and can never update itself forward (#378). VERSION
+          # uses the same `git describe --always --dirty` as the
+          # cli-binaries/cli-release jobs so the tags line up exactly.
+          VERSION="$(git describe --always --dirty)"
+          IMG="${{ env.IMAGE }}${{ matrix.image_suffix }}"
+          docker buildx imagetools create \
+            -t "${IMG}:main" \
+            -t "${IMG}:${VERSION}" \
+            "${IMG}:build-linux-amd64" \
+            "${IMG}:build-linux-arm64"
 
   # Registry contract test: assert that the install target the
   # orchestrator's main-channel resolver constructs actually exists
@@ -171,7 +186,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - name: Verify main-channel install target is pullable
+      - name: Verify install targets are pullable
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: go test -tags registry_contract -run TestMainChannelInstallTargetIsPullable -v ./internal/update/...
+        run: go test -tags registry_contract -run Pullable -v ./internal/update/...

--- a/internal/update/registry_contract_test.go
+++ b/internal/update/registry_contract_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -80,6 +81,35 @@ func ghcrToken(ctx context.Context, repo string) (string, error) {
 	return out.Token, nil
 }
 
+// manifestExists HEADs the manifest for ghcr.io/<repo>:<tag> and
+// reports whether it resolves. Accepts the OCI manifest+index media
+// types so a multi-arch image (what the manifest job pushes) resolves
+// cleanly. Returns the resolved digest on success.
+func manifestExists(ctx context.Context, repo, tag, token string) (digest string, status string, err error) {
+	url := fmt.Sprintf("https://ghcr.io/v2/%s/manifests/%s", repo, tag)
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return "", "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", strings.Join([]string{
+		"application/vnd.oci.image.index.v1+json",
+		"application/vnd.oci.image.manifest.v1+json",
+		"application/vnd.docker.distribution.manifest.list.v2+json",
+		"application/vnd.docker.distribution.manifest.v2+json",
+	}, ","))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", resp.Status, nil
+	}
+	return resp.Header.Get("Docker-Content-Digest"), resp.Status, nil
+}
+
 // TestMainChannelInstallTargetIsPullable resolves the main-channel
 // install target via the production code path and asserts the
 // resulting image reference exists on ghcr.io. Failure here is the
@@ -103,34 +133,62 @@ func TestMainChannelInstallTargetIsPullable(t *testing.T) {
 		t.Fatalf("get ghcr.io token: %v", err)
 	}
 
-	// HEAD the manifest. Accept the OCI manifest+index media types
-	// so a multi-arch image (which is what the manifest job pushes)
-	// resolves cleanly.
-	url := fmt.Sprintf("https://ghcr.io/v2/%s/manifests/%s", repo, target)
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	digest, status, err := manifestExists(ctx, repo, target, token)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("HEAD ghcr.io/%s:%s: %v", repo, target, err)
 	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", strings.Join([]string{
-		"application/vnd.oci.image.index.v1+json",
-		"application/vnd.oci.image.manifest.v1+json",
-		"application/vnd.docker.distribution.manifest.list.v2+json",
-		"application/vnd.docker.distribution.manifest.v2+json",
-	}, ","))
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("HEAD %s: %v", url, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
+	if digest == "" {
 		t.Fatalf("registry contract violation: ghcr.io/%s:%s does not exist (HEAD returned %s). "+
 			"This means the code's resolved install target is not on the registry — "+
 			"either the publish workflow didn't push it, or FetchInstallTarget returns "+
 			"a tag the workflow never publishes (issue #360).",
-			repo, target, resp.Status)
+			repo, target, status)
 	}
-	t.Logf("registry contract OK: ghcr.io/%s:%s exists (digest %s)", repo, target, resp.Header.Get("Docker-Content-Digest"))
+	t.Logf("registry contract OK: ghcr.io/%s:%s exists (digest %s)", repo, target, digest)
+}
+
+// TestCommitTagIsPullable asserts that the immutable per-commit tag
+// (`:<git-describe>`) for the commit under test exists on ghcr.io.
+//
+// This is the invariant #378 actually broke. The current orchestrator
+// pins the main channel to the rolling `:main` tag, so the test above
+// can pass while the per-commit tag is missing. But builds published
+// before the #360 `:main` fix resolve their install target to the GH
+// release Name — which equals `git describe --always --dirty` — and
+// such a build is permanently stranded if that tag was never pushed.
+// The manifest job must publish `:<VERSION>` alongside `:main`; this
+// test fails loudly if it stops doing so.
+func TestCommitTagIsPullable(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Same command the publish workflow's binary/release/manifest jobs
+	// use, so the tag we check matches the one those jobs construct.
+	out, err := exec.CommandContext(ctx, "git", "describe", "--always", "--dirty").Output()
+	if err != nil {
+		t.Fatalf("git describe: %v", err)
+	}
+	version := strings.TrimSpace(string(out))
+	if version == "" {
+		t.Fatal("git describe returned empty version")
+	}
+
+	repo := repoFromAPIBase()
+	token, err := ghcrToken(ctx, repo)
+	if err != nil {
+		t.Fatalf("get ghcr.io token: %v", err)
+	}
+
+	digest, status, err := manifestExists(ctx, repo, version, token)
+	if err != nil {
+		t.Fatalf("HEAD ghcr.io/%s:%s: %v", repo, version, err)
+	}
+	if digest == "" {
+		t.Fatalf("registry contract violation: per-commit tag ghcr.io/%s:%s does not exist (HEAD returned %s). "+
+			"The manifest job must push `:<git-describe>` alongside `:main` — without it, any build "+
+			"that resolves its install target to the release Name (every build before the #360 :main fix) "+
+			"is stranded and can never update itself forward (issue #378).",
+			repo, version, status)
+	}
+	t.Logf("registry contract OK: per-commit tag ghcr.io/%s:%s exists (digest %s)", repo, version, digest)
 }


### PR DESCRIPTION
## Summary

- The `manifest` job only pushed `:main`. Builds published before the #360 `:main` fix resolve their install target to the GH release Name (`git describe`), so they ask the registry for a per-commit tag that was never pushed and are stranded — this is what broke `main`-channel self-update on production again (#378).
- Push `:<git-describe>` alongside `:main` in the `manifest` job (single image, both tags). The rolling `:main` stays the pointer the current orchestrator pins to; `:<sha>` is the immutable target older builds resolve, so the next publish unsticks them.
- Add `TestCommitTagIsPullable` asserting the per-commit tag exists on ghcr.io for the commit under test — the invariant that actually regressed. (The existing `TestMainChannelInstallTargetIsPullable` passes legitimately because the post-#360 resolver returns the literal `main`, not via a race — so it can't catch a missing per-commit tag.)
- Run both contract tests via `-run Pullable`; factor the shared manifest-HEAD check into a helper.

Fixes #378